### PR TITLE
Removed an unused exception type.

### DIFF
--- a/Utils/JSONSchema/infer.h
+++ b/Utils/JSONSchema/infer.h
@@ -70,8 +70,6 @@ struct InferSchemaIncompatibleTypes : InferSchemaIncompatibleTypesBase {
                                          rhs.HumanReadableType() + "'.") {}
 };
 
-struct InferSchemaArrayAndObjectAreIncompatible : InferSchemaIncompatibleTypesBase {};
-
 namespace impl {
 
 inline bool IsValidCPPIdentifier(const std::string& s) {


### PR DESCRIPTION
A minor follow-up after https://github.com/c5t/Current/pull/361, removed a now unused `InferSchemaArrayAndObjectAreIncompatible`.

Regression-tested and confirmed auto-generated `.tsv` and `.h` match the ones before #361. Thank you!