### PR TITLE
`CURRENT_STRUCT_TAG` refactoring and split.

### DIFF
--- a/Storage/base.h
+++ b/Storage/base.h
@@ -68,15 +68,8 @@ struct FieldNameAndTypeByIndex {};
 template <int N, typename T_RETVAL>
 struct FieldNameAndTypeByIndexAndReturn {};
 
-// Helpers for `FieldNameAndTypeByIndex`.
-struct StorageFieldTypeSelector {
-  struct Vector {
-    static const char* HumanReadableName() { return "Vector"; }
-  };
-  struct Dictionary {
-    static const char* HumanReadableName() { return "Dictionary"; }
-  };
-};
+template <typename T>
+struct StorageFieldTypeSelector;
 
 template <typename T>
 struct FieldUnderlyingTypeWrapper {

--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -83,7 +83,7 @@ class Dictionary {
     }
   }
 
-  void operator()(const T_UPDATE_EVENT& object) { map_[sfinae::GetKey(object)] = object; }
+  void operator()(const T_UPDATE_EVENT& object) { map_[sfinae::GetKey(object)] = object.data; }
   void operator()(const T_DELETE_EVENT& object) { map_.erase(sfinae::GetKey(object)); }
 
   struct Iterator final {

--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -40,13 +40,13 @@ namespace container {
 template <typename T,
           typename T_UPDATE_EVENT,
           typename T_DELETE_EVENT,
-          template <typename...> class MAP = Unordered>
-class Dictionary {
+          template <typename...> class MAP>
+class GenericDictionary {
  public:
   using T_KEY = sfinae::ENTRY_KEY_TYPE<T>;
   using T_MAP = MAP<T_KEY, T>;
 
-  explicit Dictionary(MutationJournal& journal) : journal_(journal) {}
+  explicit GenericDictionary(MutationJournal& journal) : journal_(journal) {}
 
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }
@@ -83,8 +83,8 @@ class Dictionary {
     }
   }
 
-  void operator()(const T_UPDATE_EVENT& e) { map_[sfinae::GetKey(e)] = e.data; }
-  void operator()(const T_DELETE_EVENT& e) { map_.erase(sfinae::GetKey(e)); }
+  void operator()(const T_UPDATE_EVENT& e) { map_[sfinae::GetKey(e.data)] = e.data; }
+  void operator()(const T_DELETE_EVENT& e) { map_.erase(e.key); }
 
   struct Iterator final {
     using T_ITERATOR = typename T_MAP::const_iterator;
@@ -106,10 +106,28 @@ class Dictionary {
   MutationJournal& journal_;
 };
 
+template <typename T, typename T_UPDATE_EVENT, typename T_DELETE_EVENT>
+using UnorderedDictionary = GenericDictionary<T, T_UPDATE_EVENT, T_DELETE_EVENT, Unordered>;
+
+template <typename T, typename T_UPDATE_EVENT, typename T_DELETE_EVENT>
+using OrderedDictionary = GenericDictionary<T, T_UPDATE_EVENT, T_DELETE_EVENT, Ordered>;
+
 }  // namespace container
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedDictionary<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedDictionary"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedDictionary<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedDictionary"; }
+};
+
 }  // namespace storage
 }  // namespace current
 
-using current::storage::container::Dictionary;
+using current::storage::container::UnorderedDictionary;
+using current::storage::container::OrderedDictionary;
 
 #endif  // CURRENT_STORAGE_CONTAINER_DICTIONARY_H

--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -83,8 +83,8 @@ class Dictionary {
     }
   }
 
-  void operator()(const T_UPDATE_EVENT& object) { map_[sfinae::GetKey(object)] = object.data; }
-  void operator()(const T_DELETE_EVENT& object) { map_.erase(sfinae::GetKey(object)); }
+  void operator()(const T_UPDATE_EVENT& e) { map_[sfinae::GetKey(e)] = e.data; }
+  void operator()(const T_DELETE_EVENT& e) { map_.erase(sfinae::GetKey(e)); }
 
   struct Iterator final {
     using T_ITERATOR = typename T_MAP::const_iterator;

--- a/Storage/container/vector.h
+++ b/Storage/container/vector.h
@@ -61,15 +61,14 @@ class Vector {
   void PopBack() {
     if (!vector_.empty()) {
       const auto back_object = vector_.back();
-      journal_.LogMutation(T_POPPED_BACK_EVENT(),
-                           [this, back_object]() { vector_.push_back(back_object); });
+      journal_.LogMutation(T_POPPED_BACK_EVENT(), [this, back_object]() { vector_.push_back(back_object); });
       vector_.pop_back();
     } else {
       CURRENT_THROW(CannotPopBackFromEmptyVectorException());
     }
   }
 
-  void operator()(const T_PUSHED_BACK_EVENT& object) { vector_.push_back(object.data); }
+  void operator()(const T_PUSHED_BACK_EVENT& e) { vector_.push_back(e.data); }
   void operator()(const T_POPPED_BACK_EVENT&) { vector_.pop_back(); }
 
  private:
@@ -78,6 +77,12 @@ class Vector {
 };
 
 }  // namespace container
+
+template <typename T, typename E1, typename E2>  // Entry, `push_back` event, `pop_back` event.
+struct StorageFieldTypeSelector<container::Vector<T, E1, E2>> {
+  static const char* HumanReadableName() { return "Vector"; }
+};
+
 }  // namespace storage
 }  // namespace current
 

--- a/Storage/docu/docu_2_code.cc
+++ b/Storage/docu/docu_2_code.cc
@@ -63,10 +63,10 @@ CURRENT_STRUCT(User) {
   CURRENT_CONSTRUCTOR(User)(UserID key = UserID::INVALID) : key(key) {}
 };
 
-CURRENT_STRUCT_TAG(Dictionary, User, PersistedUser);
+CURRENT_STORAGE_FIELD_ENTRY(UnorderedDictionary, User, PersistedUser);
 
 CURRENT_STORAGE(ExampleStorageDefinition) {
-  CURRENT_STORAGE_FIELD(users, Dictionary, PersistedUser);
+  CURRENT_STORAGE_FIELD(users, PersistedUser);
 };
 
 }  // namespace storage_docu

--- a/Storage/docu/docu_2_code.cc
+++ b/Storage/docu/docu_2_code.cc
@@ -63,7 +63,7 @@ CURRENT_STRUCT(User) {
   CURRENT_CONSTRUCTOR(User)(UserID key = UserID::INVALID) : key(key) {}
 };
 
-CURRENT_STORAGE_STRUCT_TAG(User, PersistedUser);
+CURRENT_STRUCT_TAG(Dictionary, User, PersistedUser);
 
 CURRENT_STORAGE(ExampleStorageDefinition) {
   CURRENT_STORAGE_FIELD(users, Dictionary, PersistedUser);
@@ -181,12 +181,12 @@ TEST(StorageDocumentation, BasicUsage) {
     ASSERT_EQ(2u, t.first.size());
 
     ASSERT_TRUE(Exists<PersistedUserUpdated>(t.first[0]));
-    EXPECT_EQ("test1", Value<PersistedUserUpdated>(t.first[0]).name);
-    EXPECT_TRUE(Value<PersistedUserUpdated>(t.first[0]).straight);
+    EXPECT_EQ("test1", Value<PersistedUserUpdated>(t.first[0]).data.name);
+    EXPECT_TRUE(Value<PersistedUserUpdated>(t.first[0]).data.straight);
 
     ASSERT_TRUE(Exists<PersistedUserUpdated>(t.first[1]));
-    EXPECT_EQ("test2", Value<PersistedUserUpdated>(t.first[1]).name);
-    EXPECT_FALSE(Value<PersistedUserUpdated>(t.first[1]).straight);
+    EXPECT_EQ("test2", Value<PersistedUserUpdated>(t.first[1]).data.name);
+    EXPECT_FALSE(Value<PersistedUserUpdated>(t.first[1]).data.straight);
 
     EXPECT_EQ(1002, static_cast<int>(t.second.count()));
   }
@@ -196,7 +196,7 @@ TEST(StorageDocumentation, BasicUsage) {
     ASSERT_EQ(1u, t.first.size());
 
     ASSERT_TRUE(Exists<PersistedUserUpdated>(t.first[0]));
-    EXPECT_EQ("to be deleted", Value<PersistedUserUpdated>(t.first[0]).name);
+    EXPECT_EQ("to be deleted", Value<PersistedUserUpdated>(t.first[0]).data.name);
 
     EXPECT_EQ(1004, static_cast<int>(t.second.count()));
   }

--- a/Storage/storage.h
+++ b/Storage/storage.h
@@ -68,51 +68,58 @@ SOFTWARE.
 namespace current {
 namespace storage {
 
-// `CURRENT_STORAGE_STRUCT_TAG`:
+// `CURRENT_STORAGE_FIELD_ENTRY`:
 // 1) Creates a dedicated C++ type to allow compile-time disambiguation of storages of same underlying types.
-// 2) Splits the type into `T_UPDATE_EVENT` and `T_DELETE_EVENT` to enable persisting deletions too.
+// 2) Splits the type into `T_PERSISTED_EVENT_1` and `T_PERSISTED_EVENT_2` to enable persisting deletions too.
 
 // clang-format off
-#define CURRENT_STRUCT_TAG_Dictionary(base, alias)                                                    \
-  CURRENT_STRUCT(alias##Updated) {                                                                    \
-    CURRENT_FIELD(data, base);                                                                        \
-    CURRENT_DEFAULT_CONSTRUCTOR(alias##Updated) {}                                                    \
-    CURRENT_CONSTRUCTOR(alias##Updated)(const base& value) : data(value) {}                           \
-    using T_KEY = current::decay<decltype(::current::storage::sfinae::GetKey(std::declval<base>()))>; \
-    T_KEY key() const { return ::current::storage::sfinae::GetKey(data); }                            \
-    void set_key(const T_KEY& key) { ::current::storage::sfinae::SetKey(data, key); }                 \
-  };                                                                                                  \
-  CURRENT_STRUCT(alias##Deleted) {                                                                    \
-    CURRENT_FIELD(key, ::current::storage::sfinae::ENTRY_KEY_TYPE<base>);                             \
-    CURRENT_DEFAULT_CONSTRUCTOR(alias##Deleted) {}                                                    \
-    CURRENT_CONSTRUCTOR(alias##Deleted)(const base& value)                                            \
-        : key(::current::storage::sfinae::GetKey(value)) {}                                           \
-  };                                                                                                  \
-  struct alias {                                                                                      \
-    using T_ENTRY = base;                                                                             \
-    using T_UPDATE_EVENT = alias##Updated;                                                            \
-    using T_DELETE_EVENT = alias##Deleted;                                                            \
-    using T_PERSISTED_EVENT_1 = alias##Updated;                                                       \
-    using T_PERSISTED_EVENT_2 = alias##Deleted;                                                       \
+#define CURRENT_STORAGE_FIELD_ENTRY_Dictionary_IMPL(dictionary_type, entry_type, entry_name)                \
+  CURRENT_STRUCT(entry_name##Updated) {                                                                     \
+    CURRENT_FIELD(data, entry_type);                                                                        \
+    CURRENT_DEFAULT_CONSTRUCTOR(entry_name##Updated) {}                                                     \
+    CURRENT_CONSTRUCTOR(entry_name##Updated)(const entry_type& value) : data(value) {}                      \
+  };                                                                                                        \
+  CURRENT_STRUCT(entry_name##Deleted) {                                                                     \
+    CURRENT_FIELD(key, ::current::storage::sfinae::ENTRY_KEY_TYPE<entry_type>);                             \
+    CURRENT_DEFAULT_CONSTRUCTOR(entry_name##Deleted) {}                                                     \
+    CURRENT_CONSTRUCTOR(entry_name##Deleted)(const entry_type& value)                                       \
+        : key(::current::storage::sfinae::GetKey(value)) {}                                                 \
+  };                                                                                                        \
+  struct entry_name {                                                                                       \
+    template <typename T, typename E1, typename E2>                                                         \
+    using T_FIELD_TYPE = dictionary_type<T, E1, E2>;                                                        \
+    using T_ENTRY = entry_type;                                                                             \
+    using T_UPDATE_EVENT = entry_name##Updated;                                                             \
+    using T_DELETE_EVENT = entry_name##Deleted;                                                             \
+    using T_PERSISTED_EVENT_1 = entry_name##Updated;                                                        \
+    using T_PERSISTED_EVENT_2 = entry_name##Deleted;                                                        \
   }
 
-#define CURRENT_STRUCT_TAG_Vector(base, alias)                                    \
-  CURRENT_STRUCT(alias##PushedElement) {                                          \
-    CURRENT_FIELD(data, base);                                                    \
-    CURRENT_DEFAULT_CONSTRUCTOR(alias##PushedElement) {}                          \
-    CURRENT_CONSTRUCTOR(alias##PushedElement)(const base& value) : data(value) {} \
-  };                                                                              \
-  CURRENT_STRUCT(alias##PoppedElement) {};                                        \
-  struct alias {                                                                  \
-    using T_ENTRY = base;                                                         \
-    using T_PUSHED_BACK_EVENT = alias##PushedElement;                             \
-    using T_POPPED_BACK_EVENT = alias##PoppedElement;                             \
-    using T_PERSISTED_EVENT_1 = alias##PushedElement;                             \
-    using T_PERSISTED_EVENT_2 = alias##PoppedElement;                             \
+#define CURRENT_STORAGE_FIELD_ENTRY_UnorderedDictionary(entry_type, entry_name) \
+  CURRENT_STORAGE_FIELD_ENTRY_Dictionary_IMPL(UnorderedDictionary, entry_type, entry_name)
+
+#define CURRENT_STORAGE_FIELD_ENTRY_OrderedDictionary(entry_type, entry_name) \
+  CURRENT_STORAGE_FIELD_ENTRY_Dictionary_IMPL(OrderedDictionary, entry_type, entry_name)
+
+#define CURRENT_STORAGE_FIELD_ENTRY_Vector(entry_type, entry_name)                           \
+  CURRENT_STRUCT(entry_name##PushedElement) {                                                \
+    CURRENT_FIELD(data, entry_type);                                                         \
+    CURRENT_DEFAULT_CONSTRUCTOR(entry_name##PushedElement) {}                                \
+    CURRENT_CONSTRUCTOR(entry_name##PushedElement)(const entry_type& value) : data(value) {} \
+  };                                                                                         \
+  CURRENT_STRUCT(entry_name##PoppedElement){};                                               \
+  struct entry_name {                                                                        \
+    template <typename... TS>                                                                \
+    using T_FIELD_TYPE = Vector<TS...>;                                                      \
+    using T_ENTRY = entry_type;                                                              \
+    using T_PUSHED_BACK_EVENT = entry_name##PushedElement;                                   \
+    using T_POPPED_BACK_EVENT = entry_name##PoppedElement;                                   \
+    using T_PERSISTED_EVENT_1 = entry_name##PushedElement;                                   \
+    using T_PERSISTED_EVENT_2 = entry_name##PoppedElement;                                   \
   }
 
-// TODO(dkorolev) || TODO(mzhurovich): Move to `TypeSystem/` and test.
-#define CURRENT_STRUCT_TAG(tag, base, alias) CURRENT_STRUCT_TAG_##tag(base, alias)
+#define CURRENT_STORAGE_FIELD_ENTRY(container, entry_type, entry_name) \
+  CURRENT_STORAGE_FIELD_ENTRY_##container(entry_type, entry_name)
 
 // clang-format on
 
@@ -184,42 +191,44 @@ namespace storage {
             CURRENT_STORAGE_FIELDS_HELPER<CURRENT_STORAGE_FIELDS_##name<::current::storage::DeclareFields>>>
 
 // clang-format off
-#define CURRENT_STORAGE_FIELD(field_name, field_type, entry_tag, ...)                                       \
-  enum { FIELD_INDEX_##field_name = CURRENT_EXPAND_MACRO(__COUNTER__) - CURRENT_STORAGE_FIELD_INDEX_BASE }; \
-  ::current::storage::FieldInfo<entry_tag::T_PERSISTED_EVENT_1, entry_tag::T_PERSISTED_EVENT_2> operator()(           \
-      ::current::storage::FieldInfoByIndex<FIELD_INDEX_##field_name>) const {                               \
-    return ::current::storage::FieldInfo<entry_tag::T_PERSISTED_EVENT_1, entry_tag::T_PERSISTED_EVENT_2>();           \
-  }                                                                                                         \
-  std::string operator()(::current::storage::FieldNameByIndex<FIELD_INDEX_##field_name>) const {            \
-    return #field_name;                                                                                     \
-  }                                                                                                         \
-  template <typename F>                                                                                     \
-  void operator()(::current::storage::ImmutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) const {       \
-    f(field_name);                                                                                          \
-  }                                                                                                         \
-  template <typename F>                                                                                     \
-  void operator()(::current::storage::MutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) {               \
-    f(field_name);                                                                                          \
-  }                                                                                                         \
-  template <typename F>                                                                                     \
-  void operator()(::current::storage::FieldNameAndTypeByIndex<FIELD_INDEX_##field_name>, F&& f) const {     \
-    f(#field_name,                                                                                          \
-      ::current::storage::StorageFieldTypeSelector::field_type(),                                           \
-      ::current::storage::FieldUnderlyingTypeWrapper<entry_tag::T_ENTRY>());                                \
-  }                                                                                                         \
-  template <typename F, typename RETVAL>                                                                    \
-  RETVAL operator()(::current::storage::FieldNameAndTypeByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>, \
-                    F&& f) const {                                                                          \
-    return f(#field_name,                                                                                   \
-             ::current::storage::StorageFieldTypeSelector::field_type(),                                    \
-             ::current::storage::FieldUnderlyingTypeWrapper<entry_tag::T_ENTRY>());                         \
-  }                                                                                                         \
-  using T_FIELD_TYPE_##field_name = ::current::storage::Field<                                              \
-      INSTANTIATION_TYPE,                                                                                   \
-      field_type<entry_tag::T_ENTRY, entry_tag::T_PERSISTED_EVENT_1, entry_tag::T_PERSISTED_EVENT_2, ##__VA_ARGS__>>; \
-  T_FIELD_TYPE_##field_name field_name = T_FIELD_TYPE_##field_name(current_storage_mutation_journal_);      \
-  void operator()(const entry_tag::T_PERSISTED_EVENT_1& e) { field_name(e); }                               \
-  void operator()(const entry_tag::T_PERSISTED_EVENT_2& e) { field_name(e); }
+#define CURRENT_STORAGE_FIELD(field_name, entry_name)                                                         \
+  using T_FIELD_CONTAINER_TYPE_##field_name = entry_name::T_FIELD_TYPE<entry_name::T_ENTRY,                   \
+                                                                       entry_name::T_PERSISTED_EVENT_1,       \
+                                                                       entry_name::T_PERSISTED_EVENT_2>;      \
+  using T_FIELD_TYPE_##field_name =                                                                           \
+      ::current::storage::Field<INSTANTIATION_TYPE, T_FIELD_CONTAINER_TYPE_##field_name>;                     \
+  enum { FIELD_INDEX_##field_name = CURRENT_EXPAND_MACRO(__COUNTER__) - CURRENT_STORAGE_FIELD_INDEX_BASE };   \
+  ::current::storage::FieldInfo<entry_name::T_PERSISTED_EVENT_1, entry_name::T_PERSISTED_EVENT_2> operator()( \
+      ::current::storage::FieldInfoByIndex<FIELD_INDEX_##field_name>) const {                                 \
+    return ::current::storage::FieldInfo<entry_name::T_PERSISTED_EVENT_1, entry_name::T_PERSISTED_EVENT_2>(); \
+  }                                                                                                           \
+  std::string operator()(::current::storage::FieldNameByIndex<FIELD_INDEX_##field_name>) const {              \
+    return #field_name;                                                                                       \
+  }                                                                                                           \
+  template <typename F>                                                                                       \
+  void operator()(::current::storage::ImmutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) const {         \
+    f(field_name);                                                                                            \
+  }                                                                                                           \
+  template <typename F>                                                                                       \
+  void operator()(::current::storage::MutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) {                 \
+    f(field_name);                                                                                            \
+  }                                                                                                           \
+  template <typename F>                                                                                       \
+  void operator()(::current::storage::FieldNameAndTypeByIndex<FIELD_INDEX_##field_name>, F&& f) const {       \
+    f(#field_name,                                                                                            \
+      ::current::storage::StorageFieldTypeSelector<T_FIELD_CONTAINER_TYPE_##field_name>(),                    \
+      ::current::storage::FieldUnderlyingTypeWrapper<entry_name::T_ENTRY>());                                 \
+  }                                                                                                           \
+  template <typename F, typename RETVAL>                                                                      \
+  RETVAL operator()(::current::storage::FieldNameAndTypeByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,   \
+                    F&& f) const {                                                                            \
+    return f(#field_name,                                                                                     \
+             ::current::storage::StorageFieldTypeSelector<T_FIELD_CONTAINER_TYPE_##field_name>(),             \
+             ::current::storage::FieldUnderlyingTypeWrapper<entry_name::T_ENTRY>());                          \
+  }                                                                                                           \
+  T_FIELD_TYPE_##field_name field_name = T_FIELD_TYPE_##field_name(current_storage_mutation_journal_);        \
+  void operator()(const entry_name::T_PERSISTED_EVENT_1& e) { field_name(e); }                                \
+  void operator()(const entry_name::T_PERSISTED_EVENT_2& e) { field_name(e); }
 // clang-format on
 
 template <typename STORAGE>

--- a/Storage/test.cc
+++ b/Storage/test.cc
@@ -101,15 +101,18 @@ CURRENT_STRUCT(Cell) {
 #endif
 };
 
-CURRENT_STRUCT_TAG(Vector, Element, ElementVector1);
-CURRENT_STRUCT_TAG(Vector, Element, ElementVector2);
-CURRENT_STRUCT_TAG(Dictionary, Record, RecordDictionary);
+CURRENT_STORAGE_FIELD_ENTRY(Vector, Element, ElementVector1);
+CURRENT_STORAGE_FIELD_ENTRY(Vector, Element, ElementVector2);
+
+// TODO(dkorolev) + TODO(mzhurovich): Test both.
+// CURRENT_STORAGE_FIELD_ENTRY(Dictionary, Record, RecordDictionary);
+CURRENT_STORAGE_FIELD_ENTRY(OrderedDictionary, Record, RecordDictionary);
 
 using current::storage::container::Ordered;
 CURRENT_STORAGE(TestStorage) {
-  CURRENT_STORAGE_FIELD(v1, Vector, ElementVector1);
-  CURRENT_STORAGE_FIELD(v2, Vector, ElementVector2);
-  CURRENT_STORAGE_FIELD(d, Dictionary, RecordDictionary, Ordered);
+  CURRENT_STORAGE_FIELD(v1, ElementVector1);
+  CURRENT_STORAGE_FIELD(v2, ElementVector2);
+  CURRENT_STORAGE_FIELD(d, RecordDictionary);
 };
 
 }  // namespace transactional_storage_test
@@ -629,12 +632,12 @@ CURRENT_STRUCT(SimplePost) {
       : key(key), text(text) {}
 };
 
-CURRENT_STRUCT_TAG(Dictionary, SimpleUser, SimpleUserPersisted);
-CURRENT_STRUCT_TAG(Dictionary, SimplePost, SimplePostPersisted);
+CURRENT_STORAGE_FIELD_ENTRY(UnorderedDictionary, SimpleUser, SimpleUserPersisted);
+CURRENT_STORAGE_FIELD_ENTRY(UnorderedDictionary, SimplePost, SimplePostPersisted);
 
 CURRENT_STORAGE(SimpleStorage) {
-  CURRENT_STORAGE_FIELD(user, Dictionary, SimpleUserPersisted);
-  CURRENT_STORAGE_FIELD(post, Dictionary, SimplePostPersisted);
+  CURRENT_STORAGE_FIELD(user, SimpleUserPersisted);
+  CURRENT_STORAGE_FIELD(post, SimplePostPersisted);
 };
 
 }  // namespace transactional_storage_test

--- a/Storage/test.cc
+++ b/Storage/test.cc
@@ -54,8 +54,6 @@ namespace transactional_storage_test {
 CURRENT_STRUCT(Element) {
   CURRENT_FIELD(x, int32_t);
   CURRENT_CONSTRUCTOR(Element)(int32_t x = 0) : x(x) {}
-  // To use `Element` in storage, it should either define a `.key` field, or `.key()` method.
-  int32_t key() const { return x; }
 };
 
 CURRENT_STRUCT(Record) {
@@ -103,9 +101,9 @@ CURRENT_STRUCT(Cell) {
 #endif
 };
 
-CURRENT_STORAGE_STRUCT_TAG(Element, ElementVector1);
-CURRENT_STORAGE_STRUCT_TAG(Element, ElementVector2);
-CURRENT_STORAGE_STRUCT_TAG(Record, RecordDictionary);
+CURRENT_STRUCT_TAG(Vector, Element, ElementVector1);
+CURRENT_STRUCT_TAG(Vector, Element, ElementVector2);
+CURRENT_STRUCT_TAG(Dictionary, Record, RecordDictionary);
 
 using current::storage::container::Ordered;
 CURRENT_STORAGE(TestStorage) {
@@ -631,8 +629,8 @@ CURRENT_STRUCT(SimplePost) {
       : key(key), text(text) {}
 };
 
-CURRENT_STORAGE_STRUCT_TAG(SimpleUser, SimpleUserPersisted);
-CURRENT_STORAGE_STRUCT_TAG(SimplePost, SimplePostPersisted);
+CURRENT_STRUCT_TAG(Dictionary, SimpleUser, SimpleUserPersisted);
+CURRENT_STRUCT_TAG(Dictionary, SimplePost, SimplePostPersisted);
 
 CURRENT_STORAGE(SimpleStorage) {
   CURRENT_STORAGE_FIELD(user, Dictionary, SimpleUserPersisted);


### PR DESCRIPTION
Hi @mzhurovich ,

`CURRENT_STRUCT_TAG` refactoring, and separated `Dictionary` and `Vector` persistence-wise.

Thanks,
Dima