### PR TITLE
Added `struct_fields.cc`.

### DIFF
--- a/sandbox/TypeTest/.gitignore
+++ b/sandbox/TypeTest/.gitignore
@@ -1,0 +1,3 @@
+golden
+include
+dummy.h

--- a/sandbox/TypeTest/gen_test_data.sh
+++ b/sandbox/TypeTest/gen_test_data.sh
@@ -31,6 +31,19 @@ for i in `seq 1 $STRUCT_COUNT`; do
 	echo "};" >> $CURRENT_STRUCT_GOLDEN
 done
 
+# 'struct_fields.cc' test.
+STRUCT_FIELDS_HEADER="$INCLUDE_DIR/struct_fields.h"
+STRUCT_FIELDS_GOLDEN="$GOLDEN_DIR/struct_fields.cc"
+
+echo "CURRENT_STRUCT(StructWithManyFields) {" >> $STRUCT_FIELDS_HEADER
+echo "struct StructWithManyFields {" >> $STRUCT_FIELDS_GOLDEN
+for i in `seq 1 $STRUCT_COUNT`; do
+	echo "  CURRENT_FIELD(z$i, uint32_t);" >> $STRUCT_FIELDS_HEADER
+	echo "  uint32_t z$i;" >> $STRUCT_FIELDS_GOLDEN
+done
+echo "};" >> $STRUCT_FIELDS_HEADER
+echo "};" >> $STRUCT_FIELDS_GOLDEN
+
 # 'typelist.cc' test.
 TYPELIST_HEADER="$INCLUDE_DIR/typelist.h"
 TYPELIST_TEST="$INCLUDE_DIR/typelist.cc"
@@ -110,3 +123,5 @@ for i in `seq 1 $STRUCT_COUNT`; do
 	fi
 done
 echo "> DATA_TYPES;" >> $TYPELIST_DYNAMIC_TEST
+
+touch dummy.h

--- a/sandbox/TypeTest/struct_fields.cc
+++ b/sandbox/TypeTest/struct_fields.cc
@@ -1,0 +1,53 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Maxim Zhurovich <zhurovich@gmail.com>
+              2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#include "../../TypeSystem/Reflection/schema.h"
+
+#include "../../Bricks/file/file.h"
+
+#include "../../3rdparty/gtest/gtest-main.h"
+
+namespace type_test {
+
+#include "include/struct_fields.h"
+
+}  // namespace type_test
+
+TEST(TypeTest, StructFields) {
+  using namespace type_test;
+  using current::reflection::StructSchema;
+  using current::reflection::SchemaInfo;
+
+  StructSchema schema;
+  schema.AddType<StructWithManyFields>();
+
+  SchemaInfo schema_info = schema.GetSchemaInfo();
+  const std::string golden_cpp = bricks::FileSystem::ReadFileAsString("golden/struct_fields.cc");
+  std::string cpp;
+  for (size_t i = 0; i < schema_info.ordered_struct_list.size(); ++i) {
+    cpp += schema.CppDescription(schema_info.ordered_struct_list[i]);
+  }
+  EXPECT_EQ(cpp, golden_cpp);
+}

--- a/sandbox/TypeTest/test.sh
+++ b/sandbox/TypeTest/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-COUNT_LIST=(10 100 500)
+COUNT_LIST=(10 100 200)
 TEST_LIST=('.current/current_struct'
+           '.current/struct_fields'
            '.current/typelist_impl'
            '.current/rtti_dynamic_call')
 # 20 structs for '.current/typelist' and 10 for '.current/typelist_dynamic' are killing my clang :( //MZ


### PR DESCRIPTION
Hi @mzhurovich ,

Added a dummy header for our default `Makefile` to do its job, and tested a large number of fields in a struct.

A large `TypeList<>` would indeed not work. A large `Flatten<map<...>>`, however, may be tweaked.

Bedtime for me, online in ~9 hours.

Thanks,
Dima