### PR TITLE
Lowercased header names.

### DIFF
--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -58,8 +58,8 @@ const char kCRLF[] = "\r\n";
 const size_t kCRLFLength = strings::CompileTimeStringLength(kCRLF);
 const char kHeaderKeyValueSeparator[] = ": ";
 const size_t kHeaderKeyValueSeparatorLength = strings::CompileTimeStringLength(kHeaderKeyValueSeparator);
-const char* const kLowercaseContentLengthHeaderKey = "content-length";
-const char* const kLowercaseTransferEncodingHeaderKey = "transfer-encoding";
+const char* const kLowercaseContentLengthHeaderKey = "content_length";
+const char* const kLowercaseTransferEncodingHeaderKey = "transfer_encoding";
 const char* const kTransferEncodingChunkedValue = "chunked";  // Is this lowercase too? @sompylasar
 
 }  // namespace constants
@@ -256,6 +256,8 @@ class TemplatedHTTPRequestData : public HELPER {
               // Because `std::tolower` needs locale these days. -- D.K.
               if (c >= 'A' && c <= 'Z') {
                 c += 'a' - 'A';
+              } else if (c == '-') {
+                c = '_';
               }
             });
             HELPER::OnHeader(key, value);

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -58,9 +58,9 @@ const char kCRLF[] = "\r\n";
 const size_t kCRLFLength = strings::CompileTimeStringLength(kCRLF);
 const char kHeaderKeyValueSeparator[] = ": ";
 const size_t kHeaderKeyValueSeparatorLength = strings::CompileTimeStringLength(kHeaderKeyValueSeparator);
-const char* const kContentLengthHeaderKey = "Content-Length";
-const char* const kTransferEncodingHeaderKey = "Transfer-Encoding";
-const char* const kTransferEncodingChunkedValue = "chunked";
+const char* const kLowercaseContentLengthHeaderKey = "content-length";
+const char* const kLowercaseTransferEncodingHeaderKey = "transfer-encoding";
+const char* const kTransferEncodingChunkedValue = "chunked";  // Is this lowercase too? @sompylasar
 
 }  // namespace constants
 
@@ -252,10 +252,16 @@ class TemplatedHTTPRequestData : public HELPER {
             *p = '\0';
             const char* const key = &buffer_[current_line_offset];
             const char* const value = p + kHeaderKeyValueSeparatorLength;
+            std::for_each(&buffer_[current_line_offset], p, [](char& c) {
+              // Because `std::tolower` needs locale these days. -- D.K.
+              if (c >= 'A' && c <= 'Z') {
+                c += 'a' - 'A';
+              }
+            });
             HELPER::OnHeader(key, value);
-            if (!strcmp(key, kContentLengthHeaderKey)) {
+            if (!strcmp(key, kLowercaseContentLengthHeaderKey)) {
               body_length = static_cast<size_t>(atoi(value));
-            } else if (!strcmp(key, kTransferEncodingHeaderKey)) {
+            } else if (!strcmp(key, kLowercaseTransferEncodingHeaderKey)) {
               if (!strcmp(value, kTransferEncodingChunkedValue)) {
                 chunked_transfer_encoding = true;
               }

--- a/Bricks/net/http/test.cc
+++ b/Bricks/net/http/test.cc
@@ -98,6 +98,31 @@ TEST(PosixHTTPServerTest, Smoke) {
   t.join();
 }
 
+TEST(PosixHTTPServerTest, SmokeWithCaseInsensitiveHeader) {
+  thread t([](Socket s) {
+    HTTPServerConnection c(s.Accept());
+    EXPECT_EQ("POST", c.HTTPRequest().Method());
+    EXPECT_EQ("/", c.HTTPRequest().RawPath());
+    c.SendHTTPResponse("Data: " + c.HTTPRequest().Body());
+  }, Socket(FLAGS_net_http_test_port));
+  Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host: localhost\r\n", true);
+  connection.BlockingWrite("content-length: 4\r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("BODY", true);
+  connection.BlockingWrite("\r\n", false);
+  ExpectToReceive(
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
+      "Content-Length: 10\r\n"
+      "\r\n"
+      "Data: BODY",
+      connection);
+  t.join();
+}
+
 TEST(PosixHTTPServerTest, SmokeWithArray) {
   thread t([](Socket s) {
     HTTPServerConnection c(s.Accept());

--- a/EventCollector/example.cc
+++ b/EventCollector/example.cc
@@ -30,7 +30,7 @@ SOFTWARE.
 
 DEFINE_int32(port, 8686, "Port to spawn log collector on.");
 DEFINE_string(route, "/log", "The route to listen to events on.");
-DEFINE_int64(tick_interval_ms, 1000, "Maximum interval between entries.");
+DEFINE_int64(tick_interval_ms, 60 * 1000, "Maximum interval between entries.");
 
 int main(int argc, char **argv) {
   ParseDFlags(&argc, &argv);


### PR DESCRIPTION
Hey @mzhurovich @sompylasar !

Here's one heck of perfect timing of the Universe.

Same day we talked about header names being case-insensitive, it hits us in practice: Orchard's response sends `content-length` without capitalization.

Questions:
* Shall we lowercase all headers like I just did?
* Or shall we only do case-insensitive comparison instead of `std::strcmp`?

Thanks,
Dima