### PR TITLE
Minimalistic JSON format.

### DIFF
--- a/TypeSystem/README.md
+++ b/TypeSystem/README.md
@@ -55,10 +55,10 @@ CURRENT_FIELD(m, (std::map<uint32_t, std::string>));
   * `std::pair`
 * `std::string`
 * `std::chrono::milliseconds/microseconds`
-* `enum class`-es declared via the `CURRENT_ENUM`
+* `enum class`-es declared via `CURRENT_ENUM`
 
 #### Enums
-To be used in Current structures, enumerated types must be declared via `CURRENT_ENUM(EnumName, UnderlyingType)` macro:
+To be used in Current structures, enumerated types must be declared via the `CURRENT_ENUM(EnumName, UnderlyingType)` macro:
 ```cpp
 CURRENT_ENUM(Fruits, uint32_t) {APPLE = 1u, ORANGE = 2u};
 ```

--- a/TypeSystem/Serialization/test.cc
+++ b/TypeSystem/Serialization/test.cc
@@ -660,6 +660,15 @@ TEST(Serialization, PolymorphicAsJSON) {
   }
   {
     const RequiredPolymorphicType object(make_unique<Empty>());
+    const std::string json = "{\"Empty\":{}}";
+    EXPECT_EQ(json, JSON<JSONFormat::Minimalistic>(object));
+    // Confirm that `ParseJSON()` does the job. Top-level `JSON()` is just to simplify the comparison.
+    EXPECT_EQ(
+        json,
+        JSON<JSONFormat::Minimalistic>(ParseJSON<RequiredPolymorphicType, JSONFormat::Minimalistic>(json)));
+  }
+  {
+    const RequiredPolymorphicType object(make_unique<Empty>());
     const std::string json = "{\"Case\":\"Empty\",\"Fields\":[{}]}";
     EXPECT_EQ(json, JSON<JSONFormat::NewtonsoftFSharp>(object));
     // Confirm that `ParseJSON()` does the job. Top-level `JSON()` is just to simplify the comparison.
@@ -674,6 +683,22 @@ TEST(Serialization, PolymorphicAsJSON) {
     EXPECT_EQ(json, JSON(object));
     // Confirm that `ParseJSON()` does the job. Top-level `JSON()` is just to simplify the comparison.
     EXPECT_EQ(json, JSON(ParseJSON<RequiredPolymorphicType>(json)));
+  }
+  {
+    const RequiredPolymorphicType object(make_unique<Serializable>(42));
+    const std::string json = "{\"Serializable\":{\"i\":42,\"s\":\"\",\"b\":false,\"e\":0}}";
+    EXPECT_EQ(json, JSON<JSONFormat::Minimalistic>(object));
+    // Confirm that `ParseJSON()` does the job. Top-level `JSON()` is just to simplify the comparison.
+    EXPECT_EQ(
+        json,
+        JSON<JSONFormat::Minimalistic>(ParseJSON<RequiredPolymorphicType, JSONFormat::Minimalistic>(json)));
+
+    // An extra test that `Minimalistic` parser accepts the standard `Current` JSON format.
+    EXPECT_EQ(JSON(object), JSON(ParseJSON<RequiredPolymorphicType, JSONFormat::Minimalistic>(json)));
+    const std::string ok2 = "{\"Serializable\":{\"i\":42,\"s\":\"\",\"b\":false,\"e\":0},\"\":false}";
+    EXPECT_EQ(JSON(object), JSON(ParseJSON<RequiredPolymorphicType, JSONFormat::Minimalistic>(ok2)));
+    const std::string ok3 = "{\"Serializable\":{\"i\":42,\"s\":\"\",\"b\":false,\"e\":0},\"\":42}";
+    EXPECT_EQ(JSON(object), JSON(ParseJSON<RequiredPolymorphicType, JSONFormat::Minimalistic>(ok3)));
   }
   {
     const RequiredPolymorphicType object(make_unique<Serializable>(42));

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -254,10 +254,11 @@ struct CurrentTypeNameImpl<T, true, false> {
   }
 };
 
-template <typename T>
-struct CurrentTypeNameImpl<T, false, true> {
-  static const char* GetCurrentTypeName() { return "Polymorphic"; }
-};
+// Commented out the **really confusing** part for now. -- D.K.
+// template <typename T>
+// struct CurrentTypeNameImpl<T, false, true> {
+//   static const char* GetCurrentTypeName() { return "Polymorphic"; }
+// };
 
 template <typename T>
 inline const char* CurrentTypeName() {

--- a/examples/EmbeddedDB/db.cc
+++ b/examples/EmbeddedDB/db.cc
@@ -149,7 +149,9 @@ int main(int argc, char** argv) {
                 [](Request r) {
                   StructSchema schema;
                   schema.AddType<Event>();
-                  r(schema.Describe(Language::CPP()), HTTPResponseCode.OK, "text/plain; charset=us-ascii");
+                  r(schema.GetSchemaInfo().Describe<Language::CPP>(),
+                    HTTPResponseCode.OK,
+                    "text/plain; charset=us-ascii");
                 });
 
   HTTP(FLAGS_db_demo_port)
@@ -157,7 +159,9 @@ int main(int argc, char** argv) {
                 [](Request r) {
                   StructSchema schema;
                   schema.AddType<Event>();
-                  r(schema.Describe(Language::FSharp()), HTTPResponseCode.OK, "text/plain; charset=us-ascii");
+                  r(schema.GetSchemaInfo().Describe<Language::FSharp>(),
+                    HTTPResponseCode.OK,
+                    "text/plain; charset=us-ascii");
                 });
 
   HTTP(FLAGS_db_demo_port)


### PR DESCRIPTION
[ After https://github.com/c5t/Current/pull/303 ]

Hi @mzhurovich,

It occurred to us today that bulk import via a Python script of some sort would benefit from not having to supply the Type ID. (And generating F# format from Python is, really, a bad idea.)

Thanks,
Dima