### PR TITLE
JSON serialization for `CURRENT_STRUCT`-s.

### DIFF
--- a/Reflection/base.h
+++ b/Reflection/base.h
@@ -1,5 +1,5 @@
-#ifndef CURRENT_REFLECTION_SUPER_H
-#define CURRENT_REFLECTION_SUPER_H
+#ifndef CURRENT_REFLECTION_BASE_H
+#define CURRENT_REFLECTION_BASE_H
 
 namespace current {
 namespace reflection {
@@ -19,8 +19,8 @@ class FieldType {};
 class FieldName {};
 class FieldTypeAndName {};
 class FieldValue {};
-class FieldNameAndImmutableValueReference {};
-class FieldNameAndMutableValueReference {};
+class FieldNameAndImmutableValue {};
+class FieldNameAndMutableValue {};
 
 // Complex index: <HelperStruct, int Index>.
 template <class T, int N>
@@ -33,4 +33,4 @@ struct TypeSelector {};
 }  // namespace reflection
 }  // namespace current
 
-#endif  // CURRENT_REFLECTION_SUPER_H
+#endif  // CURRENT_REFLECTION_BASE_H

--- a/Reflection/basic_types.dsl.h
+++ b/Reflection/basic_types.dsl.h
@@ -1,0 +1,7 @@
+#ifdef CURRENT_BASIC_TYPE
+
+// I just kept same indexes for now. -- D.K.
+CURRENT_BASIC_TYPE(14, uint64_t, UInt64)
+CURRENT_BASIC_TYPE(31, std::string, String)
+
+#endif

--- a/Reflection/basic_types.dsl.h
+++ b/Reflection/basic_types.dsl.h
@@ -1,7 +1,0 @@
-#ifdef CURRENT_BASIC_TYPE
-
-// I just kept same indexes for now. -- D.K.
-CURRENT_BASIC_TYPE(14, uint64_t, UInt64)
-CURRENT_BASIC_TYPE(31, std::string, String)
-
-#endif

--- a/Reflection/primitive_types.dsl.h
+++ b/Reflection/primitive_types.dsl.h
@@ -1,0 +1,7 @@
+#ifdef CURRENT_DECLARE_PRIMITIVE_TYPE
+
+// I just kept same indexes for now. -- D.K.
+CURRENT_DECLARE_PRIMITIVE_TYPE(14, uint64_t, UInt64)
+CURRENT_DECLARE_PRIMITIVE_TYPE(31, std::string, String)
+
+#endif

--- a/Reflection/reflection.h
+++ b/Reflection/reflection.h
@@ -32,12 +32,12 @@ struct ReflectorImpl {
   };
 
   struct TypeReflector {
-#define CURRENT_BASIC_TYPE(unused_typeid_index, cpp_type, current_type)   \
-  std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<cpp_type>) { \
-    return make_unique<ReflectedType_##current_type>();                   \
+#define CURRENT_DECLARE_PRIMITIVE_TYPE(unused_typeid_index, cpp_type, current_type) \
+  std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<cpp_type>) {           \
+    return make_unique<ReflectedType_##current_type>();                             \
   }
-#include "basic_types.dsl.h"
-#undef CURRENT_BASIC_TYPE
+#include "primitive_types.dsl.h"
+#undef CURRENT_DECLARE_PRIMITIVE_TYPE
 
     template <typename T>
     std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<std::vector<T>>) {
@@ -66,7 +66,7 @@ struct ReflectorImpl {
       s->name = T::template CURRENT_REFLECTION_HELPER<T>::name();
       s->super_name = StructInheritanceString<T>();
       FieldReflector field_reflector(s->fields);
-      VisitAllFields<T, FieldTypeAndName>()(field_reflector);
+      VisitAllFields<T, FieldTypeAndName>::WithoutObject(field_reflector);
       s->type_id = CalculateTypeID(s);
       return std::move(s);
     }

--- a/Reflection/reflection.h
+++ b/Reflection/reflection.h
@@ -32,8 +32,12 @@ struct ReflectorImpl {
   };
 
   struct TypeReflector {
+    // TODO(dkorolev): Unify this part.
     std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<uint64_t>) {
       return make_unique<ReflectedType_UInt64>();
+    }
+    std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<std::string>) {
+      return make_unique<ReflectedType_String>();
     }
 
     template <typename T>

--- a/Reflection/reflection.h
+++ b/Reflection/reflection.h
@@ -66,7 +66,7 @@ struct ReflectorImpl {
       s->name = T::template CURRENT_REFLECTION_HELPER<T>::name();
       s->super_name = StructInheritanceString<T>();
       FieldReflector field_reflector(s->fields);
-      EnumFields<T, FieldTypeAndName>()(field_reflector);
+      VisitAllFields<T, FieldTypeAndName>()(field_reflector);
       s->type_id = CalculateTypeID(s);
       return std::move(s);
     }

--- a/Reflection/reflection.h
+++ b/Reflection/reflection.h
@@ -32,13 +32,12 @@ struct ReflectorImpl {
   };
 
   struct TypeReflector {
-    // TODO(dkorolev): Unify this part.
-    std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<uint64_t>) {
-      return make_unique<ReflectedType_UInt64>();
-    }
-    std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<std::string>) {
-      return make_unique<ReflectedType_String>();
-    }
+#define CURRENT_BASIC_TYPE(unused_typeid_index, cpp_type, current_type)   \
+  std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<cpp_type>) { \
+    return make_unique<ReflectedType_##current_type>();                   \
+  }
+#include "basic_types.dsl.h"
+#undef CURRENT_BASIC_TYPE
 
     template <typename T>
     std::unique_ptr<ReflectedTypeImpl> operator()(TypeSelector<std::vector<T>>) {

--- a/Reflection/struct.h
+++ b/Reflection/struct.h
@@ -170,9 +170,9 @@ struct FieldCounter {
 };
 
 template <typename T, typename INDEX_TYPE>
-struct EnumFields {
+struct VisitAllFields {
   static_assert(std::is_base_of<CurrentSuper, T>::value,
-                "`EnumFields` must be called with the type defined via `CURRENT_STRUCT` macro.");
+                "`VisitAllFields` must be called with the type defined via `CURRENT_STRUCT` macro.");
   typedef bricks::variadic_indexes::generate_indexes<FieldCounter<T>::value> NUM_INDEXES;
 
   template <typename F>

--- a/Reflection/struct.h
+++ b/Reflection/struct.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <type_traits>
 
-#include "super.h"
+#include "base.h"
 
 #include "../Bricks/template/variadic_indexes.h"
 
@@ -131,13 +131,12 @@ struct CurrentStructFieldsConsistency<T, -1> {
   }                                                                                                            \
   template <class F>                                                                                           \
   void CURRENT_REFLECTION(                                                                                     \
-      F&& f, ::current::reflection::Index<::current::reflection::FieldNameAndImmutableValueReference, idx>)    \
-      const {                                                                                                  \
+      F&& f, ::current::reflection::Index<::current::reflection::FieldNameAndImmutableValue, idx>) const {     \
     f(#name, name);                                                                                            \
   }                                                                                                            \
   template <class F>                                                                                           \
   void CURRENT_REFLECTION(                                                                                     \
-      F&& f, ::current::reflection::Index<::current::reflection::FieldNameAndMutableValueReference, idx>) {    \
+      F&& f, ::current::reflection::Index<::current::reflection::FieldNameAndMutableValue, idx>) {             \
     f(#name, name);                                                                                            \
   }
 

--- a/Reflection/struct.h
+++ b/Reflection/struct.h
@@ -168,28 +168,46 @@ struct FieldCounter {
   };
 };
 
-template <typename T, typename INDEX_TYPE>
+template <typename T, typename VISITOR_TYPE>
 struct VisitAllFields {
   static_assert(std::is_base_of<CurrentSuper, T>::value,
                 "`VisitAllFields` must be called with the type defined via `CURRENT_STRUCT` macro.");
   typedef bricks::variadic_indexes::generate_indexes<FieldCounter<T>::value> NUM_INDEXES;
 
+  // Visit all fields without an object. Used for enumerating fields and generating signatures.
   template <typename F>
-  void operator()(const F& f) {
+  static void WithoutObject(const F& f) {
     static NUM_INDEXES all_indexes;
-    Impl(f, all_indexes);
+    WithoutObjectImpl(f, all_indexes);
+  }
+
+  // Visit all fields with an object, const or mutable. Used for serialization.
+  template <typename TT, typename F>
+  static void WithObject(TT&& t, const F& f) {
+    static NUM_INDEXES all_indexes;
+    WithObjectImpl(std::forward<TT>(t), f, all_indexes);
   }
 
  private:
   template <typename F, int N, int... NS>
-  void Impl(const F& f, bricks::variadic_indexes::indexes<N, NS...>) {
+  static void WithoutObjectImpl(const F& f, bricks::variadic_indexes::indexes<N, NS...>) {
     static bricks::variadic_indexes::indexes<NS...> remaining_indexes;
-    T::CURRENT_REFLECTION(f, Index<INDEX_TYPE, N>());
-    Impl(f, remaining_indexes);
+    T::CURRENT_REFLECTION(f, Index<VISITOR_TYPE, N>());
+    WithoutObjectImpl(f, remaining_indexes);
   }
 
   template <typename F>
-  void Impl(const F&, bricks::variadic_indexes::indexes<>) {}
+  static void WithoutObjectImpl(const F&, bricks::variadic_indexes::indexes<>) {}
+
+  template <typename TT, typename F, int N, int... NS>
+  static void WithObjectImpl(TT&& t, const F& f, bricks::variadic_indexes::indexes<N, NS...>) {
+    static bricks::variadic_indexes::indexes<NS...> remaining_indexes;
+    t.CURRENT_REFLECTION(f, Index<VISITOR_TYPE, N>());
+    WithObjectImpl(std::forward<TT>(t), f, remaining_indexes);
+  }
+
+  template <typename TT, typename F>
+  static void WithObjectImpl(TT&&, const F&, bricks::variadic_indexes::indexes<>) {}
 };
 
 }  // namespace reflection

--- a/Reflection/test.cc
+++ b/Reflection/test.cc
@@ -253,9 +253,7 @@ struct SaveIntoJSONImpl<std::vector<T>> {
     destination.SetArray();
     rapidjson::Value element_to_push;
     for (const auto& element : value) {
-      // AssignToRapidJSONValue(element_to_push, element);
-      SaveIntoJSONImpl<T>::Go(element_to_push, allocator, element);  // document.GetAllocator(), value);
-
+      SaveIntoJSONImpl<T>::Go(element_to_push, allocator, element);
       destination.PushBack(element_to_push, allocator);
     }
   }

--- a/Reflection/test.cc
+++ b/Reflection/test.cc
@@ -143,14 +143,14 @@ TEST(Reflection, CurrentStructInternals) {
   foo.CURRENT_REFLECTION([&field_name, &field_value](const std::string& name, const uint64_t& value) {
     field_name = name;
     field_value = value;
-  }, Index<FieldNameAndImmutableValueReference, 0>());
+  }, Index<FieldNameAndImmutableValue, 0>());
   EXPECT_EQ("i", field_name);
   EXPECT_EQ(100u, field_value);
 
   foo.CURRENT_REFLECTION([&field_name](const std::string& name, uint64_t& value) {
     field_name = name;
     value = 123u;
-  }, Index<FieldNameAndMutableValueReference, 0>());
+  }, Index<FieldNameAndMutableValue, 0>());
   EXPECT_EQ("i", field_name);
   EXPECT_EQ(123u, foo.i);
 

--- a/Reflection/test.cc
+++ b/Reflection/test.cc
@@ -150,3 +150,30 @@ TEST(Reflection, CurrentStructInternals) {
   static_assert(std::is_same<SuperType<DerivedFromFoo>, Foo>::value, "");
   EXPECT_EQ(1u, FieldCounter<DerivedFromFoo>::value);
 }
+
+#include "../3rdparty/cereal/include/external/rapidjson/document.h"
+#include "../3rdparty/cereal/include/external/rapidjson/prettywriter.h"
+#include "../3rdparty/cereal/include/external/rapidjson/genericstream.h"
+
+TEST(Reflection, TryingJSONSerialization) {
+  using rapidjson::Document;
+  using rapidjson::Value;
+  using rapidjson::Writer;
+  using rapidjson::GenericWriteStream;
+
+  Document doc;
+  auto& allocator = doc.GetAllocator();
+  Value foo("bar");
+  doc.SetObject().AddMember("foo", foo, allocator);
+
+  EXPECT_TRUE(doc.IsObject());
+  EXPECT_TRUE(doc.HasMember("foo"));
+  EXPECT_TRUE(doc["foo"].IsString());
+  EXPECT_EQ("bar", doc["foo"].GetString());
+
+  std::ostringstream os;
+  auto stream = GenericWriteStream(os);
+  auto writer = Writer<GenericWriteStream>(stream);
+  doc.Accept(writer);
+  EXPECT_EQ("{\"foo\":\"bar\"}", os.str());
+}

--- a/Reflection/test.cc
+++ b/Reflection/test.cc
@@ -1,5 +1,10 @@
 #include "reflection.h"
 
+// TODO(dkorolev): Use RapidJSON from outside Cereal.
+#include "../3rdparty/cereal/include/external/rapidjson/document.h"
+#include "../3rdparty/cereal/include/external/rapidjson/prettywriter.h"
+#include "../3rdparty/cereal/include/external/rapidjson/genericstream.h"
+
 #include "../3rdparty/gtest/gtest-main.h"
 
 namespace reflection_test {
@@ -151,11 +156,27 @@ TEST(Reflection, CurrentStructInternals) {
   EXPECT_EQ(1u, FieldCounter<DerivedFromFoo>::value);
 }
 
-#include "../3rdparty/cereal/include/external/rapidjson/document.h"
-#include "../3rdparty/cereal/include/external/rapidjson/prettywriter.h"
-#include "../3rdparty/cereal/include/external/rapidjson/genericstream.h"
+namespace reflection_test {
 
-TEST(Reflection, RapidJSONSmoke) {
+CURRENT_STRUCT(Serializable) {
+  CURRENT_FIELD(i, uint64_t);
+  CURRENT_FIELD(s, std::string);
+};
+
+}  // namespace reflection_test
+
+TEST(Reflection, Serialization) {
+  using namespace reflection_test;
+
+  EXPECT_EQ(
+      "struct Serializable {\n"
+      "  uint64_t i;\n"
+      "  std::string s;\n"
+      "};\n",
+      Reflector().DescribeCppStruct<Serializable>());
+}
+
+TEST(RapidJSON, Smoke) {
   using rapidjson::Document;
   using rapidjson::Value;
   using rapidjson::Writer;
@@ -195,7 +216,7 @@ TEST(Reflection, RapidJSONSmoke) {
   }
 }
 
-TEST(Reflection, RapidJSONNullInString) {
+TEST(RapidJSON, NullInString) {
   using rapidjson::Document;
   using rapidjson::Value;
   using rapidjson::Writer;

--- a/Reflection/test.cc
+++ b/Reflection/test.cc
@@ -109,9 +109,9 @@ TEST(Reflection, TypeID) {
 
   // TODO(dkorolev): Migrate to `Polymorphic<>` and avoid `dynamic_cast<>` here.
   const ReflectedType_Struct& bar = dynamic_cast<const ReflectedType_Struct&>(*Reflector().ReflectType<Bar>());
-  EXPECT_EQ(9010000001031372545, static_cast<uint64_t>(bar.fields[0].first->type_id));
-  EXPECT_EQ(9010000003023971265, static_cast<uint64_t>(bar.fields[1].first->type_id));
-  EXPECT_EQ(9010000000769980382, static_cast<uint64_t>(bar.fields[2].first->type_id));
+  EXPECT_EQ(9010000001031372545ull, static_cast<uint64_t>(bar.fields[0].first->type_id));
+  EXPECT_EQ(9010000003023971265ull, static_cast<uint64_t>(bar.fields[1].first->type_id));
+  EXPECT_EQ(9010000000769980382ull, static_cast<uint64_t>(bar.fields[2].first->type_id));
 }
 
 TEST(Reflection, CurrentStructInternals) {

--- a/Reflection/test.cc
+++ b/Reflection/test.cc
@@ -161,19 +161,36 @@ TEST(Reflection, TryingJSONSerialization) {
   using rapidjson::Writer;
   using rapidjson::GenericWriteStream;
 
-  Document doc;
-  auto& allocator = doc.GetAllocator();
-  Value foo("bar");
-  doc.SetObject().AddMember("foo", foo, allocator);
+  std::string json;
 
-  EXPECT_TRUE(doc.IsObject());
-  EXPECT_TRUE(doc.HasMember("foo"));
-  EXPECT_TRUE(doc["foo"].IsString());
-  EXPECT_EQ("bar", doc["foo"].GetString());
+  {
+    Document doc;
+    auto& allocator = doc.GetAllocator();
+    Value foo("bar");
+    doc.SetObject().AddMember("foo", foo, allocator);
 
-  std::ostringstream os;
-  auto stream = GenericWriteStream(os);
-  auto writer = Writer<GenericWriteStream>(stream);
-  doc.Accept(writer);
-  EXPECT_EQ("{\"foo\":\"bar\"}", os.str());
+    EXPECT_TRUE(doc.IsObject());
+    EXPECT_TRUE(doc.HasMember("foo"));
+    EXPECT_TRUE(doc["foo"].IsString());
+    EXPECT_EQ("bar", doc["foo"].GetString());
+
+    std::ostringstream os;
+    auto stream = GenericWriteStream(os);
+    auto writer = Writer<GenericWriteStream>(stream);
+    doc.Accept(writer);
+    json = os.str();
+  }
+
+  EXPECT_EQ("{\"foo\":\"bar\"}", json);
+
+  {
+    Document doc;
+    ASSERT_FALSE(doc.Parse<0>(json.c_str()).HasParseError());
+    EXPECT_TRUE(doc.IsObject());
+    EXPECT_TRUE(doc.HasMember("foo"));
+    EXPECT_TRUE(doc["foo"].IsString());
+    EXPECT_EQ(std::string("bar"), doc["foo"].GetString());
+    EXPECT_FALSE(doc.HasMember("bar"));
+    EXPECT_FALSE(doc.HasMember("meh"));
+  }
 }

--- a/Reflection/types.h
+++ b/Reflection/types.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <memory>
 
-#include "super.h"
+#include "base.h"
 #include "crc32.h"
 
 namespace current {

--- a/Reflection/types.h
+++ b/Reflection/types.h
@@ -27,7 +27,8 @@ enum class TypeID : uint64_t {
   Int32 = TYPEID_BASIC_TYPE + 23,
   Int64 = TYPEID_BASIC_TYPE + 24,
   Float = TYPEID_BASIC_TYPE + 31,
-  Double = TYPEID_BASIC_TYPE + 32
+  Double = TYPEID_BASIC_TYPE + 32,
+  String = TYPEID_BASIC_TYPE + 31
 };
 
 struct ReflectedTypeImpl {
@@ -37,9 +38,14 @@ struct ReflectedTypeImpl {
   virtual ~ReflectedTypeImpl() = default;
 };
 
+// TODO(dkorolev): Unify this part.
 struct ReflectedType_UInt64 : ReflectedTypeImpl {
   TypeID type_id = TypeID::UInt64;
   std::string CppType() override { return "uint64_t"; }
+};
+struct ReflectedType_String : ReflectedTypeImpl {
+  TypeID type_id = TypeID::String;
+  std::string CppType() override { return "std::string"; }
 };
 
 struct ReflectedType_Vector : ReflectedTypeImpl {
@@ -88,13 +94,16 @@ inline TypeID CalculateTypeID(const ReflectedType_Vector& v) {
 }
 
 // Enable `CalculateTypeID` for bare and smart pointers.
-template<typename T, typename DELETER> TypeID CalculateTypeID(const std::unique_ptr<T, DELETER>& ptr) {
+template <typename T, typename DELETER>
+TypeID CalculateTypeID(const std::unique_ptr<T, DELETER>& ptr) {
   return CalculateTypeID(*ptr);
 }
-template<typename T> TypeID CalculateTypeID(const std::shared_ptr<T>& ptr) {
+template <typename T>
+TypeID CalculateTypeID(const std::shared_ptr<T>& ptr) {
   return CalculateTypeID(*ptr);
 }
-template<typename T> TypeID CalculateTypeID(const T* ptr) {
+template <typename T>
+TypeID CalculateTypeID(const T* ptr) {
   return CalculateTypeID(*ptr);
 }
 

--- a/Reflection/types.h
+++ b/Reflection/types.h
@@ -19,10 +19,10 @@ constexpr uint64_t TYPEID_COLLECTION_TYPE = 901u * TYPEID_TYPE_RANGE;
 constexpr uint64_t TYPEID_STRUCT_TYPE = 902u * TYPEID_TYPE_RANGE;
 
 enum class TypeID : uint64_t {
-#define CURRENT_BASIC_TYPE(typeid_index, unused_cpp_type, current_type) \
+#define CURRENT_DECLARE_PRIMITIVE_TYPE(typeid_index, unused_cpp_type, current_type) \
   current_type = TYPEID_BASIC_TYPE + typeid_index,
-#include "basic_types.dsl.h"
-#undef CURRENT_BASIC_TYPE
+#include "primitive_types.dsl.h"
+#undef CURRENT_DECLARE_PRIMITIVE_TYPE
 };
 
 struct ReflectedTypeImpl {
@@ -32,13 +32,13 @@ struct ReflectedTypeImpl {
   virtual ~ReflectedTypeImpl() = default;
 };
 
-#define CURRENT_BASIC_TYPE(unused_typeid_index, cpp_type, current_type) \
-  struct ReflectedType_##current_type : ReflectedTypeImpl {             \
-    TypeID type_id = TypeID::current_type;                              \
-    std::string CppType() override { return #cpp_type; }                \
+#define CURRENT_DECLARE_PRIMITIVE_TYPE(unused_typeid_index, cpp_type, current_type) \
+  struct ReflectedType_##current_type : ReflectedTypeImpl {                         \
+    TypeID type_id = TypeID::current_type;                                          \
+    std::string CppType() override { return #cpp_type; }                            \
   };
-#include "basic_types.dsl.h"
-#undef CURRENT_BASIC_TYPE
+#include "primitive_types.dsl.h"
+#undef CURRENT_DECLARE_PRIMITIVE_TYPE
 
 struct ReflectedType_Vector : ReflectedTypeImpl {
   constexpr static const char* cpp_typename = "std::vector";


### PR DESCRIPTION
Hi @mzhurovich ,

I've заботал RapidJSON and implemented non-polymorphic serialization with it. It supports primitive types (`uint64_t`), strings, vectors, and nested `CURRENT_STRUCT`-s.

Also, factored out the list of primitive types into a dedicated DSL header, adding more should be one-liners now.

Hope you could jump in and move the JSON logic away from the `test.cc` file -- I've just prototyped it there for now.

Thanks!
Dima