### PR TITLE
Branched out `SlowTypeList`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ check:
 	./scripts/check-headers.sh
 
 wc:
-	echo -n "Total files: " ; (find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | wc -l
-	(find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | xargs wc -l | sort -gr
+	echo -n "Total files: " ; (find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | grep -v "/sandbox/" | wc -l
+	(find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | grep -v "/sandbox/" | xargs wc -l | sort -gr
 
 clean:
 	rm -rf $(shell find $(shell find . -name "zzz_*" -type d) -name coverage -type d)

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -714,12 +714,12 @@ SharedCurrent<INPUT, OUTPUT_TYPE_LIST> operator|(
 
 // Define a user class ready to be used as part of RipCurrent data pipeline.
 #define CURRENT_LHS(T, X, ...) \
-  struct T final : ripcurrent::UserClassBase<InputPolicy::DoesNotAccept, TypeList<X, TypeList<__VA_ARGS__>>, T>
+  struct T final : ripcurrent::UserClassBase<InputPolicy::DoesNotAccept, SlowTypeList<X, SlowTypeList<__VA_ARGS__>>, T>
 
 #define CURRENT_RHS(T) struct T final : ripcurrent::UserClassBase<InputPolicy::Accepts, TypeListImpl<>, T>
 
 #define CURRENT_VIA(T, X, ...) \
-  struct T final : ripcurrent::UserClassBase<InputPolicy::Accepts, TypeList<X, TypeList<__VA_ARGS__>>, T>
+  struct T final : ripcurrent::UserClassBase<InputPolicy::Accepts, SlowTypeList<X, SlowTypeList<__VA_ARGS__>>, T>
 
 // Declare a user class as a source of data entries.
 #define REGISTER_LHS(T, ...)                                                                  \

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -267,16 +267,16 @@ TEST(TypeSystemTest, VariantStaticAsserts) {
 
   static_assert(is_same_or_compile_error<Variant<Foo>, Variant<Foo>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo>, Variant<TypeList<Foo>>>::value, "");
-  static_assert(is_same_or_compile_error<Variant<Foo>, Variant<TypeList<Foo, Foo>>>::value, "");
+  static_assert(is_same_or_compile_error<Variant<Foo>, Variant<SlowTypeList<Foo, Foo>>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo>, Variant<TypeListImpl<Foo>>>::value, "");
   static_assert(Variant<Foo>::T_TYPELIST_SIZE == 1u, "");
   static_assert(is_same_or_compile_error<Variant<Foo>::T_TYPELIST, TypeListImpl<Foo>>::value, "");
 
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<Foo, Bar>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<TypeList<Foo, Bar>>>::value, "");
-  static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<TypeList<Foo, Bar, Foo>>>::value, "");
-  static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<TypeList<Foo, Bar, TypeList<Bar>>>>::value,
-                "");
+  static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<SlowTypeList<Foo, Bar, Foo>>>::value, "");
+  static_assert(
+      is_same_or_compile_error<Variant<Foo, Bar>, Variant<SlowTypeList<Foo, Bar, TypeList<Bar>>>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<TypeListImpl<Foo, Bar>>>::value, "");
   static_assert(Variant<Foo, Bar>::T_TYPELIST_SIZE == 2u, "");
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>::T_TYPELIST, TypeListImpl<Foo, Bar>>::value, "");

--- a/Yoda/metaprogramming.h
+++ b/Yoda/metaprogramming.h
@@ -82,8 +82,9 @@ struct YodaTypes : YodaTypesBase {
 
   template <typename T>
   using SherlockEntryTypeFromYodaEntryType = typename T::T_SHERLOCK_TYPES;
-  // Need to flatten all the types here, so no `TypeListImpl<>`, only `TypeList`.
-  using T_UNDERLYING_TYPES_LIST = TypeList<MP::map<SherlockEntryTypeFromYodaEntryType, T_SUPPORTED_TYPES_LIST>>;
+  // Need to flatten all the types here, so no `TypeListImpl<>`, only `SlowTypeList`.
+  using T_UNDERLYING_TYPES_LIST =
+      SlowTypeList<MP::map<SherlockEntryTypeFromYodaEntryType, T_SUPPORTED_TYPES_LIST>>;
 
   using T_MQ_LISTENER = MQListener<PERSISTENCE, CLONER, T_SUPPORTED_TYPES_LIST>;
   using T_MQ_MESSAGE_INTERNAL_TYPEDEF = MQMessage<PERSISTENCE, CLONER, T_SUPPORTED_TYPES_LIST>;

--- a/Yoda/yoda.h
+++ b/Yoda/yoda.h
@@ -154,11 +154,11 @@ using API = typename APIWrapperSelector<PERSISTENCE, CLONER, SUPPORTED_TYPES_LIS
 
 template <typename... SUPPORTED_TYPES>
 using MemoryOnlyAPI =
-    API<blocks::persistence::MemoryOnly, current::DefaultCloner, TypeList<SUPPORTED_TYPES...>>;
+    API<blocks::persistence::MemoryOnly, current::DefaultCloner, SlowTypeList<SUPPORTED_TYPES...>>;
 
 template <typename... SUPPORTED_TYPES>
 using SingleFileAPI =
-    API<blocks::persistence::CerealAppendToFile, current::DefaultCloner, TypeList<SUPPORTED_TYPES...>>;
+    API<blocks::persistence::CerealAppendToFile, current::DefaultCloner, SlowTypeList<SUPPORTED_TYPES...>>;
 
 }  // namespace yoda
 

--- a/sandbox/TypeTest/test.sh
+++ b/sandbox/TypeTest/test.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-COUNT_LIST=(10 100 200)
-TEST_LIST=('.current/current_struct'
-           '.current/struct_fields'
-           '.current/typelist_impl'
-           '.current/typelist_dynamic'
-	   '.current/rtti_dynamic_call'
-	   '.current/variant')
-# 20 structs for '.current/typelist' are killing my clang :( //MZ
+COUNT_LIST=(10 25 100 500)
+TEST_LIST=(
+    '.current/current_struct'
+    '.current/struct_fields'
+    '.current/typelist'  # This is cheating as `TypeList` now effectively is `TypeListImpl`.
+    '.current/typelist_impl'
+    '.current/typelist_dynamic'
+    '.current/rtti_dynamic_call'
+    '.current/variant'
+)
 
 for c in ${COUNT_LIST[@]}; do
 	(./gen_test_data.sh $c;	make clean >/dev/null)

--- a/sandbox/TypeTest/typelist_dynamic.cc
+++ b/sandbox/TypeTest/typelist_dynamic.cc
@@ -46,5 +46,5 @@ TEST(TypeTest, TypeListImpl) {
   using current::metaprogramming::Flatten;
   typedef Flatten<map<ST, DATA_TYPES>> STORAGE_TYPES;
 
-  static_assert(IsTypeList<STORAGE_TYPES>::value, "");
+  static_assert(TypeListSize<STORAGE_TYPES>::value == TypeListSize<DATA_TYPES>::value * 2, "");
 }

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -70,5 +70,5 @@ readlink:
 	echo ${CURRENT_SCRIPTS_DIR}
 
 wc:
-	echo -n "Total files: " ; (find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | wc -l
-	(find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | xargs wc -l | sort -gr
+	echo -n "Total files: " ; (find . -name '*.cc' ; find . -iname '*.h') | grep -v "/3rdparty/" | grep -v "/.current/" | grep -v "/zzz_full_test/" | wc -l
+	(find . -name '*.cc' ; find . -iname '*.h') | grep -v "/3rdparty/" | grep -v "/.current/" | grep -v "/zzz_full_test/" | xargs wc -l | sort -gr

--- a/scripts/check-headers.sh
+++ b/scripts/check-headers.sh
@@ -10,7 +10,7 @@ RUN_DIR_FULL_PATH=$( "$CURRENT_SCRIPTS_DIR/fullpath.sh" "$PWD" )
 
 echo -e "\033[1m\033[34mTesting all headers to comply with the header-only paradigm.\033[0m"
 
-for i in $(for i in $(find . -iname "*.h" | grep -v 3rdparty | grep -vi deprecated) ; do dirname "$i" ; done | sort -u) ; do
+for i in $(for i in $(find . -iname "*.h" | grep -v "/3rdparty/" | grep -vi deprecated | grep -v "/sandbox/") ; do dirname "$i" ; done | sort -u) ; do
   echo -e "\033[1mDirectory\033[0m: $i"
   cd "$i" && "$CURRENT_SCRIPTS_DIR_FULL_PATH/check-headers-within-dir.sh" && cd "$RUN_DIR_FULL_PATH" && continue
   echo -e "\033[1m\033[31mTerminating.\033[0m" && exit 1

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -48,7 +48,7 @@ echo
 
 
 echo -n -e "\033[0m\033[1mTests:\033[0m\033[36m"
-for i in $(find . -iname "*test.cc" | grep -v 3rdparty | grep -v "/.current/" | sort -g); do
+for i in $(find . -iname "*test.cc" | grep -v "/3rdparty/" | grep -v "/.current/" | grep -v "/sandbox/" | sort -g); do
   echo "#include \"$i\"" >> "$FULL_TEST_DIR_NAME/$ALL_TESTS_TOGETHER.cc"
   echo -n " $i"
 done
@@ -56,7 +56,7 @@ done
 # Allow this one test to rule them all to access all the `golden/` files.
 mkdir -p "$GOLDEN_FULL_PATH"
 echo -e "\n\n\033[0m\033[1mGolden files\033[0m: \033[35m"
-for dirname in $(find . -iname "$GOLDEN_DIR_NAME" -type d | grep -v 3rdparty | grep -v "/.current/" | grep -v "$FULL_TEST_DIR_NAME"); do
+for dirname in $(find . -iname "$GOLDEN_DIR_NAME" -type d | grep -v "/3rdparty/" | grep -v "/.current/" | grep -v "/sandbox/" | grep -v "$FULL_TEST_DIR_NAME"); do
   (cd $dirname; for filename in * ; do cp -v "$PWD/$filename" "$GOLDEN_FULL_PATH" ; done)
 done
 echo -e -n "\033[0m"


### PR DESCRIPTION
Numbers on Hetzner (its `mongod` makes it run out of memory on 500, up to 100 looks trustworthy to me. -- D.K.)

```
Generating data for 10 structures.
Compiling: .current/current_struct
Time elapsed: 5.457 seconds.
Running: PASSED
Compiling: .current/struct_fields
Time elapsed: 5.178 seconds.
Running: PASSED
Compiling: .current/typelist
Time elapsed: 2.337 seconds.
Running: PASSED
Compiling: .current/typelist_impl
Time elapsed: 2.296 seconds.
Running: PASSED
Compiling: .current/typelist_dynamic
Time elapsed: 2.315 seconds.
Running: PASSED
Compiling: .current/rtti_dynamic_call
Time elapsed: 2.629 seconds.
Running: PASSED
Compiling: .current/variant
Time elapsed: 3.175 seconds.
Running: PASSED

Generating data for 25 structures.
Compiling: .current/current_struct
Time elapsed: 5.247 seconds.
Running: PASSED
Compiling: .current/struct_fields
Time elapsed: 5.230 seconds.
Running: PASSED
Compiling: .current/typelist
Time elapsed: 2.494 seconds.
Running: PASSED
Compiling: .current/typelist_impl
Time elapsed: 2.493 seconds.
Running: PASSED
Compiling: .current/typelist_dynamic
Time elapsed: 2.328 seconds.
Running: PASSED
Compiling: .current/rtti_dynamic_call
Time elapsed: 2.786 seconds.
Running: PASSED
Compiling: .current/variant
Time elapsed: 4.141 seconds.
Running: PASSED

Generating data for 100 structures.
Compiling: .current/current_struct
Time elapsed: 6.517 seconds.
Running: PASSED
Compiling: .current/struct_fields
Time elapsed: 5.541 seconds.
Running: PASSED
Compiling: .current/typelist
Time elapsed: 3.983 seconds.
Running: PASSED
Compiling: .current/typelist_impl
Time elapsed: 3.888 seconds.
Running: PASSED
Compiling: .current/typelist_dynamic
Time elapsed: 2.418 seconds.
Running: PASSED
Compiling: .current/rtti_dynamic_call
Time elapsed: 3.873 seconds.
Running: PASSED
Compiling: .current/variant
Time elapsed: 14.383 seconds.
Running: PASSED
```