### PR TITLE
Added `Response`.

### DIFF
--- a/Bricks/net/api/api.h
+++ b/Bricks/net/api/api.h
@@ -48,6 +48,8 @@ SOFTWARE.
 #ifndef BRICKS_NET_API_API_H
 #define BRICKS_NET_API_API_H
 
+#include "request.h"
+#include "response.h"
 #include "types.h"
 
 #include "../../port.h"
@@ -86,5 +88,7 @@ inline typename weed::call_with_type<HTTP_IMPL, TS...> HTTP(TS&&... params) {
 }  // namespace bricks
 
 using bricks::net::api::HTTP;
+using bricks::net::api::Request;
+using bricks::net::api::Response;
 
 #endif  // BRICKS_NET_API_API_H

--- a/Bricks/net/api/request.h
+++ b/Bricks/net/api/request.h
@@ -1,0 +1,108 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev, <dmitry.korolev@gmail.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_NET_API_REQUEST_H
+#define BRICKS_NET_API_REQUEST_H
+
+#include <string>
+
+#include "../http/http.h"
+#include "../../time/chrono.h"
+#include "../../template/decay.h"
+
+namespace bricks {
+namespace net {
+namespace api {
+
+// The only parameter to be passed to HTTP handlers.
+struct Request final {
+  std::unique_ptr<HTTPServerConnection> unique_connection;
+
+  HTTPServerConnection& connection;
+  const HTTPRequestData& http_data;  // Accessor to use `r.http_data` instead of `r.connection->HTTPRequest()`.
+  const url::URL& url;
+  const std::string method;
+  const std::string& body;  // TODO(dkorolev): This is inefficient, but will do.
+  const bricks::time::EPOCH_MILLISECONDS timestamp;
+
+  explicit Request(std::unique_ptr<HTTPServerConnection>&& connection)
+      : unique_connection(std::move(connection)),
+        connection(*unique_connection.get()),
+        http_data(unique_connection->HTTPRequest()),
+        url(http_data.URL()),
+        method(http_data.Method()),
+        body(http_data.Body()),
+        timestamp(bricks::time::Now()) {}
+
+  // It is essential to move `unique_connection` so that the socket outlives the destruction of `rhs`.
+  Request(Request&& rhs)
+      : unique_connection(std::move(rhs.unique_connection)),
+        connection(*unique_connection.get()),
+        http_data(unique_connection->HTTPRequest()),
+        url(http_data.URL()),
+        method(http_data.Method()),
+        body(http_data.Body()),
+        timestamp(rhs.timestamp) {}
+
+  // Support objects with user-defined HTTP response handlers.
+  template <typename T>
+  struct HasRespondViaHTTP {
+    typedef char one;
+    typedef long two;
+
+    template <typename C>
+    static one test(decltype(&C::RespondViaHTTP));
+    template <typename C>
+    static two test(...);
+
+    constexpr static bool value = (sizeof(test<T>(0)) == sizeof(one));
+  };
+
+  template <typename T>
+  inline typename std::enable_if<HasRespondViaHTTP<bricks::decay<T>>::value>::type operator()(
+      T&& that_dude_over_there) {
+    that_dude_over_there.RespondViaHTTP(std::move(*this));
+  }
+
+  // A shortcut to allow `[](Request r) { r("OK"); }` instead of `r.connection.SendHTTPResponse("OK")`.
+  template <typename... TS>
+  void operator()(TS&&... params) {
+    connection.SendHTTPResponse(std::forward<TS>(params)...);
+  }
+
+  HTTPServerConnection::ChunkedResponseSender SendChunkedResponse() {
+    return connection.SendChunkedHTTPResponse();
+  }
+
+  Request() = delete;
+  Request(const Request&) = delete;
+  void operator=(const Request&) = delete;
+  void operator=(Request&&) = delete;
+};
+
+}  // namespace api
+}  // namespace net
+}  // namespace bricks
+
+#endif  // BRICKS_NET_API_REQUEST_H

--- a/Bricks/net/api/response.h
+++ b/Bricks/net/api/response.h
@@ -90,7 +90,7 @@ struct Response {
   Construct(T&& object,
             HTTPResponseCodeValue code = HTTPResponseCode.OK,
             const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
-    this->body = cerealize::JSON(std::forward<T>(object));
+    this->body = cerealize::JSON(std::forward<T>(object)) + '\n';
     this->code = code;
     this->content_type = HTTPServerConnection::DefaultJSONContentType();
     this->extra_headers = extra_headers;
@@ -103,7 +103,7 @@ struct Response {
             const std::string& object_name,
             HTTPResponseCodeValue code = HTTPResponseCode.OK,
             const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
-    this->body = cerealize::JSON(std::forward<T>(object), object_name);
+    this->body = cerealize::JSON(std::forward<T>(object), object_name) + '\n';
     this->code = code;
     this->content_type = HTTPServerConnection::DefaultJSONContentType();
     this->extra_headers = extra_headers;

--- a/Bricks/net/api/response.h
+++ b/Bricks/net/api/response.h
@@ -58,8 +58,8 @@ struct Response {
         content_type(HTTPServerConnection::DefaultContentType()),
         extra_headers(HTTPHeadersType()) {}
 
-  void operator=(const Response&) = delete;
-  void operator=(Response&&) = delete;
+  Response& operator=(const Response&) = default;
+  Response& operator=(Response&&) = default;
 
   template <typename... ARGS>
   Response(ARGS&&... args)
@@ -68,6 +68,7 @@ struct Response {
   }
 
   void Construct(const Response& rhs) {
+    initialized = rhs.initialized;
     body = rhs.body;
     code = rhs.code;
     content_type = rhs.content_type;
@@ -75,10 +76,20 @@ struct Response {
   }
 
   void Construct(Response&& rhs) {
+    initialized = rhs.initialized;
     body = std::move(rhs.body);
     code = rhs.code;
     content_type = rhs.content_type;
     extra_headers = rhs.extra_headers;
+  }
+
+  void Construct(HTTPResponseCodeValue code = HTTPResponseCode.OK,
+                 const std::string& content_type = HTTPServerConnection::DefaultContentType(),
+                 const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+    this->body = "";
+    this->code = code;
+    this->content_type = content_type;
+    this->extra_headers = extra_headers;
   }
 
   template <typename T>

--- a/Bricks/net/api/response.h
+++ b/Bricks/net/api/response.h
@@ -41,9 +41,6 @@ namespace bricks {
 namespace net {
 namespace api {
 
-static_assert(strings::is_string_type<const char*>::value, "");
-static_assert(!strings::is_string_type<int>::value, "");
-
 struct Response {
   bool initialized = false;
 

--- a/Bricks/net/api/response.h
+++ b/Bricks/net/api/response.h
@@ -1,0 +1,155 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev, <dmitry.korolev@gmail.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_NET_API_RESPONSE_H
+#define BRICKS_NET_API_RESPONSE_H
+
+// A convenience wrapper to pass in to `Request::operator()`, for the cases where
+// the best design is to return a value from one function to have the next one in the chain,
+// which can be `std::move(request)`, to pick it up.
+
+#include "request.h"
+
+#include "../http/http.h"
+#include "../../strings/is_string_type.h"
+#include "../../cerealize/cerealize.h"
+
+namespace bricks {
+namespace net {
+namespace api {
+
+static_assert(strings::is_string_type<const char*>::value, "");
+static_assert(!strings::is_string_type<int>::value, "");
+
+struct Response {
+  std::string body;
+  HTTPResponseCodeValue code;
+  std::string content_type;
+  HTTPHeadersType extra_headers;
+
+  Response() = delete;
+  void operator=(const Response&) = delete;
+  void operator=(Response&&) = delete;
+
+  template <typename... ARGS>
+  Response(ARGS&&... args) {
+    Construct(std::forward<ARGS>(args)...);
+  }
+
+  void Construct(const Response& rhs) {
+    body = rhs.body;
+    code = rhs.code;
+    content_type = rhs.content_type;
+    extra_headers = rhs.extra_headers;
+  }
+
+  void Construct(Response&& rhs) {
+    body = std::move(rhs.body);
+    code = rhs.code;
+    content_type = rhs.content_type;
+    extra_headers = rhs.extra_headers;
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_same<bricks::decay<T>, Response>::value &&
+                          strings::is_string_type<T>::value>::type
+  Construct(T&& body,
+            HTTPResponseCodeValue code = HTTPResponseCode.OK,
+            const std::string& content_type = HTTPServerConnection::DefaultContentType(),
+            const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+    this->body = std::forward<T>(body);
+    this->code = code;
+    this->content_type = content_type;
+    this->extra_headers = extra_headers;
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_same<bricks::decay<T>, Response>::value &&
+                          !(strings::is_string_type<T>::value)>::type
+  Construct(T&& object,
+            HTTPResponseCodeValue code = HTTPResponseCode.OK,
+            const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+    this->body = cerealize::JSON(std::forward<T>(object));
+    this->code = code;
+    this->content_type = HTTPServerConnection::DefaultJSONContentType();
+    this->extra_headers = extra_headers;
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_same<bricks::decay<T>, Response>::value &&
+                          !(strings::is_string_type<T>::value)>::type
+  Construct(T&& object,
+            const std::string& object_name,
+            HTTPResponseCodeValue code = HTTPResponseCode.OK,
+            const HTTPHeadersType& extra_headers = HTTPHeadersType()) {
+    this->body = cerealize::JSON(std::forward<T>(object), object_name);
+    this->code = code;
+    this->content_type = HTTPServerConnection::DefaultJSONContentType();
+    this->extra_headers = extra_headers;
+  }
+
+  Response& Body(const std::string& s) {
+    body = s;
+    return *this;
+  }
+
+  template <typename T>
+  Response& JSON(const T& object) {
+    body = cerealize::JSON(object);
+    content_type = HTTPServerConnection::DefaultJSONContentType();
+    return *this;
+  }
+
+  template <typename T>
+  Response& JSON(const T& object, const std::string& object_name) {
+    body = cerealize::JSON(object, object_name);
+    content_type = HTTPServerConnection::DefaultJSONContentType();
+    return *this;
+  }
+
+  Response& Code(HTTPResponseCodeValue c) {
+    code = c;
+    return *this;
+  }
+
+  Response& ContentType(const std::string& s) {
+    content_type = s;
+    return *this;
+  }
+
+  Response& Headers(const HTTPHeadersType& h) {
+    extra_headers = h;
+    return *this;
+  }
+
+  void RespondViaHTTP(Request r) const { r(body, code, content_type, extra_headers); }
+};
+
+static_assert(Request::HasRespondViaHTTP<Response>::value, "");
+
+}  // namespace api
+}  // namespace net
+}  // namespace bricks
+
+#endif  // BRICKS_NET_API_RESPONSE_H

--- a/Bricks/net/api/test.cc
+++ b/Bricks/net/api/test.cc
@@ -647,6 +647,9 @@ TEST(HTTPAPI, ResponseSmokeTest) {
     send_response(Response().JSON(SerializableObject(), "magic").Code(HTTPResponseCode.OK), std::move(r));
   });
   HTTP(FLAGS_net_api_test_port).Register("/response8", [send_response](Request r) {
+    send_response(Response(HTTPResponseCode.Created), std::move(r));
+  });
+  HTTP(FLAGS_net_api_test_port).Register("/response9", [send_response](Request r) {
     send_response(Response(), std::move(r));  // Will result in a 500 "INTERNAL SERVER ERROR".
   });
 
@@ -679,6 +682,10 @@ TEST(HTTPAPI, ResponseSmokeTest) {
   EXPECT_EQ("{\"magic\":{\"x\":42,\"s\":\"foo\"}}\n", response7.body);
 
   const auto response8 = HTTP(GET(Printf("http://localhost:%d/response8", FLAGS_net_api_test_port)));
-  EXPECT_EQ(500, static_cast<int>(response8.code));
-  EXPECT_EQ("<h1>INTERNAL SERVER ERROR</h1>\n", response8.body);
+  EXPECT_EQ(201, static_cast<int>(response8.code));
+  EXPECT_EQ("", response8.body);
+
+  const auto response9 = HTTP(GET(Printf("http://localhost:%d/response9", FLAGS_net_api_test_port)));
+  EXPECT_EQ(500, static_cast<int>(response9.code));
+  EXPECT_EQ("<h1>INTERNAL SERVER ERROR</h1>\n", response9.body);
 }

--- a/Bricks/net/api/test.cc
+++ b/Bricks/net/api/test.cc
@@ -655,9 +655,9 @@ TEST(HTTPAPI, ResponseSmokeTest) {
 
   const auto response4 = HTTP(GET(Printf("http://localhost:%d/response4", FLAGS_net_api_test_port)));
   EXPECT_EQ(202, static_cast<int>(response4.code));
-  EXPECT_EQ("{\"value0\":{\"x\":42,\"s\":\"foo\"}}", response4.body);
+  EXPECT_EQ("{\"value0\":{\"x\":42,\"s\":\"foo\"}}\n", response4.body);
 
   const auto response5 = HTTP(GET(Printf("http://localhost:%d/response5", FLAGS_net_api_test_port)));
   EXPECT_EQ(201, static_cast<int>(response5.code));
-  EXPECT_EQ("{\"meh\":{\"x\":42,\"s\":\"foo\"}}", response5.body);
+  EXPECT_EQ("{\"meh\":{\"x\":42,\"s\":\"foo\"}}\n", response5.body);
 }

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -42,7 +42,6 @@ SOFTWARE.
 
 #include "../../../strings/util.h"
 #include "../../../cerealize/cerealize.h"
-#include "../../../template/decay.h"
 
 namespace bricks {
 namespace net {
@@ -405,7 +404,7 @@ class HTTPServerConnection final {
     SendHTTPResponseImpl(begin, end, code, content_type, extra_headers);
   }
   template <typename T>
-  inline typename std::enable_if<sizeof(typename rmref<T>::value_type) == 1>::type SendHTTPResponse(
+  inline typename std::enable_if<sizeof(typename T::value_type) == 1>::type SendHTTPResponse(
       T&& container,
       HTTPResponseCodeValue code = HTTPResponseCode.OK,
       const std::string& content_type = DefaultContentType(),
@@ -478,7 +477,7 @@ class HTTPServerConnection final {
 
       // Only support STL containers of chars and bytes, this does not yet cover std::string.
       template <typename T>
-      inline typename std::enable_if<sizeof(typename rmref<T>::value_type) == 1>::type Send(T&& data) {
+      inline typename std::enable_if<sizeof(typename T::value_type) == 1>::type Send(T&& data) {
         SendImpl(std::forward<T>(data));
       }
 


### PR DESCRIPTION
Hi @mzhurovich,

Here's a helper class to forward HTTP responses to the 2nd parameter to `Yoda` transactions, that own the HTTP request object.

PTAL.

Thanks,
Dima