### PR TITLE
Yoda: `MatrixEntry`->`Matrix`.

### DIFF
--- a/Sherlock/yoda/DOCU.md
+++ b/Sherlock/yoda/DOCU.md
@@ -76,7 +76,7 @@ CEREAL_REGISTER_TYPE(StringIntTuple);
 // Define the `api` object.
 typedef API<Dictionary<StringIntTuple>,
             Dictionary<Prime>,
-            MatrixEntry<PrimeCell>> PrimesAPI;
+            Matrix<PrimeCell>> PrimesAPI;
 PrimesAPI api("YodaExampleUsage");
 
 // Simple dictionary usecase, and a unit test for type system implementation.
@@ -251,7 +251,7 @@ api.Transaction([](PrimesAPI::T_DATA data) {
   EXPECT_EQ(10u, c2);
 }).Go();
 
-// Work with `MatrixEntry<>` as well.
+// Work with `Matrix<>` as well.
 api.Add(PrimeCell(0, 2, 100));
 api.Add(PrimeCell(0, 2, 1));  // Overwrite.
 api.Add(PrimeCell(0, 3, 2));
@@ -266,8 +266,8 @@ EXPECT_EQ(2, static_cast<int>(p2.col));
 EXPECT_EQ(1, p2.index);
  
 api.Transaction([](PrimesAPI::T_DATA data) {
-  const auto getter = MatrixEntry<PrimeCell>::Accessor(data);
-  auto adder = MatrixEntry<PrimeCell>::Mutator(data);
+  const auto getter = Matrix<PrimeCell>::Accessor(data);
+  auto adder = Matrix<PrimeCell>::Mutator(data);
 
   const EntryWrapper<PrimeCell> e3 =
     getter.Get(static_cast<FIRST_DIGIT>(0), static_cast<SECOND_DIGIT>(3));
@@ -378,7 +378,7 @@ EXPECT_EQ("7,17,37,47,67,97",
 
 // Top-level per-row and per-column accessors.
 api.Transaction([](PrimesAPI::T_DATA data) {
-  const auto accessor = MatrixEntry<PrimeCell>::Accessor(data);
+  const auto accessor = Matrix<PrimeCell>::Accessor(data);
   EXPECT_EQ(10u, accessor.Rows().size());
   EXPECT_EQ(6u, accessor.Cols().size());  // 1, 2, 3, 5, 7 or 9, my captain.
   std::string by_rows_keys;

--- a/Sherlock/yoda/container/matrix/api.h
+++ b/Sherlock/yoda/container/matrix/api.h
@@ -42,10 +42,10 @@ using sfinae::T_MAP_TYPE;
 using sfinae::GetRow;
 using sfinae::GetCol;
 
-// User type interface: Use `MatrixEntry<MyMatrixEntry>` in Yoda's type list for required storage types
-// for Yoda to support key-entry (key-value) accessors over the type `MyMatrixEntry`.
+// User type interface: Use `Matrix<MyMatrix>` in Yoda's type list for required storage types
+// for Yoda to support key-entry (key-value) accessors over the type `MyMatrix`.
 template <typename ENTRY>
-struct MatrixEntry {
+struct Matrix {
   static_assert(std::is_base_of<Padawan, ENTRY>::value, "Entry type must be derived from `yoda::Padawan`.");
 
   typedef ENTRY T_ENTRY;
@@ -61,13 +61,13 @@ struct MatrixEntry {
   typedef SubscriptException<T_ENTRY> T_SUBSCRIPT_EXCEPTION;
 
   template <typename DATA>
-  static decltype(std::declval<DATA>().template Accessor<MatrixEntry<ENTRY>>()) Accessor(DATA&& c) {
-    return c.template Accessor<MatrixEntry<ENTRY>>();
+  static decltype(std::declval<DATA>().template Accessor<Matrix<ENTRY>>()) Accessor(DATA&& c) {
+    return c.template Accessor<Matrix<ENTRY>>();
   }
 
   template <typename DATA>
-  static decltype(std::declval<DATA>().template Mutator<MatrixEntry<ENTRY>>()) Mutator(DATA&& c) {
-    return c.template Mutator<MatrixEntry<ENTRY>>();
+  static decltype(std::declval<DATA>().template Mutator<Matrix<ENTRY>>()) Mutator(DATA&& c) {
+    return c.template Mutator<Matrix<ENTRY>>();
   }
 };
 
@@ -164,9 +164,9 @@ class OuterMapAccessor final {
 };
 
 template <typename YT, typename ENTRY>
-struct Container<YT, MatrixEntry<ENTRY>> {
+struct Container<YT, Matrix<ENTRY>> {
   static_assert(std::is_base_of<YodaTypesBase, YT>::value, "");
-  typedef MatrixEntry<ENTRY> YET;
+  typedef Matrix<ENTRY> YET;
 
   template <typename T>
   using CF = bricks::copy_free<T>;

--- a/Sherlock/yoda/docu/docu_2_reference_code.cc
+++ b/Sherlock/yoda/docu/docu_2_reference_code.cc
@@ -39,7 +39,7 @@ using yoda::Padawan;
 using yoda::API;
 using yoda::Future;
 using yoda::Dictionary;
-using yoda::MatrixEntry;
+using yoda::Matrix;
 using yoda::EntryWrapper;
 using yoda::NonexistentEntryAccessed;
 using yoda::KeyNotFoundException;
@@ -128,7 +128,7 @@ HTTP(port).ResetAllHandlers();
   // Define the `api` object.
   typedef API<Dictionary<StringIntTuple>,
               Dictionary<Prime>,
-              MatrixEntry<PrimeCell>> PrimesAPI;
+              Matrix<PrimeCell>> PrimesAPI;
   PrimesAPI api("YodaExampleUsage");
   
   // Simple dictionary usecase, and a unit test for type system implementation.
@@ -324,7 +324,7 @@ HTTP(port).ResetAllHandlers();
 }
   
 {
-  // Work with `MatrixEntry<>` as well.
+  // Work with `Matrix<>` as well.
   api.Add(PrimeCell(0, 2, 100));
   api.Add(PrimeCell(0, 2, 1));  // Overwrite.
   api.Add(PrimeCell(0, 3, 2));
@@ -340,8 +340,8 @@ HTTP(port).ResetAllHandlers();
   EXPECT_EQ(1, p2.index);
    
   api.Transaction([](PrimesAPI::T_DATA data) {
-    const auto getter = MatrixEntry<PrimeCell>::Accessor(data);
-    auto adder = MatrixEntry<PrimeCell>::Mutator(data);
+    const auto getter = Matrix<PrimeCell>::Accessor(data);
+    auto adder = Matrix<PrimeCell>::Mutator(data);
   
     const EntryWrapper<PrimeCell> e3 =
       getter.Get(static_cast<FIRST_DIGIT>(0), static_cast<SECOND_DIGIT>(3));
@@ -458,7 +458,7 @@ HTTP(port).ResetAllHandlers();
   
   // Top-level per-row and per-column accessors.
   api.Transaction([](PrimesAPI::T_DATA data) {
-    const auto accessor = MatrixEntry<PrimeCell>::Accessor(data);
+    const auto accessor = Matrix<PrimeCell>::Accessor(data);
     EXPECT_EQ(10u, accessor.Rows().size());
     EXPECT_EQ(6u, accessor.Cols().size());  // 1, 2, 3, 5, 7 or 9, my captain.
     std::string by_rows_keys;

--- a/Sherlock/yoda/metaprogramming.h
+++ b/Sherlock/yoda/metaprogramming.h
@@ -116,13 +116,13 @@ struct RetrieveAccessor {};
 template <typename T>
 struct RetrieveMutator {};
 
-// A wrapper to convert `T` into `Dictionary<T>`, `MatrixEntry<T>`, etc., using `decltype()`.
+// A wrapper to convert `T` into `Dictionary<T>`, `Matrix<T>`, etc., using `decltype()`.
 // Used to enable top-level `Add()`/`Get()` when passed in the entry only.
 template <typename T>
 struct YETFromE {};
 
 // A wrapper to convert `T::T_KEY` into `Dictionary<T>`,
-// `std::tuple<T::T_ROW, T::T_COL>` into `MatrixEntry<T>`, etc.
+// `std::tuple<T::T_ROW, T::T_COL>` into `Matrix<T>`, etc.
 // Used to enable top-level `Add()`/`Get()` when passed in the entry only.
 template <typename K>
 struct YETFromK {};


### PR DESCRIPTION
@dkorolev Renamed `MatrixEntry` as we discussed.