### PR TITLE
Polymorphic types.

### DIFF
--- a/TypeSystem/Serialization/binary.h
+++ b/TypeSystem/Serialization/binary.h
@@ -29,6 +29,10 @@ SOFTWARE.
 
 #include "../struct.h"
 
+// TODO(dkorolev): Soon to be added.
+// #include "../optional.h"
+// #include "../polymorphic.h"
+
 namespace current {
 namespace serialization {
 

--- a/TypeSystem/Serialization/binary.h
+++ b/TypeSystem/Serialization/binary.h
@@ -189,7 +189,7 @@ struct LoadPrimitiveTypeFromBinary {
     BINARY_FORMAT_SIZE_TYPE size = LoadSizeFromBinary(istream);
     destination.resize(static_cast<size_t>(size));
     // Should be legitimate since c++11 requires internal buffer to be contiguous.
-    const size_t bytes_read = istream.rdbuf()->sgetn(const_cast<char*>(destination.data()), size);
+    const size_t bytes_read = istream.rdbuf()->sgetn(&destination[0], size);
     if (bytes_read != static_cast<size_t>(size)) {
       throw BinaryLoadFromStreamException(size, bytes_read);
     }
@@ -263,8 +263,8 @@ struct LoadFromBinaryImpl<std::map<TK, TV>> {
   static void Load(std::istream& istream, std::map<TK, TV>& destination) {
     destination.clear();
     BINARY_FORMAT_SIZE_TYPE size = LoadSizeFromBinary(istream);
+    std::pair<TK, TV> entry;
     for (size_t i = 0; i < static_cast<size_t>(size); ++i) {
-      std::pair<TK, TV> entry;  // TODO(dkorolev): Investigate.
       LoadFromBinaryImpl<std::pair<TK, TV>>::Load(istream, entry);
       destination.insert(entry);
     }

--- a/TypeSystem/Serialization/json.h
+++ b/TypeSystem/Serialization/json.h
@@ -30,6 +30,10 @@ SOFTWARE.
 
 #include "exceptions.h"
 
+#include "../struct.h"
+#include "../optional.h"
+#include "../polymorphic.h"
+
 #include "../Reflection/reflection.h"
 
 #include "../../Bricks/template/enable_if.h"

--- a/TypeSystem/Serialization/json.h
+++ b/TypeSystem/Serialization/json.h
@@ -368,8 +368,8 @@ struct LoadFromJSONImpl<std::map<TK, TV>> {
                                                              const std::string& path) {
     if (source && source->IsObject()) {
       destination.clear();
+      std::pair<TK, TV> entry;
       for (rapidjson::Value::MemberIterator cit = source->MemberBegin(); cit != source->MemberEnd(); ++cit) {
-        std::pair<TK, TV> entry;  // TODO(dkorolev): Investigate.
         LoadFromJSONImpl<TK>::Load(&cit->name, entry.first, path);
         LoadFromJSONImpl<TV>::Load(&cit->value, entry.second, path);
         destination.insert(entry);
@@ -384,8 +384,8 @@ struct LoadFromJSONImpl<std::map<TK, TV>> {
                                                               const std::string& path) {
     if (source && source->IsArray()) {
       destination.clear();
+      std::pair<TK, TV> entry;
       for (rapidjson::Value::ValueIterator cit = source->Begin(); cit != source->End(); ++cit) {
-        std::pair<TK, TV> entry;  // TODO(dkorolev): Investigate.
         if (!cit->IsArray()) {
           throw JSONSchemaException("map entry as array", source, path);
         }

--- a/TypeSystem/Serialization/json.h
+++ b/TypeSystem/Serialization/json.h
@@ -243,7 +243,6 @@ struct LoadFromJSONImpl {
   static ENABLE_IF<IS_CURRENT_STRUCT(TT)> Load(rapidjson::Value* source,
                                                T& destination,
                                                const std::string& path) {
-    //  static void Load(rapidjson::Value* source, T& destination, const std::string& path) {
     if (source && source->IsObject()) {
       LoadFieldVisitor visitor(*source, path);
       current::reflection::VisitAllFields<bricks::decay<T>, current::reflection::FieldNameAndMutableValue>::
@@ -337,9 +336,9 @@ template <typename T>
 struct LoadFromJSONImpl<std::vector<T>> {
   static void Load(rapidjson::Value* source, std::vector<T>& destination, const std::string& path) {
     if (source && source->IsArray()) {
-      const size_t n = source->Size();
-      destination.resize(n);
-      for (rapidjson::SizeType i = 0; i < static_cast<rapidjson::SizeType>(n); ++i) {
+      const size_t size = source->Size();
+      destination.resize(size);
+      for (rapidjson::SizeType i = 0; i < static_cast<rapidjson::SizeType>(size); ++i) {
         LoadFromJSONImpl<T>::Load(&((*source)[i]), destination[i], path + '[' + std::to_string(i) + ']');
       }
     } else {

--- a/TypeSystem/Serialization/test.cc
+++ b/TypeSystem/Serialization/test.cc
@@ -30,6 +30,8 @@ SOFTWARE.
 #include "binary.h"
 #include "json.h"
 
+#include "../struct.h"
+
 #include "../Reflection/reflection.h"
 #include "../Reflection/schema.h"
 

--- a/TypeSystem/exceptions.h
+++ b/TypeSystem/exceptions.h
@@ -22,39 +22,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#ifndef CURRENT_TYPE_SYSTEM_SFINAE_H
-#define CURRENT_TYPE_SYSTEM_SFINAE_H
+#ifndef CURRENT_TYPE_SYSTEM_EXCEPTIONS_H
+#define CURRENT_TYPE_SYSTEM_EXCEPTIONS_H
 
-#include <utility>
-
-#include "../Bricks/template/enable_if.h"
+#include <exception>
 
 namespace current {
-namespace sfinae {
 
-// Whether an `Exists()` method is defined for a type.
-template <typename ENTRY>
-constexpr bool HasExistsMethod(char) {
-  return false;
-}
+struct NoValueException : std::exception {};
+template <typename T>
+struct NoValueOfTypeException : NoValueException {};
 
-template <typename ENTRY>
-constexpr auto HasExistsMethod(int) -> decltype(std::declval<const ENTRY>().Exists(), bool()) {
-  return true;
-}
+typedef const NoValueException& NoValue;
 
-// Whether a `Value()` method is defined for a type.
-template <typename ENTRY>
-constexpr bool HasValueMethod(char) {
-  return false;
-}
+template <typename T>
+struct NoValueOfTypeExceptionWrapper {
+  using underlying_type = NoValueOfTypeException<T>;
+  typedef const underlying_type& const_reference_type;
+};
 
-template <typename ENTRY>
-constexpr auto HasValueMethod(int) -> decltype(std::declval<const ENTRY>().Value(), bool()) {
-  return true;
-}
+template <typename T>
+using NoValueOfType = typename NoValueOfTypeExceptionWrapper<T>::const_reference_type;
 
-}  // namespace sfinae
 }  // namespace current
 
-#endif  // CURRENT_TYPE_SYSTEM_SFINAE_H
+using current::NoValueException;
+using current::NoValueOfTypeException;
+
+using current::NoValue;        // == `const NoValueException&` for cleaner `catch (NoValue)` syntax.
+using current::NoValueOfType;  // == `const NoValueOfTypeException<T>&` for cleaner `catch ()` syntax.
+
+#endif  // CURRENT_TYPE_SYSTEM_EXCEPTIONS_H

--- a/TypeSystem/helpers.h
+++ b/TypeSystem/helpers.h
@@ -1,0 +1,79 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Maxim Zhurovich <zhurovich@gmail.com>
+          (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_TYPE_SYSTEM_HELPERS_H
+#define CURRENT_TYPE_SYSTEM_HELPERS_H
+
+#include "sfinae.h"
+
+namespace current {
+
+template <typename T>
+struct ExistsImpl {
+  // Primitive types.
+  template <typename TT = T>
+  static ENABLE_IF<!current::sfinae::HasExistsMethod<TT>(0), bool> CallExists(TT&&) {
+    return true;
+  }
+
+  // Special types.
+  template <typename TT = T>
+  static ENABLE_IF<current::sfinae::HasExistsMethod<TT>(0), bool> CallExists(TT&& x) {
+    return x.Exists();
+  }
+};
+
+template <typename T>
+bool Exists(T&& x) {
+  return ExistsImpl<T>::CallExists(std::forward<T>(x));
+}
+
+template <typename T>
+struct ValueImpl {
+  // Primitive types.
+  template <typename TT = T>
+  static ENABLE_IF<!current::sfinae::HasValueMethod<TT>(0), T&&> CallValue(T&& x) {
+    return x;
+  }
+
+  // Special types.
+  template <typename TT = T>
+  static ENABLE_IF<current::sfinae::HasValueMethod<TT>(0), decltype(std::declval<TT>().Value())> CallValue(
+      TT&& x) {
+    return x.Value();
+  }
+};
+
+template <typename T>
+auto Value(T&& x) -> decltype(ValueImpl<T>::CallValue(std::declval<T>())) {
+  return ValueImpl<T>::CallValue(std::forward<T>(x));
+}
+
+}  // namespace current
+
+using current::Exists;
+using current::Value;
+
+#endif  // CURRENT_TYPE_SYSTEM_HELPERS_H

--- a/TypeSystem/optional.h
+++ b/TypeSystem/optional.h
@@ -59,11 +59,15 @@ SOFTWARE.
 
 namespace current {
 
+// A special constructor parameter to indicate `Optional` it should indeed
+// construct itself from a bare pointer.
+struct FromBarePointer {};
+
 template <typename T>
 class ImmutableOptional final {
  public:
   ImmutableOptional() = delete;
-  ImmutableOptional(const T* object) : optional_object_(object) {}
+  ImmutableOptional(const FromBarePointer&, const T* object) : optional_object_(object) {}
 
   // NOTE: Constructors taking references or const references are a bad idea,
   // since it makes it very easy to make a mistake of passing in a short-lived temporary.
@@ -93,7 +97,7 @@ template <typename T>
 class Optional final {
  public:
   Optional() = default;
-  Optional(const T* object) : optional_object_(object) {}
+  Optional(const FromBarePointer&, const T* object) : optional_object_(object) {}
 
   // NOTE: Constructors taking references or const references are a bad idea,
   // since it makes it very easy to make a mistake of passing in a short-lived temporary.
@@ -152,5 +156,6 @@ class Optional final {
 
 using current::ImmutableOptional;
 using current::Optional;
+using current::FromBarePointer;
 
 #endif  // CURRENT_TYPE_SYSTEM_OPTIONAL_H

--- a/TypeSystem/optional.h
+++ b/TypeSystem/optional.h
@@ -48,28 +48,16 @@ SOFTWARE.
 #ifndef CURRENT_TYPE_SYSTEM_OPTIONAL_H
 #define CURRENT_TYPE_SYSTEM_OPTIONAL_H
 
-#include "sfinae.h"
+#include "../port.h"  // `make_unique<>`.
 
-#include "../Bricks/time/chrono.h"
+#include <memory>
+
+#include "exceptions.h"
+
 #include "../Bricks/template/enable_if.h"
 #include "../Bricks/template/decay.h"
 
 namespace current {
-
-struct NoValueException : std::exception {};
-template <typename T>
-struct NoValueOfTypeException : NoValueException {};
-
-typedef const NoValueException& NoValue;
-
-template <typename T>
-struct NoValueOfTypeExceptionWrapper {
-  using underlying_type = NoValueOfTypeException<T>;
-  typedef const underlying_type& const_reference_type;
-};
-
-template <typename T>
-using NoValueOfType = typename NoValueOfTypeExceptionWrapper<T>::const_reference_type;
 
 template <typename T>
 class ImmutableOptional final {
@@ -160,59 +148,9 @@ class Optional final {
   T* optional_object_ = nullptr;
 };
 
-template <typename T>
-struct ExistsImpl {
-  // Primitive types.
-  template <typename TT = T>
-  static ENABLE_IF<!current::sfinae::HasExistsMethod<TT>(0), bool> CallExists(TT&&) {
-    return true;
-  }
-
-  // Special types.
-  template <typename TT = T>
-  static ENABLE_IF<current::sfinae::HasExistsMethod<TT>(0), bool> CallExists(TT&& x) {
-    return x.Exists();
-  }
-};
-
-template <typename T>
-bool Exists(T&& x) {
-  return ExistsImpl<T>::CallExists(std::forward<T>(x));
-}
-
-template <typename T>
-struct ValueImpl {
-  // Primitive types.
-  template <typename TT = T>
-  static ENABLE_IF<!current::sfinae::HasValueMethod<TT>(0), T&&> CallValue(T&& x) {
-    return x;
-  }
-
-  // Special types.
-  template <typename TT = T>
-  static ENABLE_IF<current::sfinae::HasValueMethod<TT>(0), decltype(std::declval<TT>().Value())> CallValue(
-      TT&& x) {
-    return x.Value();
-  }
-};
-
-template <typename T>
-auto Value(T&& x) -> decltype(ValueImpl<T>::CallValue(std::declval<T>())) {
-  return ValueImpl<T>::CallValue(std::forward<T>(x));
-}
-
 }  // namespace current
 
 using current::ImmutableOptional;
 using current::Optional;
-
-using current::NoValueException;
-using current::NoValueOfTypeException;
-
-using current::NoValue;        // == `const NoValueException&` for cleaner `catch (NoValue)` syntax.
-using current::NoValueOfType;  // == `const NoValueOfTypeException<T>&` for cleaner `catch ()` syntax.
-
-using current::Exists;
-using current::Value;
 
 #endif  // CURRENT_TYPE_SYSTEM_OPTIONAL_H

--- a/TypeSystem/optional.h
+++ b/TypeSystem/optional.h
@@ -97,7 +97,7 @@ template <typename T>
 class Optional final {
  public:
   Optional() = default;
-  Optional(const FromBarePointer&, const T* object) : optional_object_(object) {}
+  Optional(const FromBarePointer&, T* object) : optional_object_(object) {}
 
   // NOTE: Constructors taking references or const references are a bad idea,
   // since it makes it very easy to make a mistake of passing in a short-lived temporary.

--- a/TypeSystem/polymorphic.h
+++ b/TypeSystem/polymorphic.h
@@ -123,18 +123,20 @@ struct PolymorphicImpl<T, TS...> {
   }
 
   template <typename F>
-  void Match(F&& f) {
+  void Call(F&& f) {
     bricks::metaprogramming::RTTIDynamicCall<T_TYPELIST>(*object_, std::forward<F>(f));
   }
 
   template <typename F>
-  void Match(F&& f) const {
+  void Call(F&& f) const {
     bricks::metaprogramming::RTTIDynamicCall<T_TYPELIST>(*object_, std::forward<F>(f));
   }
 
   // Note that `Has()` and `Value()` do not check whether `X` is part of `T_TYPELIST`.
-  // This is a) for performance reasons, and b) to allow accessing base types from derived ones.
-  // Use `Match()` to run a strict check.
+  // More specifically, they pass if `dynamic_cast<>` succeeds, and thus will successfully
+  // retrieve a derived type as a base one, regardless of whether the derived one
+  // is present in `T_TYPELIST`.
+  // Use `Call()` to run a strict check.
   template <typename X>
   bool Has() const {
     return dynamic_cast<const X*>(object_.get()) != nullptr;

--- a/TypeSystem/polymorphic.h
+++ b/TypeSystem/polymorphic.h
@@ -1,0 +1,173 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_TYPE_SYSTEM_POLYMORPHIC_H
+#define CURRENT_TYPE_SYSTEM_POLYMORPHIC_H
+
+#include "../port.h"  // `make_unique`.
+
+#include <memory>
+
+#include "base.h"
+#include "exceptions.h"
+
+#include "../Bricks/template/combine.h"
+#include "../Bricks/template/mapreduce.h"
+#include "../Bricks/template/typelist.h"
+#include "../Bricks/template/rtti_dynamic_call.h"
+
+namespace current {
+
+// Note: `Polymorphic<...>` never uses `TypeList<...>`, only `TypeListImpl<...>`.
+// Thus, it emphasizes performance over correctness.
+// The user hold the risk of having duplicate types, and it's their responsibility to pass in a `TypeList<...>`
+// instead of a `TypeListImpl<...>` in such a case, to ensure type de-duplication takes place.
+
+// Explicitly disable an empty `Polymorphic<>`.
+template <typename... TS>
+struct PolymorphicImpl;
+
+template <typename T, typename... TS>
+struct PolymorphicImpl<T, TS...> {
+  using T_TYPELIST = TypeListImpl<T, TS...>;
+  enum { T_TYPELIST_SIZE = TypeListSize<T_TYPELIST>::value };
+
+  std::unique_ptr<CurrentSuper> object_;
+
+  // Initializes an `std::unique_ptr<CurrentSuper>` given the object of the right type.
+  // The input object could be an object itself (in which case it's copied),
+  // an `std::move()`-d `std::unique_ptr` to that object (in which cast it's moved),
+  // or a bare pointer (in which case it's captured).
+  // TODO(dkorolev): The bare pointer one is sure unsafe -- consult with @mzhurovich.
+  struct TypeCheckedAsisgnment {
+    template <typename X>
+    struct Impl {
+      // Copy `X`.
+      void operator()(const X& source, std::unique_ptr<CurrentSuper>& destination) {
+        if (!destination || !dynamic_cast<X*>(destination.get())) {
+          destination = make_unique<X>();
+        }
+        X& placeholder = dynamic_cast<X&>(*destination.get());
+        placeholder = source;
+      }
+      // Move `X`.
+      void operator()(X&& source, std::unique_ptr<CurrentSuper>& destination) {
+        if (!destination || !dynamic_cast<X*>(destination.get())) {
+          destination = make_unique<X>();
+        }
+        X& placeholder = dynamic_cast<X&>(*destination.get());
+        placeholder = std::move(source);
+      }
+      // Move `std::unique_ptr`.
+      void operator()(std::unique_ptr<X>&& source, std::unique_ptr<CurrentSuper>& destination) {
+        if (!source) {
+          throw NoValueOfTypeException<X>();
+        }
+        destination = std::move(source);
+      }
+      // Capture a bare `X*`.
+      // TODO(dkorolev): Unsafe? Remove?
+      void operator()(X* source, std::unique_ptr<CurrentSuper>& destination) { destination.reset(source); }
+    };
+    using Instance = bricks::metaprogramming::combine<bricks::metaprogramming::map<Impl, T_TYPELIST>>;
+    template <typename Q>
+    static void Perform(Q&& source, std::unique_ptr<CurrentSuper>& destination) {
+      Instance instance;
+      instance(std::forward<Q>(source), destination);
+    }
+  };
+
+  PolymorphicImpl() = delete;
+
+  // PolymorphicImpl(std::unique_ptr<CurrentSuper>&& rhs) : object_(std::move(rhs)) {}
+  template <typename X>
+  PolymorphicImpl(X&& input) {
+    TypeCheckedAsisgnment::Perform(std::forward<X>(input), object_);
+  }
+
+  PolymorphicImpl(PolymorphicImpl&& rhs) : object_(std::move(rhs.object)) {}
+
+  template <typename X>
+  void operator=(X&& input) {
+    TypeCheckedAsisgnment::Perform(std::forward<X>(input), object_);
+  }
+
+  template<typename F>
+  void Match(F&& f) {
+    bricks::metaprogramming::RTTIDynamicCall<T_TYPELIST>(*object_, std::forward<F>(f));
+  }
+
+  template<typename F>
+  void Match(F&& f) const {
+    bricks::metaprogramming::RTTIDynamicCall<T_TYPELIST>(*object_, std::forward<F>(f));
+  }
+
+  // Note that `Has()` and `Value()` do not check whether `X` is part of `T_TYPELIST`.
+  // This is a) for performance reasons, and b) to allow accessing base types from derived ones.
+  // Use `Match()` to run a strict check.
+  template <typename X>
+  bool Has() const {
+    return dynamic_cast<const X*>(object_.get()) != nullptr;
+  }
+
+  template <typename X>
+  X& Value() {
+    X* ptr = dynamic_cast<X*>(object_.get());
+    if (ptr) {
+      return *ptr;
+    } else {
+      throw NoValueOfTypeException<X>();
+    }
+  }
+
+  template <typename X>
+  const X& Value() const {
+    const X* ptr = dynamic_cast<const X*>(object_.get());
+    if (ptr) {
+      return *ptr;
+    } else {
+      throw NoValueOfTypeException<X>();
+    }
+  }
+};
+
+// `Polymorphic<...>` can accept either a list of types, or a `TypeList<...>`.
+template <typename... TS>
+struct PolymorphicSelector {
+  using type = PolymorphicImpl<TS...>;
+};
+
+template <typename... TS>
+struct PolymorphicSelector<TypeListImpl<TS...>> {
+  using type = PolymorphicImpl<TS...>;
+};
+
+template <typename... TS>
+using Polymorphic = typename PolymorphicSelector<TS...>::type;
+
+}  // namespace current
+
+using current::Polymorphic;
+
+#endif  // CURRENT_TYPE_SYSTEM_POLYMORPHIC_H

--- a/TypeSystem/polymorphic.h
+++ b/TypeSystem/polymorphic.h
@@ -57,10 +57,10 @@ struct PolymorphicImpl<T, TS...> {
 
   // Initializes an `std::unique_ptr<CurrentSuper>` given the object of the right type.
   // The input object could be an object itself (in which case it's copied),
-  // an `std::move()`-d `std::unique_ptr` to that object (in which cast it's moved),
+  // an `std::move()`-d `std::unique_ptr` to that object (in which case it's moved),
   // or a bare pointer (in which case it's captured).
   // TODO(dkorolev): The bare pointer one is sure unsafe -- consult with @mzhurovich.
-  struct TypeCheckedAsisgnment {
+  struct TypeCheckedAssignment {
     template <typename Z>
     struct DerivedTypesDifferentiator {};
 
@@ -112,14 +112,14 @@ struct PolymorphicImpl<T, TS...> {
   // PolymorphicImpl(std::unique_ptr<CurrentSuper>&& rhs) : object_(std::move(rhs)) {}
   template <typename X>
   PolymorphicImpl(X&& input) {
-    TypeCheckedAsisgnment::Perform(std::forward<X>(input), object_);
+    TypeCheckedAssignment::Perform(std::forward<X>(input), object_);
   }
 
   PolymorphicImpl(PolymorphicImpl&& rhs) : object_(std::move(rhs.object)) {}
 
   template <typename X>
   void operator=(X&& input) {
-    TypeCheckedAsisgnment::Perform(std::forward<X>(input), object_);
+    TypeCheckedAssignment::Perform(std::forward<X>(input), object_);
   }
 
   template <typename F>

--- a/TypeSystem/polymorphic.h
+++ b/TypeSystem/polymorphic.h
@@ -73,16 +73,16 @@ struct PolymorphicImpl<T, TS...> {
         if (!destination || !dynamic_cast<X*>(destination.get())) {
           destination = make_unique<X>();
         }
-        X& placeholder = dynamic_cast<X&>(*destination.get());
-        placeholder = source;
+        // Note: `destination.get() = source` is a mistake, and we made sure it doesn't compile. -- D.K.
+        dynamic_cast<X&>(*destination.get()) = source;
       }
       // Move `X`.
       void operator()(DerivedTypesDifferentiator<X>, X&& source, std::unique_ptr<CurrentSuper>& destination) {
         if (!destination || !dynamic_cast<X*>(destination.get())) {
           destination = make_unique<X>();
         }
-        X& placeholder = dynamic_cast<X&>(*destination.get());
-        placeholder = std::move(source);
+        // Note: `destination.get() = source` is a mistake, and we made sure it doesn't compile. -- D.K.
+        dynamic_cast<X&>(*destination.get()) = source;
       }
       // Move `std::unique_ptr`.
       void operator()(DerivedTypesDifferentiator<std::unique_ptr<X>>,

--- a/TypeSystem/polymorphic.h
+++ b/TypeSystem/polymorphic.h
@@ -109,7 +109,8 @@ struct PolymorphicImpl<T, TS...> {
 
   PolymorphicImpl() = delete;
 
-  // PolymorphicImpl(std::unique_ptr<CurrentSuper>&& rhs) : object_(std::move(rhs)) {}
+  PolymorphicImpl(std::unique_ptr<CurrentSuper>&& rhs) : object_(std::move(rhs)) {}
+
   template <typename X>
   PolymorphicImpl(X&& input) {
     TypeCheckedAssignment::Perform(std::forward<X>(input), object_);

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -125,12 +125,14 @@ struct WithoutParentheses<int(T)> {
     typedef CURRENT_STRUCT_IMPL_##s<::current::reflection::CountFields> CURRENT_FIELD_COUNT_STRUCT; \
   }
 
-#define CURRENT_STRUCT_NOT_DERIVED(s)                 \
-  CURRENT_STRUCT_HELPERS(s, ::current::CurrentSuper); \
-  template <typename INSTANTIATION_TYPE>              \
-  struct CURRENT_STRUCT_IMPL_##s                      \
-      : CURRENT_REFLECTION_HELPER<s>,                 \
-        ::current::reflection::BaseTypeHelper<INSTANTIATION_TYPE, ::current::CurrentSuper>
+#define CURRENT_STRUCT_NOT_DERIVED(s)                                                 \
+  CURRENT_STRUCT_HELPERS(s, ::current::CurrentSuper);                                 \
+  template <typename INSTANTIATION_TYPE>                                              \
+  struct CURRENT_STRUCT_IMPL_##s : CURRENT_REFLECTION_HELPER<s>,                      \
+                                   ::current::reflection::BaseTypeHelper<             \
+                                       INSTANTIATION_TYPE,                            \
+                                       ::current::CurrentSuperAllowingInitialization< \
+                                           CURRENT_STRUCT_IMPL_##s<::current::reflection::DeclareFields>>>
 
 #define CURRENT_STRUCT_DERIVED(s, base)                                                  \
   static_assert(IS_CURRENT_STRUCT(base), #base " must be derived from `CurrentSuper`."); \
@@ -228,34 +230,34 @@ struct VisitAllFields {
 
   // Visit all fields without an object. Used for enumerating fields and generating signatures.
   template <typename F>
-  static void WithoutObject(const F& f) {
+  static void WithoutObject(F&& f) {
     static NUM_INDEXES all_indexes;
-    WithoutObjectImpl(f, all_indexes);
+    WithoutObjectImpl(std::forward<F>(f), all_indexes);
   }
 
   // Visit all fields with an object, const or mutable. Used for serialization.
   template <typename TT, typename F>
-  static void WithObject(TT&& t, const F& f) {
+  static void WithObject(TT&& t, F&& f) {
     static NUM_INDEXES all_indexes;
-    WithObjectImpl(std::forward<TT>(t), f, all_indexes);
+    WithObjectImpl(std::forward<TT>(t), std::forward<F>(f), all_indexes);
   }
 
  private:
   template <typename F, int N, int... NS>
-  static void WithoutObjectImpl(const F& f, bricks::variadic_indexes::indexes<N, NS...>) {
+  static void WithoutObjectImpl(F&& f, bricks::variadic_indexes::indexes<N, NS...>) {
     static bricks::variadic_indexes::indexes<NS...> remaining_indexes;
-    T::CURRENT_REFLECTION(f, Index<VISITOR_TYPE, N>());
-    WithoutObjectImpl(f, remaining_indexes);
+    T::CURRENT_REFLECTION(std::forward<F>(f), Index<VISITOR_TYPE, N>());
+    WithoutObjectImpl(std::forward<F>(f), remaining_indexes);
   }
 
   template <typename F>
   static void WithoutObjectImpl(const F&, bricks::variadic_indexes::indexes<>) {}
 
   template <typename TT, typename F, int N, int... NS>
-  static void WithObjectImpl(TT&& t, const F& f, bricks::variadic_indexes::indexes<N, NS...>) {
+  static void WithObjectImpl(TT&& t, F&& f, bricks::variadic_indexes::indexes<N, NS...>) {
     static bricks::variadic_indexes::indexes<NS...> remaining_indexes;
-    t.CURRENT_REFLECTION(f, Index<VISITOR_TYPE, N>());
-    WithObjectImpl(std::forward<TT>(t), f, remaining_indexes);
+    t.CURRENT_REFLECTION(std::forward<F>(f), Index<VISITOR_TYPE, N>());
+    WithObjectImpl(std::forward<TT>(t), std::forward<F>(f), remaining_indexes);
   }
 
   template <typename TT, typename F>

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -33,7 +33,7 @@ SOFTWARE.
 #include <vector>
 
 #include "base.h"
-#include "optional.h"
+#include "helpers.h"
 
 #include "../port.h"
 #include "../Bricks/template/decay.h"

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -343,6 +343,20 @@ TEST(TypeSystemTest, PolymorphicSmokeTestOneType) {
       EXPECT_EQ("lambda: Foo 601\nlambda: Foo 602\n", s);
     }
   }
+
+  {
+    const Polymorphic<Foo> p((Foo()));
+    try {
+      p.Value<Empty>();
+      ASSERT_TRUE(false);
+    } catch (NoValue) {
+    }
+    try {
+      p.Value<Empty>();
+      ASSERT_TRUE(false);
+    } catch (NoValueOfType<Empty>) {
+    }
+  }
 }
 
 TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
@@ -374,6 +388,17 @@ TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
     cp.Match(v);
     EXPECT_EQ("Foo 1", v.s);
 
+    try {
+      p.Value<Empty>();
+      ASSERT_TRUE(false);
+    } catch (NoValue) {
+    }
+    try {
+      p.Value<Empty>();
+      ASSERT_TRUE(false);
+    } catch (NoValueOfType<Empty>) {
+    }
+
     p = make_unique<DerivedFromFoo>();
     p.Match(v);
     EXPECT_EQ("DerivedFromFoo [0]", v.s);
@@ -385,5 +410,16 @@ TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
     EXPECT_EQ("DerivedFromFoo [3]", v.s);
     cp.Match(v);
     EXPECT_EQ("DerivedFromFoo [3]", v.s);
+
+    try {
+      p.Value<Empty>();
+      ASSERT_TRUE(false);
+    } catch (NoValue) {
+    }
+    try {
+      p.Value<Empty>();
+      ASSERT_TRUE(false);
+    } catch (NoValueOfType<Empty>) {
+    }
   }
 }

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -199,7 +199,7 @@ TEST(TypeSystemTest, ImmutableOptional) {
   }
   {
     struct_definition_test::Foo bare;
-    ImmutableOptional<struct_definition_test::Foo> wrapped(&bare);
+    ImmutableOptional<struct_definition_test::Foo> wrapped(FromBarePointer(), &bare);
     ASSERT_TRUE(Exists(wrapped));
     EXPECT_EQ(42u, wrapped.Value().i);
     EXPECT_EQ(42u, Value(wrapped).i);
@@ -207,7 +207,7 @@ TEST(TypeSystemTest, ImmutableOptional) {
   }
   {
     struct_definition_test::Foo bare;
-    ImmutableOptional<struct_definition_test::Foo> wrapped(&bare);
+    ImmutableOptional<struct_definition_test::Foo> wrapped(FromBarePointer(), &bare);
     const ImmutableOptional<struct_definition_test::Foo>& double_wrapped(wrapped);
     ASSERT_TRUE(Exists(double_wrapped));
     EXPECT_EQ(42u, double_wrapped.Value().i);

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -319,12 +319,12 @@ TEST(TypeSystemTest, PolymorphicSmokeTestOneType) {
     Visitor v;
     {
       Polymorphic<Foo> p(Foo(501u));
-      p.Match(v);
+      p.Call(v);
       EXPECT_EQ("Foo 501\n", v.s);
     }
     {
       const Polymorphic<Foo> p(Foo(502u));
-      p.Match(v);
+      p.Call(v);
       EXPECT_EQ("Foo 501\nFoo 502\n", v.s);
     }
   }
@@ -334,12 +334,12 @@ TEST(TypeSystemTest, PolymorphicSmokeTestOneType) {
     const auto lambda = [&s](const Foo& foo) { s += "lambda: Foo " + bricks::strings::ToString(foo.i) + '\n'; };
     {
       Polymorphic<Foo> p(Foo(601u));
-      p.Match(lambda);
+      p.Call(lambda);
       EXPECT_EQ("lambda: Foo 601\n", s);
     }
     {
       const Polymorphic<Foo> p(Foo(602u));
-      p.Match(lambda);
+      p.Call(lambda);
       EXPECT_EQ("lambda: Foo 601\nlambda: Foo 602\n", s);
     }
   }
@@ -376,16 +376,16 @@ TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
     Polymorphic<Empty, Foo, DerivedFromFoo> p((Empty()));
     const Polymorphic<Empty, Foo, DerivedFromFoo>& cp = p;
 
-    p.Match(v);
+    p.Call(v);
     EXPECT_EQ("Empty", v.s);
-    cp.Match(v);
+    cp.Call(v);
     EXPECT_EQ("Empty", v.s);
 
     p = Foo(1u);
 
-    p.Match(v);
+    p.Call(v);
     EXPECT_EQ("Foo 1", v.s);
-    cp.Match(v);
+    cp.Call(v);
     EXPECT_EQ("Foo 1", v.s);
 
     try {
@@ -400,15 +400,15 @@ TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
     }
 
     p = make_unique<DerivedFromFoo>();
-    p.Match(v);
+    p.Call(v);
     EXPECT_EQ("DerivedFromFoo [0]", v.s);
-    cp.Match(v);
+    cp.Call(v);
     EXPECT_EQ("DerivedFromFoo [0]", v.s);
 
     p.Value<DerivedFromFoo>().bar.v1.resize(3);
-    p.Match(v);
+    p.Call(v);
     EXPECT_EQ("DerivedFromFoo [3]", v.s);
-    cp.Match(v);
+    cp.Call(v);
     EXPECT_EQ("DerivedFromFoo [3]", v.s);
 
     try {


### PR DESCRIPTION
Hi Max!

For after https://github.com/c5t/Current/pull/273.

Polymorphic types, all but serialization by now.

**Suggestion**: Looks like with a bit of tweaking, the dream may come true. Specifically:

* Use global `Exists(...)` or `Exists<T>(...)` for base types, optionals, and polymorphics.
* Use global `Value(...)` or `Value<T>(...)` for base types, optionals, and polymorphics.

We'll have to be careful with type hierarchies of types within `Polymorphic<>`. As of now, `Match()` would do the right thing with RTTI dispatching, while `Value<T>` would happily case derived to base if requested. The above does sound right to me, but want to double-check with you.

Thanks,
Dima

PS: Better naming suggestions for `Match()`? I don't like it. `MatchWith()` is more functional, but still doesn't sound right in C++.