### PR TITLE
TypeSystem fix to allow base struct belong to different namespace.

### DIFF
--- a/Midichlorians/Dev/Beta2/MidichloriansDataDictionary.h
+++ b/Midichlorians/Dev/Beta2/MidichloriansDataDictionary.h
@@ -47,15 +47,24 @@ SOFTWARE.
 namespace current {
 namespace midichlorians {
 
-// Base event.
+// `MidichloriansBaseEvent` is the universal base class for all analytics events, mobile and web.
+// `customer_id` is used to separate events from different customers, when they are collected by a single
+// server, and could be ignored in case of single-customer environment.
+// TODO(dk+mz): make `customer_id` a mandatory parameter in initialization?
+// `user_ms` is the event timestamp on user device, measured in milliseconds since epoch.
+// `client_id` is the unique identifier of the user. It could be set by corresponding `identify` methods or
+// generated automatically.
 CURRENT_STRUCT(MidichloriansBaseEvent) {
+  CURRENT_FIELD(customer_id, std::string);
   CURRENT_FIELD(user_ms, std::chrono::milliseconds);
-  CURRENT_FIELD(device_id, std::string);
   CURRENT_FIELD(client_id, std::string);
 };
 
-// iOS-specific base event.
-CURRENT_STRUCT(iOSBaseEvent, MidichloriansBaseEvent){};
+namespace ios {
+
+CURRENT_STRUCT(iOSBaseEvent, MidichloriansBaseEvent) {
+  CURRENT_FIELD(device_id, std::string);
+};
 
 // iOS event denoting the very first application launch.
 // Emitted once during Midichlorians initialization.
@@ -133,6 +142,13 @@ using T_IOS_EVENTS = TypeList<iOSFirstLaunchEvent,
                               iOSIdentifyEvent,
                               iOSFocusEvent,
                               iOSGenericEvent>;
+
+}  // namespace ios
+
+namespace web {
+
+}  // namespace web
+
 
 }  // namespace midichlorians
 }  // namespace current

--- a/Midichlorians/Dev/Beta2/iOS/Midichlorians.mm
+++ b/Midichlorians/Dev/Beta2/iOS/Midichlorians.mm
@@ -24,7 +24,7 @@
 
 @implementation Midichlorians
 
-using namespace current::midichlorians;
+using namespace current::midichlorians::ios;
 
 + (void)setup:(NSString*)serverUrl withLaunchOptions:(NSDictionary*)options {
     [MidichloriansImpl setup:serverUrl withLaunchOptions:options];

--- a/Midichlorians/Dev/Beta2/iOS/MidichloriansImpl.h
+++ b/Midichlorians/Dev/Beta2/iOS/MidichloriansImpl.h
@@ -60,7 +60,7 @@
 + (void)setup:(NSString*)serverUrl withLaunchOptions:(NSDictionary*)options;
 
 // Emits the event.
-+ (void)emit:(const current::midichlorians::iOSBaseEvent&)event;
++ (void)emit:(const current::midichlorians::ios::iOSBaseEvent&)event;
 
 // Identifies the user.
 + (void)identify:(NSString*)identifier;

--- a/Midichlorians/Dev/Beta2/iOS/MidichloriansImpl.mm
+++ b/Midichlorians/Dev/Beta2/iOS/MidichloriansImpl.mm
@@ -55,6 +55,7 @@
 
 namespace current {
 namespace midichlorians {
+namespace ios {
 
     // Conversion from [possible nullptr] `const char*` to `std::string`.
     static std::string ToStdString(const char* s) {
@@ -236,12 +237,14 @@ namespace midichlorians {
 
         Variant<T_IOS_EVENTS>& variant_;
     };
+
+}  // namespace ios
 }  // namespace midichlorians
 }  // namespace current
 
 @implementation MidichloriansImpl
 
-using namespace current::midichlorians;
+using namespace current::midichlorians::ios;
 
 + (void)setup:(NSString *)serverUrl withLaunchOptions:(NSDictionary *)options {
     const auto installationId = InstallationId();

--- a/Midichlorians/test2.cc
+++ b/Midichlorians/test2.cc
@@ -48,7 +48,7 @@ SOFTWARE.
 DEFINE_int32(http_port, 8383, "Port to spawn server on.");
 DEFINE_string(http_route, "/log", "HTTP route of the server.");
 
-using namespace current::midichlorians;
+using namespace current::midichlorians::ios;
 
 struct Server {
   using T_EVENT_VARIANT = Variant<T_IOS_EVENTS>;

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -158,6 +158,7 @@ struct CurrentStructFieldsConsistency<T, -1> {
   template <>                                                                                       \
   struct CURRENT_REFLECTION_HELPER<s> {                                                             \
     constexpr static const char* CURRENT_STRUCT_NAME() { return #s; }                               \
+    constexpr static size_t CURRENT_FIELD_INDEX_BASE = __COUNTER__;                                 \
     typedef CURRENT_STRUCT_IMPL_##s<::current::reflection::CountFields> CURRENT_FIELD_COUNT_STRUCT; \
   }
 

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -56,25 +56,13 @@ CURRENT_STRUCT(Baz) {
   CURRENT_FIELD(v1, std::vector<uint64_t>);
   CURRENT_FIELD(v2, std::vector<Foo>);
   CURRENT_FIELD(v3, std::vector<std::vector<Foo>>);
-#ifndef _MSC_VER
   CURRENT_FIELD(v4, (std::map<std::string, std::string>));
   CURRENT_FIELD(v5, (std::map<Foo, int>));
-#else
-  typedef std::map<std::string, std::string> t_map_string_string;
-  CURRENT_FIELD(v4, t_map_string_string);
-  typedef std::map<Foo, int> t_map_foo_int;
-  CURRENT_FIELD(v5, t_map_foo_int);
-#endif
 };
 
 CURRENT_STRUCT(DerivedFromFoo, Foo) {
-#ifndef _MSC_VER
-  CURRENT_DEFAULT_CONSTRUCTOR(DerivedFromFoo) : Foo(100u) {}
-  CURRENT_CONSTRUCTOR(DerivedFromFoo)(size_t x) : Foo(x * 1001u) {}
-#else
   CURRENT_DEFAULT_CONSTRUCTOR(DerivedFromFoo) : SUPER(100u) {}
   CURRENT_CONSTRUCTOR(DerivedFromFoo)(size_t x) : SUPER(x * 1001u) {}
-#endif
   CURRENT_FIELD(baz, Baz);
 };
 
@@ -589,12 +577,7 @@ TEST(TypeSystemTest, TimestampSimple) {
 
 namespace struct_definition_test {
 CURRENT_STRUCT(WithTimestampVariant) {
-#ifndef _MSC_VER
   CURRENT_FIELD(magic, (Variant<WithTimestampUS, WithTimestampUInt64>));
-#else
-  typedef Variant<WithTimestampUS, WithTimestampUInt64> t_magic;
-  CURRENT_FIELD(magic, t_magic);
-#endif
   CURRENT_CONSTRUCTOR(WithTimestampVariant)(const WithTimestampUS& magic) : magic(magic) {}
   CURRENT_CONSTRUCTOR(WithTimestampVariant)(const WithTimestampUInt64& magic) : magic(magic) {}
   CURRENT_TIMESTAMP(magic);
@@ -638,12 +621,7 @@ TEST(TypeSystemTest, ConstructorsAndMemberFunctions) {
 namespace struct_definition_test {
 
 CURRENT_STRUCT(WithVariant) {
-#ifndef _MSC_VER
   CURRENT_FIELD(p, (Variant<Foo, Bar>));
-#else
-  typedef Variant<Foo, Bar> t_p;
-  CURRENT_FIELD(p, t_p);
-#endif
   CURRENT_CONSTRUCTOR(WithVariant)(Foo foo) : p(foo) {}
 };
 


### PR DESCRIPTION
@dkorolev Looks like I fixed dat shit. 
For now, it's common base class constructor call syntax - ` : SUPER(...)`