### PR TITLE
REST modifications.

### DIFF
--- a/Storage/api.h
+++ b/Storage/api.h
@@ -86,44 +86,60 @@ struct RESTfulHandlerGenerator {
 
   STORAGE& storage;
   const std::string restful_url_prefix;
+  const std::string data_url_component;
 
-  RESTfulHandlerGenerator(STORAGE& storage, const std::string& restful_url_prefix)
-      : storage(storage), restful_url_prefix(restful_url_prefix) {}
+  RESTfulHandlerGenerator(STORAGE& storage,
+                          const std::string& restful_url_prefix,
+                          const std::string& data_url_component)
+      : storage(storage), restful_url_prefix(restful_url_prefix), data_url_component(data_url_component) {}
 
   template <typename FIELD_TYPE, typename ENTRY_TYPE_WRAPPER>
   STORAGE_HANDLERS_MAP_ENTRY operator()(const char* input_field_name, FIELD_TYPE, ENTRY_TYPE_WRAPPER) {
     auto& storage = this->storage;  // For lambdas.
     const std::string restful_url_prefix = this->restful_url_prefix;
+    const std::string data_url_component = this->data_url_component;
     const std::string field_name = input_field_name;
     return STORAGE_HANDLERS_MAP_ENTRY(
         field_name,
-        [&storage, restful_url_prefix, field_name](Request request) {
+        [&storage, restful_url_prefix, field_name, data_url_component](Request request) {
           if (request.method == "GET") {
             CustomHandler<GET,
                           T_IMMUTABLE_FIELDS,
                           T_SPECIFIC_FIELD,
                           typename ENTRY_TYPE_WRAPPER::T_ENTRY,
                           typename ENTRY_TYPE_WRAPPER::T_KEY> handler;
-            handler.Enter(
-                std::move(request),
-                [&handler, &storage, &restful_url_prefix, field_name](Request request,
-                                                                      const std::string& url_key) {
-                  const T_SPECIFIC_FIELD& field = storage(::current::storage::ImmutableFieldByIndex<INDEX>());
-                  storage.Transaction(
-                              [handler, url_key, &storage, &field, &restful_url_prefix, field_name](
-                                  T_IMMUTABLE_FIELDS fields) -> Response {
-                                const struct {
-                                  T_STORAGE& storage;
-                                  T_IMMUTABLE_FIELDS fields;
-                                  const T_SPECIFIC_FIELD& field;
-                                  const std::string& url_key;
-                                  const std::string& restful_url_prefix;
-                                  const std::string& field_name;
-                                } args{storage, fields, field, url_key, restful_url_prefix, field_name};
-                                return handler.Run(args);
-                              },
-                              std::move(request)).Detach();
-                });
+            handler.Enter(std::move(request),
+                          [&handler, &storage, &restful_url_prefix, field_name, data_url_component](
+                              Request request, const std::string& url_key) {
+                            const T_SPECIFIC_FIELD& field =
+                                storage(::current::storage::ImmutableFieldByIndex<INDEX>());
+                            storage.Transaction(
+                                        [handler,
+                                         url_key,
+                                         &storage,
+                                         &field,
+                                         &restful_url_prefix,
+                                         field_name,
+                                         data_url_component](T_IMMUTABLE_FIELDS fields) -> Response {
+                                          const struct {
+                                            T_STORAGE& storage;
+                                            T_IMMUTABLE_FIELDS fields;
+                                            const T_SPECIFIC_FIELD& field;
+                                            const std::string& url_key;
+                                            const std::string& restful_url_prefix;
+                                            const std::string& field_name;
+                                            const std::string& data_url_component;
+                                          } args{storage,
+                                                 fields,
+                                                 field,
+                                                 url_key,
+                                                 restful_url_prefix,
+                                                 field_name,
+                                                 data_url_component};
+                                          return handler.Run(args);
+                                        },
+                                        std::move(request)).Detach();
+                          });
           } else if (request.method == "POST") {
             CustomHandler<POST,
                           T_IMMUTABLE_FIELDS,
@@ -237,9 +253,12 @@ struct RESTfulHandlerGenerator {
 };
 
 template <class REST_IMPL, int INDEX, typename STORAGE>
-STORAGE_HANDLERS_MAP_ENTRY GenerateRESTfulHandler(STORAGE& storage, const std::string& restful_url_prefix) {
-  return storage(::current::storage::FieldNameAndTypeByIndexAndReturn<INDEX, STORAGE_HANDLERS_MAP_ENTRY>(),
-                 RESTfulHandlerGenerator<REST_IMPL, INDEX, STORAGE>(storage, restful_url_prefix));
+STORAGE_HANDLERS_MAP_ENTRY GenerateRESTfulHandler(STORAGE& storage,
+                                                  const std::string& restful_url_prefix,
+                                                  const std::string& data_url_component) {
+  return storage(
+      ::current::storage::FieldNameAndTypeByIndexAndReturn<INDEX, STORAGE_HANDLERS_MAP_ENTRY>(),
+      RESTfulHandlerGenerator<REST_IMPL, INDEX, STORAGE>(storage, restful_url_prefix, data_url_component));
 }
 
 }  // namespace impl
@@ -265,7 +284,7 @@ class RESTfulStorage {
     }
     // Fill in the map of `Storage field name` -> `HTTP handler`.
     ForEachFieldByIndex<void, T_STORAGE_IMPL::FieldsCount()>::RegisterIt(
-        storage, restful_url_prefix, handlers_);
+        storage, restful_url_prefix, data_url_component, handlers_);
     // Register handlers on a specific port under a specific path prefix.
     for (const auto& handler : handlers_) {
       const std::string route = route_prefix + '/' + data_url_component_ + '/' + handler.first;
@@ -325,21 +344,25 @@ class RESTfulStorage {
   struct ForEachFieldByIndex {
     static void RegisterIt(T_STORAGE_IMPL& storage,
                            const std::string& restful_url_prefix,
+                           const std::string& data_url_component,
                            impl::STORAGE_HANDLERS_MAP& handlers) {
-      ForEachFieldByIndex<BLAH, I - 1>::RegisterIt(storage, restful_url_prefix, handlers);
+      ForEachFieldByIndex<BLAH, I - 1>::RegisterIt(storage, restful_url_prefix, data_url_component, handlers);
       using T_SPECIFIC_ENTRY_TYPE =
           typename impl::RESTfulHandlerGenerator<T_REST_IMPL, I - 1, T_STORAGE_IMPL>::T_SPECIFIC_ENTRY_TYPE;
       current::metaprogramming::CallIf<
           FieldExposedViaREST<T_STORAGE_IMPL, T_SPECIFIC_ENTRY_TYPE>::exposed>::With([&] {
-        handlers.insert(
-            impl::GenerateRESTfulHandler<T_REST_IMPL, I - 1, T_STORAGE_IMPL>(storage, restful_url_prefix));
+        handlers.insert(impl::GenerateRESTfulHandler<T_REST_IMPL, I - 1, T_STORAGE_IMPL>(
+            storage, restful_url_prefix, data_url_component));
       });
     }
   };
 
   template <typename BLAH>
   struct ForEachFieldByIndex<BLAH, 0> {
-    static void RegisterIt(T_STORAGE_IMPL&, const std::string&, impl::STORAGE_HANDLERS_MAP&) {}
+    static void RegisterIt(T_STORAGE_IMPL&,
+                           const std::string&,
+                           const std::string&,
+                           impl::STORAGE_HANDLERS_MAP&) {}
   };
 
   static void Serve503(Request r) {

--- a/Storage/api.h
+++ b/Storage/api.h
@@ -268,17 +268,14 @@ class RESTfulStorage {
  public:
   RESTfulStorage(T_STORAGE_IMPL& storage,
                  int port,
-                 const std::string& route_prefix = "/api",
-                 const std::string& restful_url_prefix_input = "",
+                 const std::string& route_prefix,
+                 const std::string& restful_url_prefix_input,
                  const std::string& data_url_component = "data")
       : port_(port),
         up_status_(std::make_unique<std::atomic_bool>(true)),
         route_prefix_(route_prefix),
         data_url_component_(data_url_component) {
-    const std::string restful_url_prefix = restful_url_prefix_input.empty()
-                                               ? "http://localhost:" + current::ToString(port)
-                                               : restful_url_prefix_input;
-
+    const std::string restful_url_prefix = restful_url_prefix_input;
     if (!route_prefix.empty() && route_prefix.back() == '/') {
       CURRENT_THROW(current::Exception("`route_prefix` should not end with a slash."));  // LCOV_EXCL_LINE
     }

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -123,7 +123,7 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
   {
     const auto result = HTTP(GET(base_url + "/api2/data/client"));
     EXPECT_EQ(200, static_cast<int>(result.code));
-    EXPECT_EQ("{\"url\":\"" + base_url + "/client\",\"data\":[]}\n", result.body);
+    EXPECT_EQ("{\"url\":\"" + base_url + "/data/client\",\"data\":[]}\n", result.body);
   }
 
   // GET a non-existing resource.
@@ -258,11 +258,11 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
     EXPECT_EQ(200, static_cast<int>(result.code));
     EXPECT_EQ(
         "{"
-        "\"url\":\"" + base_url + "/client\","
+        "\"url\":\"" + base_url + "/data/client\","
         "\"data\":[\"" +
-        base_url + "/client/101\",\"" +
-        base_url + "/client/102\",\"" +
-        base_url + "/client/" + client1_key_str + "\"" +
+        base_url + "/data/client/101\",\"" +
+        base_url + "/data/client/102\",\"" +
+        base_url + "/data/client/" + client1_key_str + "\"" +
         "]}\n",
         result.body);
   }

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -82,15 +82,17 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
 
   TestStorage storage;
 
-  const auto rest1 = RESTfulStorage<TestStorage>(storage, FLAGS_client_storage_test_port, "/api1");
+  const auto rest1 = RESTfulStorage<TestStorage>(storage, FLAGS_client_storage_test_port, "/api1", "http://example.current.ai/api1");
   const auto rest2 = RESTfulStorage<TestStorage, current::storage::rest::Hypermedia>(
       storage,
       FLAGS_client_storage_test_port,
-      "/api2");
+      "/api2",
+      "http://example.current.ai/api2");
   const auto rest3 = RESTfulStorage<TestStorage, current::storage::rest::AdvancedHypermedia>(
       storage,
       FLAGS_client_storage_test_port,
-      "/api3");
+      "/api3",
+      "http://example.current.ai/api3");
 
   const auto base_url = current::strings::Printf("http://localhost:%d", FLAGS_client_storage_test_port);
 
@@ -105,7 +107,7 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
     {
       const auto result = HTTP(GET(base_url + "/api2"));
       EXPECT_EQ(200, static_cast<int>(result.code));
-      EXPECT_EQ(base_url + "/status", ParseJSON<HypermediaRESTTopLevel>(result.body).url_status);
+      EXPECT_EQ("http://example.current.ai/api2/status", ParseJSON<HypermediaRESTTopLevel>(result.body).url_status);
     }
     {
       const auto result = HTTP(GET(base_url + "/api2/status"));
@@ -123,7 +125,7 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
   {
     const auto result = HTTP(GET(base_url + "/api2/data/client"));
     EXPECT_EQ(200, static_cast<int>(result.code));
-    EXPECT_EQ("{\"url\":\"" + base_url + "/data/client\",\"data\":[]}\n", result.body);
+    EXPECT_EQ("{\"url\":\"http://example.current.ai/api2/data/client\",\"data\":[]}\n", result.body);
   }
 
   // GET a non-existing resource.
@@ -258,11 +260,11 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
     EXPECT_EQ(200, static_cast<int>(result.code));
     EXPECT_EQ(
         "{"
-        "\"url\":\"" + base_url + "/data/client\","
-        "\"data\":[\"" +
-        base_url + "/data/client/101\",\"" +
-        base_url + "/data/client/102\",\"" +
-        base_url + "/data/client/" + client1_key_str + "\"" +
+        "\"url\":\"http://example.current.ai/api2/data/client\","
+        "\"data\":[\""
+        "http://example.current.ai/api2/data/client/101\",\""
+        "http://example.current.ai/api2/data/client/102\",\""
+        "http://example.current.ai/api2/data/client/" + client1_key_str + "\"" +
         "]}\n",
         result.body);
   }
@@ -270,7 +272,7 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
     const auto result = HTTP(GET(base_url + "/api3/data/client"));
     EXPECT_EQ(200, static_cast<int>(result.code));
     // Shamelessly copy-pasted from the output. -- D.K.
-    EXPECT_EQ("{\"url\":\"" + base_url + "/data/client?i=0&n=10\",\"url_directory\":\"" + base_url + "/data/client\",\"i\":0,\"n\":3,\"total\":3,\"url_next_page\":null,\"url_previous_page\":null,\"data\":[{\"url\":\"" + base_url + "/data/client/101\",\"url_full\":\"" + base_url + "/data/client/101\",\"url_brief\":\"" + base_url + "/data/client/101?fields=brief\",\"url_directory\":\"" + base_url + "/data/client\",\"data\":{\"key\":101,\"name\":\"John Doe\"}},{\"url\":\"" + base_url + "/data/client/102\",\"url_full\":\"" + base_url + "/data/client/102\",\"url_brief\":\"" + base_url + "/data/client/102?fields=brief\",\"url_directory\":\"" + base_url + "/data/client\",\"data\":{\"key\":102,\"name\":\"John Doe\"}},{\"url\":\"" + base_url + "/data/client/" + client1_key_str + "\",\"url_full\":\"" + base_url + "/data/client/" + client1_key_str + "\",\"url_brief\":\"" + base_url + "/data/client/" + client1_key_str + "?fields=brief\",\"url_directory\":\"" + base_url + "/data/client\",\"data\":{\"key\":" + client1_key_str + ",\"name\":\"Jane Doe\"}}]}",
+    EXPECT_EQ("{\"url\":\"http://example.current.ai/api3/data/client?i=0&n=10\",\"url_directory\":\"http://example.current.ai/api3/data/client\",\"i\":0,\"n\":3,\"total\":3,\"url_next_page\":null,\"url_previous_page\":null,\"data\":[{\"url\":\"http://example.current.ai/api3/data/client/101\",\"url_full\":\"http://example.current.ai/api3/data/client/101\",\"url_brief\":\"http://example.current.ai/api3/data/client/101?fields=brief\",\"url_directory\":\"http://example.current.ai/api3/data/client\",\"data\":{\"key\":101,\"name\":\"John Doe\"}},{\"url\":\"http://example.current.ai/api3/data/client/102\",\"url_full\":\"http://example.current.ai/api3/data/client/102\",\"url_brief\":\"http://example.current.ai/api3/data/client/102?fields=brief\",\"url_directory\":\"http://example.current.ai/api3/data/client\",\"data\":{\"key\":102,\"name\":\"John Doe\"}},{\"url\":\"http://example.current.ai/api3/data/client/" + client1_key_str + "\",\"url_full\":\"http://example.current.ai/api3/data/client/" + client1_key_str + "\",\"url_brief\":\"http://example.current.ai/api3/data/client/" + client1_key_str + "?fields=brief\",\"url_directory\":\"http://example.current.ai/api3/data/client\",\"data\":{\"key\":" + client1_key_str + ",\"name\":\"Jane Doe\"}}]}",
         result.body);
   }
 

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -82,7 +82,10 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
 
   TestStorage storage;
 
-  const auto rest1 = RESTfulStorage<TestStorage>(storage, FLAGS_client_storage_test_port, "/api1", "http://example.current.ai/api1");
+  const auto rest1 = RESTfulStorage<TestStorage>(
+      storage,
+      FLAGS_client_storage_test_port,
+      "/api1", "http://example.current.ai/api1");
   const auto rest2 = RESTfulStorage<TestStorage, current::storage::rest::Hypermedia>(
       storage,
       FLAGS_client_storage_test_port,

--- a/Storage/rest/advanced_hypermedia.h
+++ b/Storage/rest/advanced_hypermedia.h
@@ -32,6 +32,7 @@ SOFTWARE.
 #define CURRENT_STORAGE_REST_ADVANCED_HYPERMEDIA_H
 
 #include "hypermedia.h"
+#include "sfinae.h"
 
 CURRENT_STRUCT(AdvancedHypermediaRESTRecordResponse) {
   CURRENT_FIELD(url, std::string);
@@ -61,7 +62,7 @@ static std::string json_content_type = current::net::HTTPServerConnection::Defau
 template <typename T, typename INPUT, typename TT>
 std::string FormatAsAdvancedHypermediaRecord(TT& record, const INPUT& input) {
   AdvancedHypermediaRESTRecordResponse response_builder;
-  const std::string key_as_string = current::ToString(sfinae::GetKey(record));
+  const std::string key_as_string = current::ToString(current::storage::sfinae::GetKey(record));
   response_builder.url_directory = input.restful_url_prefix + "/data/" + input.field_name;
   response_builder.url = response_builder.url_directory + '/' + key_as_string;
   response_builder.url_full = response_builder.url;
@@ -78,7 +79,7 @@ struct AdvancedHypermedia : Hypermedia {
 
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
-    using T_BRIEF_ENTRY = typename ENTRY::T_BRIEF;
+    using T_BRIEF_ENTRY = sfinae::BRIEF_OF_T<ENTRY>;
 
     // For per-record view, whether a full or brief format should be used.
     bool brief = false;

--- a/Storage/rest/hypermedia.h
+++ b/Storage/rest/hypermedia.h
@@ -136,7 +136,7 @@ struct Hypermedia {
         }
       } else {
         HypermediaRESTContainerResponse response;
-        response.url = input.restful_url_prefix + '/' + input.field_name;
+        response.url = input.restful_url_prefix + '/' + input.data_url_component + '/' + input.field_name;
         for (const auto& element : input.field) {
           response.data.emplace_back(response.url + '/' + current::ToString(sfinae::GetKey(element)));
         }

--- a/Storage/rest/sfinae.h
+++ b/Storage/rest/sfinae.h
@@ -1,0 +1,67 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Maxim Zhurovich <zhurovich@gmail.com>
+          (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_STORAGE_REST_SFINAE_H
+#define CURRENT_STORAGE_REST_SFINAE_H
+
+#include "../storage.h"
+
+namespace current {
+namespace storage {
+namespace rest {
+namespace sfinae {
+
+template <typename T>
+constexpr bool Has_T_BRIEF(char) {
+  return false;
+}
+
+template <typename T>
+constexpr auto Has_T_BRIEF(int) -> decltype(sizeof(typename T::T_BRIEF), bool()) {
+  return true;
+}
+
+template <typename T, bool>
+struct BRIEF_OF_T_IMPL;
+
+template <typename T>
+struct BRIEF_OF_T_IMPL<T, false> {
+  using type = T;
+};
+
+template <typename T>
+struct BRIEF_OF_T_IMPL<T, true> {
+  using type = typename T::T_BRIEF;
+};
+
+template <typename T>
+using BRIEF_OF_T = typename BRIEF_OF_T_IMPL<T, Has_T_BRIEF<T>(0)>::type;
+
+}  // namespace sfinae
+}  // namespace rest
+}  // namespace storage
+}  // namespace current
+
+#endif  // CURRENT_STORAGE_REST_SFINAE_H

--- a/Storage/transaction.h
+++ b/Storage/transaction.h
@@ -42,6 +42,7 @@ CURRENT_STRUCT(TransactionMeta) {
 };
 
 CURRENT_STRUCT_T(Transaction) {
+  using T_VARIANT = T;
   CURRENT_FIELD(meta, TransactionMeta);
   CURRENT_FIELD(mutations, std::vector<T>);
   CURRENT_USE_FIELD_AS_TIMESTAMP(meta.timestamp);


### PR DESCRIPTION
Hi @mzhurovich ,

1. Made sure `/data/` is where it should be in hypermedia RESTful responses.
2. While fixing nasty bugs, thought of it more, and made both `route` and `url_prefix_route` (internal and external HTTP routes) required parameter for `RESTful` API. Hope you're cool with this.

Thanks,
Dima
