### PR TITLE
Walk through the coverage report.

### DIFF
--- a/Bricks/template/rtti_dynamic_call.h
+++ b/Bricks/template/rtti_dynamic_call.h
@@ -42,6 +42,7 @@ SOFTWARE.
 namespace current {
 namespace metaprogramming {
 
+// LCOV_EXCL_START
 struct RTTIException : Exception {
   RTTIException() = delete;
   explicit RTTIException(const std::string& s) : Exception(s) {}
@@ -78,9 +79,13 @@ struct SpecificUncastableTypeException : UncastableTypeException {
       : UncastableTypeException(typeid(BASE).name() + std::string(" -> ") + typeid(DERIVED).name()) {}
 };
 
+// LCOV_EXCL_STOP
+
 template <typename BASE, typename F, typename... ARGS>
 struct RTTIDispatcherBase {
-  virtual void Handle(BASE&&, F&&, ARGS&&...) const { throw SpecificUnhandledTypeException<BASE>(); }
+  virtual void Handle(BASE&&, F&&, ARGS&&...) const {
+    throw SpecificUnhandledTypeException<BASE>();  // LCOV_EXCL_LINE
+  }
 };
 
 template <typename BASE, typename F, typename DERIVED, typename... ARGS>
@@ -91,7 +96,7 @@ struct RTTIDispatcher : RTTIDispatcherBase<BASE, F, ARGS...> {
     if (derived) {
       f(*derived, std::forward<ARGS>(args)...);
     } else {
-      throw SpecificUncastableTypeException<BASE, DERIVED>();
+      throw SpecificUncastableTypeException<BASE, DERIVED>();  // LCOV_EXCL_LINE
     }
   }
 };
@@ -149,7 +154,7 @@ const RTTIDispatcherBase<BASE, F, ARGS...>* RTTIFindHandler(const std::type_info
   if (handler != map.end()) {
     return handler->second.get();
   } else {
-    throw SpecificUnlistedTypeException<BASE>();
+    throw SpecificUnlistedTypeException<BASE>();  // LCOV_EXCL_LINE
   }
 }
 

--- a/CompactTSV/test.cc
+++ b/CompactTSV/test.cc
@@ -111,6 +111,7 @@ TEST(CompactTSV, Smoke) {
   const auto t_f_end = current::time::Now();
 
   if (FLAGS_benchmark) {
+    // LCOV_EXCL_START
     const size_t golden_size = golden.length();
     const size_t packed_size = fast.GetPackedString().length();
     std::cerr << "Original TSV size:\t" << golden_size << "b, or\t" << golden_size / (1024u * 1024u) << "MB.\n";
@@ -122,5 +123,6 @@ TEST(CompactTSV, Smoke) {
     std::cerr << "Unpack into std::string-s:                  " << K *(t_d_end - t_d_begin).count() << "ms.\n";
     std::cerr << "Unpack into std::pair<const char*, size_t>: " << K *(t_e_end - t_e_begin).count() << "ms.\n";
     std::cerr << "Unpack into UniqueChunk-s:                  " << K *(t_f_end - t_f_begin).count() << "ms.\n";
+    // LCOV_EXCL_STOP
   }
 }

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -77,11 +77,13 @@ class RipCurrentMockableErrorHandler {
  public:
   typedef std::function<void(const std::string& error_message)> handler_type;
 
+  // LCOV_EXCL_START
   RipCurrentMockableErrorHandler()
       : handler_([](const std::string& error_message) {
           std::cerr << error_message;
           std::exit(-1);
         }) {}
+  // LCOV_EXCL_STOP
 
   void HandleError(const std::string& error_message) const { handler_(error_message); }
 
@@ -270,10 +272,12 @@ class EntriesConsumer {
 class DummyNoEntryTypeAcceptor : public EntriesConsumer<InputPolicy::DoesNotAccept> {
  public:
   virtual ~DummyNoEntryTypeAcceptor() = default;
+  // LCOV_EXCL_START
   void Accept(const DummyNoEntryType&) override {
     current::Singleton<RipCurrentMockableErrorHandler>().HandleError(
         "Internal error: Attepmted to send entries into a non-accepting block.");
   }
+  // LCOV_EXCL_STOP
 };
 
 // Run context for RipCurrent allows to run it in background, foreground, or scoped.
@@ -292,7 +296,7 @@ class RipCurrentRunContext {
   }
   ~RipCurrentRunContext() {
     if (!sync_called_) {
-      current::Singleton<RipCurrentMockableErrorHandler>().HandleError(error_message_);
+      current::Singleton<RipCurrentMockableErrorHandler>().HandleError(error_message_);  // LCOV_EXCL_LINE
     }
   }
 
@@ -405,7 +409,7 @@ class NextHandlerInitializer {
 
   // TODO(dkorolev): Here be RTTI, per type than can be emitted.
   void Accept(const H2O& x) { impl_.f(x); }
-  void Accept(const DummyNoEntryType&) {}
+  void Accept(const DummyNoEntryType&) {}  // LCOV_EXCL_LINE
 
  private:
   struct NextHandlerEarlyInitializer {

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -54,7 +54,7 @@ struct String : H2O {
 // `RCFoo`: The emitter of events. Emits the integers passed to its constructor.
 CURRENT_LHS(RCFoo, Integer) {
   static std::string UnitTestClassName() { return "RCFoo"; }
-  RCFoo() {}
+  RCFoo() {}  // LCOV_EXCL_LINE
   RCFoo(int a) { emit(Integer(a)); }
   RCFoo(int a, int b) {
     emit(Integer(a));
@@ -81,7 +81,7 @@ CURRENT_VIA(RCBar, int) {
 CURRENT_RHS(RCBaz) {
   static std::string UnitTestClassName() { return "RCBaz"; }
   std::vector<int>* ptr;
-  RCBaz() : ptr(nullptr) {}
+  RCBaz() : ptr(nullptr) {}  // LCOV_EXCL_LINE
   RCBaz(std::vector<int>& ref) : ptr(&ref) {}
   void f(Integer x) {
     assert(ptr);

--- a/Sherlock/sherlock.h
+++ b/Sherlock/sherlock.h
@@ -220,8 +220,10 @@ class StreamInstanceImpl {
     ~ListenerThread() {
       if (thread_.joinable()) {
         // TODO(dkorolev): Phrase the error message better.
+        // LCOV_EXCL_START
         std::cerr << "Unrecoverable error in destructor: ListenerThread was not joined/detached.\n";
         std::exit(-1);
+        // LCOV_EXCL_STOP
       }
     }
 
@@ -300,8 +302,10 @@ class StreamInstanceImpl {
 
     ~SyncListenerScope() {
       if (!joined_) {
+        // LCOV_EXCL_START
         std::cerr << "Unrecoverable error in destructor: Join() was not called on for SyncListener.\n";
         std::exit(-1);
+        // LCOV_EXCL_STOP
       }
     }
 

--- a/TransactionalStorage/test.cc
+++ b/TransactionalStorage/test.cc
@@ -176,8 +176,10 @@ void RunUnitTest(UnitTestStorage<POLICY>& storage, bool leave_data_behind = fals
     size_t count = 0u;
     int32_t value = 0;
     for (const auto& e : storage.d) {
+      // LCOV_EXCL_START
       ++count;
       value += e.rhs;
+      // LCOV_EXCL_STOP
     }
     EXPECT_EQ(0u, count);
     EXPECT_EQ(0, value);

--- a/TypeSystem/Reflection/test.cc
+++ b/TypeSystem/Reflection/test.cc
@@ -385,9 +385,11 @@ TEST(Reflection, SmokeTestFullStruct) {
   struct_schema.AddType<smoke_test_struct_namespace::FullTest>();
 
   if (FLAGS_write_reflection_golden_files) {
+    // LCOV_EXCL_START
     FileSystem::WriteStringToFile(struct_schema.Describe(Language::CPP()), "golden/smoke_test_struct.cc");
     FileSystem::WriteStringToFile(struct_schema.Describe(Language::FSharp()), "golden/smoke_test_struct.fsx");
     FileSystem::WriteStringToFile(JSON(struct_schema.GetSchemaInfo()), "golden/smoke_test_struct.json");
+    // LCOV_EXCL_STOP
   }
 
   EXPECT_EQ(FileSystem::ReadFileAsString("golden/smoke_test_struct.cc"),

--- a/TypeSystem/Serialization/binary.h
+++ b/TypeSystem/Serialization/binary.h
@@ -47,7 +47,7 @@ inline void SaveSizeIntoBinary(std::ostream& ostream, const size_t size) {
   const size_t bytes_written =
       ostream.rdbuf()->sputn(reinterpret_cast<const char*>(&save_size), sizeof(BINARY_FORMAT_SIZE_TYPE));
   if (bytes_written != sizeof(BINARY_FORMAT_SIZE_TYPE)) {
-    throw BinarySaveToStreamException(sizeof(BINARY_FORMAT_SIZE_TYPE), bytes_written);
+    throw BinarySaveToStreamException(sizeof(BINARY_FORMAT_SIZE_TYPE), bytes_written);  // LCOV_EXCL_LINE
   }
 };
 
@@ -56,7 +56,7 @@ inline BINARY_FORMAT_SIZE_TYPE LoadSizeFromBinary(std::istream& istream) {
   const size_t bytes_read =
       istream.rdbuf()->sgetn(reinterpret_cast<char*>(&result), sizeof(BINARY_FORMAT_SIZE_TYPE));
   if (bytes_read != sizeof(BINARY_FORMAT_SIZE_TYPE)) {
-    throw BinaryLoadFromStreamException(sizeof(BINARY_FORMAT_SIZE_TYPE), bytes_read);
+    throw BinaryLoadFromStreamException(sizeof(BINARY_FORMAT_SIZE_TYPE), bytes_read);  // LCOV_EXCL_LINE
   }
   return result;
 }
@@ -70,7 +70,7 @@ struct SavePrimitiveTypeIntoBinary {
     const size_t bytes_written =
         ostream.rdbuf()->sputn(reinterpret_cast<const char*>(std::addressof(value)), sizeof(T));
     if (bytes_written != sizeof(T)) {
-      throw BinarySaveToStreamException(sizeof(T), bytes_written);
+      throw BinarySaveToStreamException(sizeof(T), bytes_written);  // LCOV_EXCL_LINE
     }
   }
 
@@ -79,7 +79,7 @@ struct SavePrimitiveTypeIntoBinary {
     const size_t bytes_written =
         ostream.rdbuf()->sputn(reinterpret_cast<const char*>(&b), sizeof(BINARY_FORMAT_BOOL_TYPE));
     if (bytes_written != sizeof(BINARY_FORMAT_BOOL_TYPE)) {
-      throw BinarySaveToStreamException(sizeof(BINARY_FORMAT_BOOL_TYPE), bytes_written);
+      throw BinarySaveToStreamException(sizeof(BINARY_FORMAT_BOOL_TYPE), bytes_written);  // LCOV_EXCL_LINE
     }
   }
 
@@ -87,7 +87,7 @@ struct SavePrimitiveTypeIntoBinary {
     SaveSizeIntoBinary(ostream, value.size());
     const size_t bytes_written = ostream.rdbuf()->sputn(value.data(), value.size());
     if (bytes_written != value.size()) {
-      throw BinarySaveToStreamException(value.size(), bytes_written);
+      throw BinarySaveToStreamException(value.size(), bytes_written);  // LCOV_EXCL_LINE
     }
   }
 };
@@ -193,7 +193,7 @@ struct LoadPrimitiveTypeFromBinary {
     const size_t bytes_read =
         istream.rdbuf()->sgetn(reinterpret_cast<char*>(std::addressof(destination)), sizeof(T));
     if (bytes_read != sizeof(T)) {
-      throw BinaryLoadFromStreamException(sizeof(T), bytes_read);
+      throw BinaryLoadFromStreamException(sizeof(T), bytes_read);  // LCOV_EXCL_LINE
     }
   }
 
@@ -202,7 +202,7 @@ struct LoadPrimitiveTypeFromBinary {
     const size_t bytes_read =
         istream.rdbuf()->sgetn(reinterpret_cast<char*>(&b), sizeof(BINARY_FORMAT_BOOL_TYPE));
     if (bytes_read != sizeof(BINARY_FORMAT_BOOL_TYPE)) {
-      throw BinaryLoadFromStreamException(sizeof(BINARY_FORMAT_BOOL_TYPE), bytes_read);
+      throw BinaryLoadFromStreamException(sizeof(BINARY_FORMAT_BOOL_TYPE), bytes_read);  // LCOV_EXCL_LINE
     }
     destination = static_cast<bool>(b);
   }
@@ -213,7 +213,7 @@ struct LoadPrimitiveTypeFromBinary {
     // Should be legitimate since c++11 requires internal buffer to be contiguous.
     const size_t bytes_read = istream.rdbuf()->sgetn(&destination[0], size);
     if (bytes_read != static_cast<size_t>(size)) {
-      throw BinaryLoadFromStreamException(size, bytes_read);
+      throw BinaryLoadFromStreamException(size, bytes_read);  // LCOV_EXCL_LINE
     }
   }
 
@@ -280,7 +280,7 @@ struct LoadFromBinaryImpl {
     const size_t bytes_read =
         istream.rdbuf()->sgetn(reinterpret_cast<char*>(std::addressof(destination)), sizeof(T_UNDERLYING));
     if (bytes_read != sizeof(T_UNDERLYING)) {
-      throw BinaryLoadFromStreamException(sizeof(T_UNDERLYING), bytes_read);
+      throw BinaryLoadFromStreamException(sizeof(T_UNDERLYING), bytes_read);  // LCOV_EXCL_LINE
     }
   }
 };

--- a/TypeSystem/Serialization/json.h
+++ b/TypeSystem/Serialization/json.h
@@ -329,7 +329,7 @@ struct LoadFromJSONImpl {
       current::reflection::VisitAllFields<DECAYED_T, current::reflection::FieldNameAndMutableValue>::WithObject(
           destination, visitor);
     } else {
-      throw JSONSchemaException("object", source, path);
+      throw JSONSchemaException("object", source, path);  // LCOV_EXCL_LINE
     }
   }
 
@@ -341,7 +341,7 @@ struct LoadFromJSONImpl {
     if (source && source->IsNumber()) {
       destination = static_cast<T>(source->GetUint64());
     } else {
-      throw JSONSchemaException("number", source, path);
+      throw JSONSchemaException("number", source, path);  // LCOV_EXCL_LINE
     }
   }
 
@@ -352,7 +352,7 @@ struct LoadFromJSONImpl {
     if (source && source->IsNumber()) {
       destination = static_cast<T>(source->GetInt64());
     } else {
-      throw JSONSchemaException("number", source, path);
+      throw JSONSchemaException("number", source, path);  // LCOV_EXCL_LINE
     }
   }
 
@@ -361,7 +361,7 @@ struct LoadFromJSONImpl {
     if (source && source->IsNumber()) {
       destination = static_cast<float>(source->GetDouble());
     } else {
-      throw JSONSchemaException("float", source, path);
+      throw JSONSchemaException("float", source, path);  // LCOV_EXCL_LINE
     }
   }
 
@@ -370,7 +370,7 @@ struct LoadFromJSONImpl {
     if (source && source->IsNumber()) {
       destination = source->GetDouble();
     } else {
-      throw JSONSchemaException("double", source, path);
+      throw JSONSchemaException("double", source, path);  // LCOV_EXCL_LINE
     }
   }
 
@@ -386,7 +386,7 @@ struct LoadFromJSONImpl {
         destination = static_cast<T>(source->GetUint64());
       }
     } else {
-      throw JSONSchemaException("number", source, path);
+      throw JSONSchemaException("number", source, path);  // LCOV_EXCL_LINE
     }
   }
 
@@ -413,13 +413,13 @@ struct LoadFromJSONImpl {
             if (cit != deserializers_.end()) {
               cit->second->Deserialize(source, destination, path);
             } else {
-              throw JSONSchemaException("a type id listed in the type list", member, path);
+              throw JSONSchemaException("a type id listed in the type list", member, path);  // LCOV_EXCL_LINE
             }
           } else {
-            throw JSONSchemaException("type id as value for an empty string", source, path);
+            throw JSONSchemaException("type id as value for an empty string", source, path);  // LCOV_EXCL_LINE
           }
         } else {
-          throw JSONSchemaException("polymorphic type as object", source, path);
+          throw JSONSchemaException("polymorphic type as object", source, path);  // LCOV_EXCL_LINE
         }
       };
 
@@ -442,7 +442,9 @@ struct LoadFromJSONImpl {
             LoadFromJSONImpl<X>::Load(
                 &(*source)[key_name_], destination.template Value<X>(), path + "[\"" + key_name_ + "\"]");
           } else {
+            // LCOV_EXCL_START
             throw JSONSchemaException("polymorphic value", source, path + "[\"" + key_name_ + "\"]");
+            // LCOV_EXCL_STOP
           }
         }
 
@@ -484,7 +486,7 @@ struct LoadFromJSONImpl<std::string> {
     if (source && source->IsString()) {
       destination.assign(source->GetString(), source->GetStringLength());
     } else {
-      throw JSONSchemaException("string", source, path);
+      throw JSONSchemaException("string", source, path);  // LCOV_EXCL_LINE
     }
   }
 };
@@ -495,7 +497,7 @@ struct LoadFromJSONImpl<bool> {
     if (source && (source->IsTrue() || source->IsFalse())) {
       destination = source->IsTrue();
     } else {
-      throw JSONSchemaException("bool", source, path);
+      throw JSONSchemaException("bool", source, path);  // LCOV_EXCL_LINE
     }
   }
 };
@@ -510,7 +512,7 @@ struct LoadFromJSONImpl<std::vector<T>> {
         LoadFromJSONImpl<T>::Load(&((*source)[i]), destination[i], path + '[' + std::to_string(i) + ']');
       }
     } else {
-      throw JSONSchemaException("array", source, path);
+      throw JSONSchemaException("array", source, path);  // LCOV_EXCL_LINE
     }
   }
 };
@@ -522,7 +524,7 @@ struct LoadFromJSONImpl<std::pair<TF, TS>> {
       LoadFromJSONImpl<TF>::Load(&((*source)[static_cast<rapidjson::SizeType>(0)]), destination.first, path);
       LoadFromJSONImpl<TS>::Load(&((*source)[static_cast<rapidjson::SizeType>(1)]), destination.second, path);
     } else {
-      throw JSONSchemaException("pair as array", source, path);
+      throw JSONSchemaException("pair as array", source, path);  // LCOV_EXCL_LINE
     }
   }
 };
@@ -542,7 +544,7 @@ struct LoadFromJSONImpl<std::map<TK, TV>> {
         destination.insert(entry);
       }
     } else {
-      throw JSONSchemaException("map as object", source, path);
+      throw JSONSchemaException("map as object", source, path);  // LCOV_EXCL_LINE
     }
   }
   template <typename K = TK>
@@ -554,17 +556,17 @@ struct LoadFromJSONImpl<std::map<TK, TV>> {
       std::pair<TK, TV> entry;
       for (rapidjson::Value::ValueIterator cit = source->Begin(); cit != source->End(); ++cit) {
         if (!cit->IsArray()) {
-          throw JSONSchemaException("map entry as array", source, path);
+          throw JSONSchemaException("map entry as array", source, path);  // LCOV_EXCL_LINE
         }
         if (cit->Size() != 2u) {
-          throw JSONSchemaException("map entry as array of two elements", source, path);
+          throw JSONSchemaException("map entry as array of two elements", source, path);  // LCOV_EXCL_LINE
         }
         LoadFromJSONImpl<TK>::Load(&(*cit)[static_cast<rapidjson::SizeType>(0)], entry.first, path);
         LoadFromJSONImpl<TV>::Load(&(*cit)[static_cast<rapidjson::SizeType>(1)], entry.second, path);
         destination.insert(entry);
       }
     } else {
-      throw JSONSchemaException("map as array", source, path);
+      throw JSONSchemaException("map as array", source, path);  // LCOV_EXCL_LINE
     }
   }
 };

--- a/TypeSystem/Serialization/test.cc
+++ b/TypeSystem/Serialization/test.cc
@@ -280,7 +280,7 @@ TEST(Serialization, JSON) {
   {
     try {
       ParseJSON<WithTrivialMap>("{\"m\":[]}");
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (const JSONSchemaException& e) {
       EXPECT_EQ(std::string("Expected map as object for `m`, got: []"), e.what());
     }
@@ -311,7 +311,7 @@ TEST(Serialization, JSON) {
   {
     try {
       ParseJSON<WithNontrivialMap>("{\"q\":{}}");
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (const JSONSchemaException& e) {
       EXPECT_EQ(std::string("Expected map as array for `q`, got: {}"), e.what());
     }
@@ -341,56 +341,56 @@ TEST(Serialization, JSONExceptions) {
   // Valid JSONs with missing fields, or with fields of wrong types.
   try {
     ParseJSON<Serializable>("{}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `i`, got: missing field."), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":\"boo\"}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `i`, got: \"boo\""), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":[]}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `i`, got: []"), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":{}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `i`, got: {}"), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":100}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected string for `s`, got: missing field."), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":42,\"s\":42}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected string for `s`, got: 42"), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":42,\"s\":[]}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected string for `s`, got: []"), e.what());
   }
 
   try {
     ParseJSON<Serializable>("{\"i\":42,\"s\":{}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected string for `s`, got: {}"), e.what());
   }
@@ -399,7 +399,7 @@ TEST(Serialization, JSONExceptions) {
   try {
     ParseJSON<ComplexSerializable>(
         "{\"j\":43,\"q\":\"bar\",\"v\":[\"one\",\"two\"],\"z\":{\"i\":\"error\",\"s\":\"foo\"}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `z.i`, got: \"error\""), e.what());
   }
@@ -407,28 +407,28 @@ TEST(Serialization, JSONExceptions) {
   try {
     ParseJSON<ComplexSerializable>(
         "{\"j\":43,\"q\":\"bar\",\"v\":[\"one\",\"two\"],\"z\":{\"i\":null,\"s\":\"foo\"}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `z.i`, got: null"), e.what());
   }
 
   try {
     ParseJSON<ComplexSerializable>("{\"j\":43,\"q\":\"bar\",\"v\":[\"one\",\"two\"],\"z\":{\"s\":\"foo\"}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected number for `z.i`, got: missing field."), e.what());
   }
 
   try {
     ParseJSON<ComplexSerializable>("{\"j\":43,\"q\":\"bar\",\"v\":[\"one\",true],\"z\":{\"i\":0,\"s\":0}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected string for `v[1]`, got: true"), e.what());
   }
 
   try {
     ParseJSON<ComplexSerializable>("{\"j\":43,\"q\":\"bar\",\"v\":[\"one\",\"two\"],\"z\":{\"i\":0,\"s\":0}}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ(std::string("Expected string for `z.s`, got: 0"), e.what());
   }
@@ -523,7 +523,7 @@ TEST(Serialization, JSONForCppTypes) {
   ASSERT_THROW(ParseJSON<map_int_int>("{}"), JSONSchemaException);
   try {
     ParseJSON<map_int_int>("{}");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ("Expected map as array, got: {}", std::string(e.what()));
   }
@@ -533,7 +533,7 @@ TEST(Serialization, JSONForCppTypes) {
   ASSERT_THROW(ParseJSON<map_string_int>("[]"), JSONSchemaException);
   try {
     ParseJSON<map_string_int>("[]");
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (const JSONSchemaException& e) {
     EXPECT_EQ("Expected map as object, got: []", std::string(e.what()));
   }
@@ -652,7 +652,7 @@ TEST(Serialization, PolymorphicAsJSON) {
   {
     try {
       ParseJSON<RequiredPolymorphicType>("null");
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (JSONUninitializedPolymorphicObjectException) {
     }
   }

--- a/TypeSystem/enum.h
+++ b/TypeSystem/enum.h
@@ -48,8 +48,10 @@ struct EnumNameSingletonImpl {
     if (names_.count(type_index) != 0u) {
       return names_.at(type_index);
     } else {
+      // LCOV_EXCL_START
       std::cerr << "Enum is not registered in `EnumNameSingletonImpl`: " << typeid(T).name() << std::endl;
       std::exit(-1);
+      // LCOV_EXCL_STOP
     }
   }
 

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -183,7 +183,7 @@ TEST(TypeSystemTest, ImmutableOptional) {
     ASSERT_FALSE(Exists(bar));
     try {
       Value(bar);
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValue) {
     }
   }
@@ -192,7 +192,7 @@ TEST(TypeSystemTest, ImmutableOptional) {
     ASSERT_FALSE(Exists(meh));
     try {
       Value(meh);
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValueOfType<int>) {
     }
   }
@@ -237,7 +237,7 @@ TEST(TypeSystemTest, Optional) {
   ASSERT_FALSE(Exists(foo));
   try {
     Value(foo);
-    ASSERT_TRUE(false);
+    ASSERT_TRUE(false);  // LCOV_EXCL_LINE
   } catch (NoValue) {
   }
 }
@@ -353,12 +353,12 @@ TEST(TypeSystemTest, PolymorphicSmokeTestOneType) {
     const Polymorphic<Foo> p((Foo()));
     try {
       p.Value<Bar>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValue) {
     }
     try {
       p.Value<Bar>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValueOfType<Bar>) {
     }
   }
@@ -395,12 +395,12 @@ TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
 
     try {
       p.Value<Bar>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValue) {
     }
     try {
       p.Value<Bar>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValueOfType<Bar>) {
     }
 
@@ -418,12 +418,12 @@ TEST(TypeSystemTest, PolymorphicSmokeTestMultipleTypes) {
 
     try {
       p.Value<Bar>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValue) {
     }
     try {
       p.Value<Bar>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValueOfType<Bar>) {
     }
   }
@@ -456,7 +456,7 @@ TEST(TypeSystemTest, PolymorphicRequiredAndOptional) {
 
     try {
       x.Value<Foo>();
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (NoValueOfType<Foo>) {
     }
 
@@ -468,12 +468,12 @@ TEST(TypeSystemTest, PolymorphicRequiredAndOptional) {
     OptionalPolymorphic<Foo, Bar> p;
     try {
       Polymorphic<Foo, Bar> q = std::move(p);
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (UninitializedRequiredPolymorphic) {
     }
     try {
       Polymorphic<Foo, Bar> r = std::move(p);
-      ASSERT_TRUE(false);
+      ASSERT_TRUE(false);  // LCOV_EXCL_LINE
     } catch (UninitializedRequiredPolymorphicOfType<Foo, Bar>) {
     }
   }

--- a/examples/Iris/test.cc
+++ b/examples/Iris/test.cc
@@ -130,6 +130,7 @@ TEST(Iris, Demo) {
   EXPECT_DOUBLE_EQ(1.8, flower2.PW);
   EXPECT_EQ("virginica", flower2.label);
 
+  // LCOV_EXCL_START
   if (FLAGS_run) {
     // Ref.: http://localhost:3000/get?id=42
     HTTP(FLAGS_iris_port)
@@ -212,4 +213,5 @@ TEST(Iris, Demo) {
 
     HTTP(FLAGS_iris_port).Join();
   }
+  // LCOV_EXCL_STOP
 }


### PR DESCRIPTION
Made the "output" of the top-level `make test` a bit greener by adding `// LCOV_EXCL_*` guards to where they belong.