### PR TITLE
REST v0.5

### DIFF
--- a/Storage/base.h
+++ b/Storage/base.h
@@ -59,8 +59,14 @@ struct FieldNameByIndex {};
 template <int N>
 struct ImmutableFieldByIndex {};
 
+template <int N, typename T_RETVAL>
+struct ImmutableFieldByIndexAndReturn {};
+
 template <int N>
 struct MutableFieldByIndex {};
+
+template <int N, typename T_RETVAL>
+struct MutableFieldByIndexAndReturn {};
 
 template <int N>
 struct FieldNameAndTypeByIndex {};
@@ -71,9 +77,23 @@ struct FieldNameAndTypeByIndexAndReturn {};
 template <typename T>
 struct StorageFieldTypeSelector;
 
+template <int N>
+struct FieldTypeExtractor {};
+
 template <typename T>
-struct FieldUnderlyingTypeWrapper {
-  using type = T;
+struct StorageExtractedFieldType {
+  using T_PARTICULAR_FIELD = T;
+};
+
+template <typename T>
+struct FieldUnderlyingTypesWrapper {
+  // The entry type itself.
+  // For template-specialize user-defined API code with the specific entry underlying type.
+  using T_ENTRY = typename T::T_ENTRY;
+
+  // For the RESTful API to understand URLs.
+  // Map key type for dictionaries, `size_t` for vectors, etc.
+  using T_KEY = typename T::T_KEY;
 };
 
 // Fields declaration and counting.

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -1,0 +1,75 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+          (c) 2015 Maxim Zhurovich <zhurovich@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#define CURRENT_MOCK_TIME
+
+#include "../../port.h"
+
+#include "../storage.h"
+#include "../api.h"
+#include "../persister/sherlock.h"
+
+#include "../../Blocks/HTTP/api.h"
+
+#include "../../Bricks/dflags/dflags.h"
+
+#include "../../3rdparty/gtest/gtest.h"
+
+DEFINE_int32(client_storage_test_port, PickPortForUnitTest(), "");
+
+namespace storage_docu {
+
+CURRENT_ENUM(ClientID, uint64_t) { INVALID = 0ull };
+
+CURRENT_STRUCT(Client) {
+  CURRENT_FIELD(key, ClientID);
+
+  CURRENT_FIELD(name, std::string, "John Doe");
+  
+  CURRENT_FIELD(white, bool, true);
+  CURRENT_FIELD(straight, bool, true);
+  CURRENT_FIELD(male, bool, true);
+
+  CURRENT_CONSTRUCTOR(Client)(ClientID key = ClientID::INVALID) : key(key) {}
+};
+
+CURRENT_STORAGE_FIELD_ENTRY(UnorderedDictionary, Client, PersistedClient);
+
+CURRENT_STORAGE(StorageOfClients) {
+  CURRENT_STORAGE_FIELD(client, PersistedClient);
+};
+
+}  // namespace storage_docu
+
+TEST(StorageDocumentation, RESTifiedStorageExample) {
+  using namespace storage_docu;
+  using TestStorage = StorageOfClients<SherlockInMemoryStreamPersister>;
+
+  TestStorage storage("storage_of_clients_dummy_stream_name");
+
+  // const auto base_url = current::strings::Printf("http://localhost:%d", FLAGS_client_storage_test_port);
+  const auto rest1 = RESTfulStorage<TestStorage>(storage, FLAGS_client_storage_test_port, "/api1/");
+  const auto rest2 = RESTfulStorage<TestStorage>(storage, FLAGS_client_storage_test_port, "/api2/");
+}

--- a/Storage/rest.h
+++ b/Storage/rest.h
@@ -35,131 +35,137 @@ namespace rest {
 namespace impl {
 
 struct BasicREST {
-  template <typename HTTP_VERB, int INDEX, typename T>
+  template <class HTTP_VERB, typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTfulWrapper;
 
-  template <int INDEX, typename T>
-  struct RESTfulWrapper<GET, INDEX, T> {
-    template <typename KEY>
-    struct Impl {
-      const KEY& key;
-      Response& response;
-      Impl(const KEY& key, Response& response) : key(key), response(response) {}
-      template <typename FIELD_DATA>
-      void operator()(const FIELD_DATA& field_data) {
-        const auto result = field_data[key];
-        if (Exists(result)) {
-          response = Value(result);
-        } else {
-          response = Response("nope", HTTPResponseCode.NotFound);
-        }
+  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTfulWrapper<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+    template <class INPUT>
+    static Response Run(const INPUT& input) {
+      const ImmutableOptional<ENTRY> result = input.field[input.key];
+      if (Exists(result)) {
+        return Value(result);
+      } else {
+        return Response("Nope.\n", HTTPResponseCode.NotFound);
       }
-    };
-    template <typename STORAGE, typename KEY>
-    static Response Run(const STORAGE& storage, const KEY& key) {
-      Response response;
-      // NOTE: THIS IS VERY UNSAFE! `ImmutableFieldByIndex` assumes it is called from within a transaction
-      // Better would be to move this call to support `data(...), and pass in `template
-      // STORAGE_IMMUTABLE_FIELDS`.
-      storage(::current::storage::ImmutableFieldByIndex<INDEX>(), Impl<KEY>(key, response));
-      return response;
     }
   };
 
-  template <int INDEX, typename T>
-  struct RESTfulWrapper<POST, INDEX, T> {
-    template <typename ENTRY>
-    struct Impl {
-      const ENTRY& entry;
-      explicit Impl(const ENTRY& entry) : entry(entry) {}
-      template <typename FIELD_DATA>
-      void operator()(FIELD_DATA& field_data) {
-        field_data.Add(entry);
-      }
-    };
-    template <typename STORAGE, typename ENTRY>
-    static void Run(STORAGE& storage, const ENTRY& entry) {
-      // NOTE: THIS IS VERY UNSAFE! `MutableFieldByIndex` assumes it is called from within a transaction
-      // Better would be to move this call to support `data(...), and pass in `template
-      // STORAGE_IMMUTABLE_FIELDS`.
-      storage(::current::storage::MutableFieldByIndex<INDEX>(), Impl<ENTRY>(entry));
+  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTfulWrapper<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+    template <class INPUT>
+    static Response Run(const INPUT& input) {
+      input.field.Add(input.entry);
+      return Response("Added.\n", HTTPResponseCode.NoContent);
     }
   };
 
-  template <int INDEX, typename T>
-  struct RESTfulWrapper<DELETE, INDEX, T> {
-    template <typename KEY>
-    struct Impl {
-      const KEY& key;
-      explicit Impl(const KEY& key) : key(key) {}
-      template <typename FIELD_DATA>
-      void operator()(FIELD_DATA& field_data) {
-        field_data.Erase(key);
-      }
-    };
-    template <typename STORAGE, typename KEY>
-    static void Run(STORAGE& storage, const KEY& key) {
-      // NOTE: THIS IS VERY UNSAFE! `MutableFieldByIndex` assumes it is called from within a transaction
-      // Better would be to move this call to support `data(...), and pass in `template
-      // STORAGE_IMMUTABLE_FIELDS`.
-      storage(::current::storage::MutableFieldByIndex<INDEX>(), Impl<KEY>(key));
+  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTfulWrapper<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+    template <class INPUT>
+    static Response Run(const INPUT& input) {
+      input.field.Erase(input.key);
+      return Response("Deleted.\n", HTTPResponseCode.NoContent);
     }
   };
 };
 
 template <class REST_IMPL, int INDEX, typename SERVER, typename STORAGE>
 struct RESTfulStorageEndpointRegisterer {
-  template <class VERB, int I, typename T>
-  using UserCode = typename REST_IMPL::template RESTfulWrapper<VERB, I, T>;
+  using T_STORAGE = STORAGE;
+  using T_IMMUTABLE_FIELDS = ImmutableFields<STORAGE>;
+  using T_MUTABLE_FIELDS = MutableFields<STORAGE>;
+
+  // Field accessor type for this `INDEX`.
+  // The type of `data.x` from within a `Transaction()`, where `x` is the field corresponding to index `INDEX`.
+  using T_SPECIFIC_FIELD = typename decltype(
+      std::declval<STORAGE>()(::current::storage::FieldTypeExtractor<INDEX>()))::T_PARTICULAR_FIELD;
+
+  template <class VERB, typename T1, typename T2, typename T3, typename T4>
+  using CustomHandler = typename REST_IMPL::template RESTfulWrapper<VERB, T1, T2, T3, T4>;
 
   SERVER& server;
   STORAGE& storage;
   RESTfulStorageEndpointRegisterer(SERVER& server, STORAGE& storage) : server(server), storage(storage) {}
 
-  // TODO: The code below assumes FIELD_TYPE is `Dictionary` for now, which is not true in general.
-  template <typename FIELD_TYPE, typename ENTRY_TYPE>
-  HTTPRoutesScopeEntry operator()(const char*, FIELD_TYPE, ENTRY_TYPE) {
+  template <typename FIELD_TYPE, typename ENTRY_TYPE_WRAPPER>
+  HTTPRoutesScopeEntry operator()(const char*, FIELD_TYPE, ENTRY_TYPE_WRAPPER) {
     auto& storage = this->storage;  // For lambdas.
-    return server.Register("/api/" + storage(::current::storage::FieldNameByIndex<INDEX>()),
-                           URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
-                           [&storage](Request r) {
-                             if (r.method == "GET") {
-                               if (r.url_path_args.size() != 1) {
-                                 r("TBD ERROR", HTTPResponseCode.BadRequest);
-                               } else {
-                                 const auto& key = r.url_path_args[0];
-                                 storage.Transaction([key, &storage](ImmutableFields<STORAGE>) -> Response {
-                                   return UserCode<GET, INDEX, typename ENTRY_TYPE::type>::Run(storage, key);
-                                 }, std::move(r)).Wait();
-                               }
-                             } else if (r.method == "POST") {
-                               if (!r.url_path_args.empty()) {
-                                 r("TBD ERROR", HTTPResponseCode.BadRequest);
-                               } else {
-                                 try {
-                                   const auto body = ParseJSON<typename ENTRY_TYPE::type>(r.body);
-                                   storage.Transaction([body, &storage](MutableFields<STORAGE>) {
-                                     UserCode<POST, INDEX, typename ENTRY_TYPE::type>::Run(storage, body);
-                                   }).Wait();
-                                   r("", HTTPResponseCode.NoContent);
-                                 } catch (const TypeSystemParseJSONException&) {
-                                   r("TBD ERROR", HTTPResponseCode.BadRequest);
-                                 }
-                               }
-                             } else if (r.method == "DELETE") {
-                               if (r.url_path_args.size() != 1) {
-                                 r("TBD ERROR", HTTPResponseCode.BadRequest);
-                               } else {
-                                 const auto& key = r.url_path_args[0];
-                                 storage.Transaction([key, &storage](MutableFields<STORAGE>) {
-                                   UserCode<DELETE, INDEX, typename ENTRY_TYPE::type>::Run(storage, key);
-                                 }).Wait();
-                                 r("", HTTPResponseCode.NoContent);
-                               }
-                             } else {
-                               r("", HTTPResponseCode.MethodNotAllowed);
-                             }
-                           });
+    return server.Register(
+        "/api/" + storage(::current::storage::FieldNameByIndex<INDEX>()),
+        URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
+        [&storage](Request request) {
+          if (request.method == "GET") {
+            if (request.url_path_args.size() != 1) {
+              request("Need resource key in the URL.", HTTPResponseCode.BadRequest);
+            } else {
+              const auto& key_as_string = request.url_path_args[0];
+              const auto key = FromString<typename ENTRY_TYPE_WRAPPER::T_KEY>(key_as_string);
+              const T_SPECIFIC_FIELD& field = storage(::current::storage::ImmutableFieldByIndex<INDEX>());
+              storage.Transaction([key, &storage, &field](T_IMMUTABLE_FIELDS fields) -> Response {
+                const struct {
+                  T_STORAGE& storage;
+                  T_IMMUTABLE_FIELDS fields;
+                  const T_SPECIFIC_FIELD& field;
+                  const typename ENTRY_TYPE_WRAPPER::T_KEY& key;
+                } args{storage, fields, field, key};
+
+                return CustomHandler<GET,
+                                     T_IMMUTABLE_FIELDS,
+                                     T_SPECIFIC_FIELD,
+                                     typename ENTRY_TYPE_WRAPPER::T_ENTRY,
+                                     typename ENTRY_TYPE_WRAPPER::T_KEY>::Run(args);
+              }, std::move(request)).Detach();
+            }
+          } else if (request.method == "POST") {
+            if (!request.url_path_args.empty()) {
+              request("Should not have resource key in the URL", HTTPResponseCode.BadRequest);
+            } else {
+              try {
+                const auto body = ParseJSON<typename ENTRY_TYPE_WRAPPER::T_ENTRY>(request.body);
+                T_SPECIFIC_FIELD& field = storage(::current::storage::MutableFieldByIndex<INDEX>());
+                storage.Transaction([&storage, &field, body](T_MUTABLE_FIELDS fields) -> Response {
+                  const struct {
+                    T_STORAGE& storage;
+                    T_MUTABLE_FIELDS fields;
+                    T_SPECIFIC_FIELD& field;
+                    const typename ENTRY_TYPE_WRAPPER::T_ENTRY& entry;
+                  } args{storage, fields, field, body};
+                  return CustomHandler<POST,
+                                       T_IMMUTABLE_FIELDS,
+                                       T_SPECIFIC_FIELD,
+                                       typename ENTRY_TYPE_WRAPPER::T_ENTRY,
+                                       typename ENTRY_TYPE_WRAPPER::T_KEY>::Run(args);
+                }, std::move(request)).Detach();
+              } catch (const TypeSystemParseJSONException&) {
+                request("Bad JSON.", HTTPResponseCode.BadRequest);
+              }
+            }
+          } else if (request.method == "DELETE") {
+            if (request.url_path_args.size() != 1) {
+              request("Need resource key in the URL.", HTTPResponseCode.BadRequest);
+            } else {
+              const auto& key_as_string = request.url_path_args[0];
+              const auto key = FromString<typename ENTRY_TYPE_WRAPPER::T_KEY>(key_as_string);
+              T_SPECIFIC_FIELD& field = storage(::current::storage::MutableFieldByIndex<INDEX>());
+              storage.Transaction([&storage, &field, key](T_MUTABLE_FIELDS fields) -> Response {
+                const struct {
+                  T_STORAGE& storage;
+                  T_MUTABLE_FIELDS fields;
+                  T_SPECIFIC_FIELD& field;
+                  const typename ENTRY_TYPE_WRAPPER::T_KEY& key;
+                } args{storage, fields, field, key};
+                return CustomHandler<DELETE,
+                                     T_IMMUTABLE_FIELDS,
+                                     T_SPECIFIC_FIELD,
+                                     typename ENTRY_TYPE_WRAPPER::T_ENTRY,
+                                     typename ENTRY_TYPE_WRAPPER::T_KEY>::Run(args);
+              }, std::move(request)).Detach();
+            }
+          } else {
+            request("", HTTPResponseCode.MethodNotAllowed);
+          }
+        });
   }
 };
 
@@ -169,38 +175,32 @@ HTTPRoutesScopeEntry RegisterRESTfulStorageEndpoint(SERVER& server, STORAGE& sto
                  RESTfulStorageEndpointRegisterer<REST_IMPL, INDEX, SERVER, STORAGE>(server, storage));
 }
 
-template <class, typename>
-struct RegisterRESTfulStorageEndpoints;
-
-template <class REST_IMPL, int N, int... NS>
-struct RegisterRESTfulStorageEndpoints<REST_IMPL, current::variadic_indexes::indexes<N, NS...>> {
-  template <typename T_SERVER, typename T_STORAGE>
-  static void Run(HTTPRoutesScope& scope, T_SERVER& http_server, T_STORAGE& storage) {
-    scope += RegisterRESTfulStorageEndpoint<REST_IMPL, N>(http_server, storage);
-    RegisterRESTfulStorageEndpoints<REST_IMPL, current::variadic_indexes::indexes<NS...>>::Run(
-        scope, http_server, storage);
-  }
-};
-
-template <class REST_IMPL>
-struct RegisterRESTfulStorageEndpoints<REST_IMPL, current::variadic_indexes::indexes<>> {
-  template <typename T_SERVER, typename T_STORAGE>
-  static void Run(HTTPRoutesScope&, T_SERVER&, T_STORAGE&) {}
-};
-
 }  // namespace impl
 
 template <class T_STORAGE_IMPL, class T_REST_IMPL = impl::BasicREST>
-struct RESTfulStorage {
-  HTTPRoutesScope handlers_scope;
+class RESTfulStorage {
+ public:
   RESTfulStorage(T_STORAGE_IMPL& storage, int port) {
-    auto& http_server = HTTP(port);
-    impl::RegisterRESTfulStorageEndpoints<
-        T_REST_IMPL,
-        current::variadic_indexes::generate_indexes<T_STORAGE_IMPL::FieldsCount()>>::Run(handlers_scope,
-                                                                                         http_server,
-                                                                                         storage);
+    ForEachFieldByIndex<T_REST_IMPL, T_STORAGE_IMPL::FieldsCount()>::Run(handlers_scope, HTTP(port), storage);
   }
+
+ private:
+  HTTPRoutesScope handlers_scope;
+
+  template <class REST_IMPL, int I>
+  struct ForEachFieldByIndex {
+    template <typename T_SERVER, typename T_STORAGE>
+    static void Run(HTTPRoutesScope& scope, T_SERVER& http_server, T_STORAGE& storage) {
+      ForEachFieldByIndex<REST_IMPL, I - 1>::Run(scope, http_server, storage);
+      scope += impl::RegisterRESTfulStorageEndpoint<REST_IMPL, I - 1>(http_server, storage);
+    }
+  };
+
+  template <class REST_IMPL>
+  struct ForEachFieldByIndex<REST_IMPL, 0> {
+    template <typename T_SERVER, typename T_STORAGE>
+    static void Run(HTTPRoutesScope&, T_SERVER&, T_STORAGE&) {}
+  };
 };
 
 }  // namespace rest

--- a/Storage/rest/basic.h
+++ b/Storage/rest/basic.h
@@ -1,0 +1,109 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Maxim Zhurovich <zhurovich@gmail.com>
+          (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// `BasicREST` is a boilerplate example of how to customize RESTful access to Current Storage.
+// This basic implementation supports GET, POST, and DELETE, with rudimentary text-only messages on errors.
+
+#ifndef CURRENT_STORAGE_REST_BASIC_H
+#define CURRENT_STORAGE_REST_BASIC_H
+
+#include "../storage.h"
+
+#include "../../Blocks/HTTP/api.h"
+
+namespace current {
+namespace storage {
+namespace rest {
+
+struct BasicREST {
+  template <class HTTP_VERB, typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful;
+
+  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+    template <typename F>
+    void Enter(Request request, F&& next) {
+      if (request.url_path_args.size() != 1) {
+        request("Need resource key in the URL.\n", HTTPResponseCode.BadRequest);
+      } else {
+        next(std::move(request));
+      }
+    }
+    template <class INPUT>
+    Response Run(const INPUT& input) const {
+      const ImmutableOptional<ENTRY> result = input.field[input.key];
+      if (Exists(result)) {
+        return Value(result);
+      } else {
+        return Response("Nope.\n", HTTPResponseCode.NotFound);
+      }
+    }
+  };
+
+  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+    template <typename F>
+    void Enter(Request request, F&& next) {
+      if (!request.url_path_args.empty()) {
+        request("Should not have resource key in the URL.\n", HTTPResponseCode.BadRequest);
+      } else {
+        next(std::move(request));
+      }
+    }
+    template <class INPUT>
+    Response Run(const INPUT& input) const {
+      input.field.Add(input.entry);
+      return Response("Added.\n", HTTPResponseCode.NoContent);
+    }
+    static Response ErrorBadJSON() { return Response("Bad JSON.\n", HTTPResponseCode.BadRequest); }
+  };
+
+  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+    template <typename F>
+    void Enter(Request request, F&& next) {
+      if (request.url_path_args.size() != 1) {
+        request("Need resource key in the URL.", HTTPResponseCode.BadRequest);
+      } else {
+        next(std::move(request));
+      }
+    }
+    template <class INPUT>
+    Response Run(const INPUT& input) const {
+      input.field.Erase(input.key);
+      return Response("Deleted.\n", HTTPResponseCode.NoContent);
+    }
+  };
+
+  static Response ErrorMethodNotAllowed() {
+    return Response("Method not allowed.\n", HTTPResponseCode.MethodNotAllowed);
+  }
+};
+
+}  // namespace rest
+}  // namespace storage
+}  // namespace current
+
+#endif  // CURRENT_STORAGE_REST_BASIC_H

--- a/Storage/test.cc
+++ b/Storage/test.cc
@@ -24,6 +24,7 @@ SOFTWARE.
 *******************************************************************************/
 
 #include "docu/docu_2_code.cc"
+#include "docu/docu_3_code.cc"
 
 #include "storage.h"
 #include "api.h"

--- a/Storage/test.cc
+++ b/Storage/test.cc
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "docu/docu_2_code.cc"
 
 #include "storage.h"
-#include "rest.h"
+#include "api.h"
 
 #include "../Blocks/HTTP/api.h"
 

--- a/Storage/test.cc
+++ b/Storage/test.cc
@@ -219,10 +219,10 @@ TEST(TransactionalStorage, SmokeTest) {
 struct CurrentStorageTestMagicTypesExtractor {
   std::string& s;
   CurrentStorageTestMagicTypesExtractor(std::string& s) : s(s) {}
-  template <typename FIELD_TYPE, typename ENTRY_TYPE>
-  int operator()(const char* name, FIELD_TYPE, ENTRY_TYPE) {
-    s = std::string(name) + ", " + FIELD_TYPE::HumanReadableName() + ", " +
-        current::reflection::CurrentTypeName<typename ENTRY_TYPE::type>();
+  template <typename CONTAINER_TYPE_WRAPPER, typename ENTRY_TYPE_WRAPPER>
+  int operator()(const char* name, CONTAINER_TYPE_WRAPPER, ENTRY_TYPE_WRAPPER) {
+    s = std::string(name) + ", " + CONTAINER_TYPE_WRAPPER::HumanReadableName() + ", " +
+        current::reflection::CurrentTypeName<typename ENTRY_TYPE_WRAPPER::T_ENTRY>();
     return 42;  // Checked against via `::current::storage::FieldNameAndTypeByIndexAndReturn`.
   }
 };


### PR DESCRIPTION
Hi @mzhurovich 

Getting there. Done:

* Cleaned up template metaprogramming.
* Have dedicated template-selected per-method handlers now.
* The user logic class represents the state of the request itself, and the initial, pre-`Transaction` URL++ parsing logic is done by it too. Easy to inject custom code now, auth included.
* Separated REST itself and REST wrappers. As an example, have `Basic` and `Hypermedia` wrappers now.

Not done:
* "Proper" hypermedia (it formats errors as JSONs now, but returns objects plain straight still.)
* GET for the whole collection (I suggest we just return the array of strings on `/api/${field}` for now.)
* Support for anything other than `Dictionary`. (Should be easy as field type selector is already a template parameter of the implementation of RESTful wrappers.)
* Top-level URL listing possible fields accessible via the API.
* The top-level `make test` stopped passing, some `CURRENT_STRUCT` circular dependency in sight.

Thanks,
Dima