### PR TITLE
Several fixes in persisters and Sherlock.

### DIFF
--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -94,7 +94,7 @@ template <typename ENTRY>
 class FilePersister {
  private:
   struct Impl {
-    const std::string& filename;
+    const std::string filename;
     idxts_t next_initializer;
     std::atomic<uint64_t> next_index;
     std::atomic<std::chrono::microseconds> next_timestamp;
@@ -211,6 +211,14 @@ class FilePersister {
   }
 
   uint64_t Size() const noexcept { return impl_->next_index; }
+
+  idxts_t LastIndexAndTimestamp() const noexcept {
+    if (impl_->next_index) {
+      return idxts_t(impl_->next_index - 1, impl_->next_timestamp.load() - std::chrono::microseconds(1));
+    } else {
+      return idxts_t();
+    }
+  }
 
   IterableRange Iterate(uint64_t begin_index, uint64_t end_index) const {
     if (end_index == static_cast<uint64_t>(-1)) {

--- a/Blocks/Persistence/memory.h
+++ b/Blocks/Persistence/memory.h
@@ -110,6 +110,15 @@ class MemoryPersister {
     return static_cast<uint64_t>(container_->entries.size());
   }
 
+  idxts_t LastIndexAndTimestamp() const noexcept {
+    std::lock_guard<std::mutex> lock(container_->mutex);
+    if (!container_->entries.empty()) {
+      return idxts_t(container_->entries.size(), container_->entries.back().first);
+    } else {
+      return idxts_t();
+    }
+  }
+
   IterableRange Iterate(uint64_t begin, uint64_t end) const {
     const uint64_t size = [this]() {
       std::lock_guard<std::mutex> lock(container_->mutex);

--- a/Sherlock/sherlock.h
+++ b/Sherlock/sherlock.h
@@ -71,8 +71,8 @@ SOFTWARE.
 // Both scopes can be `.Join()`-ed, which would be a blocking call waiting until the subscriber is done.
 // Asynchronous scope can also be `.Detach()`-ed, internally calling `std::thread::detach()`.
 // A detached subscriber will live until it decides to terminate. In case the stream itself would be
-// destructing, each subscriber, detached subscribers included, will be notified of stream termination, 
-// and the destructor of the stream object will wait for all subscribers, detached included, to terminate 
+// destructing, each subscriber, detached subscribers included, will be notified of stream termination,
+// and the destructor of the stream object will wait for all subscribers, detached included, to terminate
 // themselves.
 //
 // The `my_subscriber` object should be an instance of `StreamSubscriber<IMPL, ENTRY>`,
@@ -122,14 +122,10 @@ class StreamImpl {
   using T_ENTRY = ENTRY;
   using T_PERSISTENCE_LAYER = PERSISTENCE_LAYER<ENTRY>;
 
-  StreamImpl()
-      : storage_(std::make_shared<T_PERSISTENCE_LAYER>()),
-        last_idx_ts_(std::make_shared<current::WaitableAtomic<idxts_t>>()) {}
-
-  template <typename... EXTRA_PARAMS>
-  StreamImpl(EXTRA_PARAMS&&... extra_params)
-      : storage_(std::make_shared<T_PERSISTENCE_LAYER>(std::forward<EXTRA_PARAMS>(extra_params)...)),
-        last_idx_ts_(std::make_shared<current::WaitableAtomic<idxts_t>>()) {}
+  template <typename... ARGS>
+  StreamImpl(ARGS&&... args)
+      : storage_(std::make_shared<T_PERSISTENCE_LAYER>(std::forward<ARGS>(args)...)),
+        last_idx_ts_(std::make_shared<current::WaitableAtomic<idxts_t>>(storage_->LastIndexAndTimestamp())) {}
 
   StreamImpl(StreamImpl&& rhs) : storage_(std::move(rhs.storage_)), last_idx_ts_(std::move(rhs.last_idx_ts_)) {}
 

--- a/Sherlock/test.cc
+++ b/Sherlock/test.cc
@@ -181,7 +181,7 @@ TEST(Sherlock, SubscribeAndProcessThreeEntries) {
   }
   ASSERT_FALSE(d.subscriber_alive_);
 
-  std::vector<std::string> expected_values{"[0:10,2:30] 1", "[1:20,2:30] 2", "[2:30,2:30] 3"};
+  const std::vector<std::string> expected_values{"[0:10,2:30] 1", "[1:20,2:30] 2", "[2:30,2:30] 3"};
   // A careful condition, since the subscriber may process some or all entries before going out of scope.
   EXPECT_TRUE(
       CompareValuesMixedWithTerminate(d.results_, expected_values, SherlockTestProcessor::kTerminateStr))
@@ -209,7 +209,7 @@ TEST(Sherlock, SubscribeSynchronously) {
     ;  // Spin lock.
   }
 
-  std::vector<std::string> expected_values{"[0:40,2:60] 4", "[1:50,2:60] 5", "[2:60,2:60] 6"};
+  const std::vector<std::string> expected_values{"[0:40,2:60] 4", "[1:50,2:60] 5", "[2:60,2:60] 6"};
   // A careful condition, since the subscriber may process some or all entries before going out of scope.
   EXPECT_TRUE(
       CompareValuesMixedWithTerminate(d.results_, expected_values, SherlockTestProcessor::kTerminateStr))
@@ -234,7 +234,7 @@ TEST(Sherlock, SubscribeAsynchronously) {
     ;  // Spin lock.
   }
   EXPECT_EQ(3u, d.seen_);
-  std::vector<std::string> expected_values{"[0:40,2:60] 4", "[1:50,2:60] 5", "[2:60,2:60] 6"};
+  const std::vector<std::string> expected_values{"[0:40,2:60] 4", "[1:50,2:60] 5", "[2:60,2:60] 6"};
   EXPECT_EQ(Join(expected_values, ','), d.results_);  // No `TERMINATE` for an asyncronous subscriber.
   EXPECT_TRUE(d.subscriber_alive_);
   bar_stream.Publish(42);  // Need the 4th entry for the async subscriber to terminate.
@@ -477,7 +477,7 @@ TEST(Sherlock, ParsesFromFile) {
   }
   ASSERT_FALSE(d.subscriber_alive_);
 
-  std::vector<std::string> expected_values{"[0:100,2:300] 1", "[1:200,2:300] 2", "[2:300,2:300] 3"};
+  const std::vector<std::string> expected_values{"[0:100,2:300] 1", "[1:200,2:300] 2", "[2:300,2:300] 3"};
   // A careful condition, since the subscriber may process some or all entries before going out of scope.
   EXPECT_TRUE(
       CompareValuesMixedWithTerminate(d.results_, expected_values, SherlockTestProcessor::kTerminateStr))


### PR DESCRIPTION
@dkorolev This fixes two bugs:
1) `file.h` line 97
2) Sherlock didn't know last index and timestamp when started from non-empty persistence file.