### PR TITLE
REST matrix support prototype.

### DIFF
--- a/Storage/api.h
+++ b/Storage/api.h
@@ -195,7 +195,7 @@ struct RESTfulHandlerGenerator {
                   try {
                     const auto url_key = current::FromString<typename ENTRY_TYPE_WRAPPER::T_KEY>(key_as_string);
                     const auto entry = ParseJSON<typename ENTRY_TYPE_WRAPPER::T_ENTRY>(request.body);
-                    const auto entry_key = current::storage::sfinae::GetKey(entry);
+                    const auto entry_key = PerStorageFieldType<T_SPECIFIC_FIELD>::ExtractOrComposeKey(entry);
                     T_SPECIFIC_FIELD& field = storage(::current::storage::MutableFieldByIndex<INDEX>());
                     storage.Transaction(
                                 [handler,

--- a/Storage/base.h
+++ b/Storage/base.h
@@ -182,6 +182,14 @@ struct FieldsBase : BASE {
   MutationJournal current_storage_mutation_journal_;
 };
 
+// Field tags for REST calls dispatching.
+namespace rest {
+namespace behavior {
+struct Dictionary {};
+struct Matrix {};
+}  // namespace rest::behavior
+}  // namespace rest
+
 }  // namespace storage
 }  // namespace current
 

--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -42,6 +42,7 @@ class GenericDictionary {
  public:
   using T_KEY = sfinae::ENTRY_KEY_TYPE<T>;
   using T_MAP = MAP<T_KEY, T>;
+  using T_REST_BEHAVIOR = rest::behavior::Dictionary;
 
   explicit GenericDictionary(MutationJournal& journal) : journal_(journal) {}
 

--- a/Storage/container/sfinae.h
+++ b/Storage/container/sfinae.h
@@ -125,6 +125,13 @@ struct ROW_ACCESSOR_IMPL<ENTRY, true> {
   static void SetRow(ENTRY& entry, CF<T_ROW> row) { entry.set_row(row); }
 };
 
+template <typename ROW, typename COL>
+struct ROW_ACCESSOR_IMPL<std::pair<ROW, COL>, false> {
+  typedef ROW T_ROW;
+  static CF<T_ROW> GetRow(const std::pair<ROW, COL>& entry) { return entry.first; }
+  static void SetRow(std::pair<ROW, COL>& entry, CF<T_ROW> row) { entry.first = row; }
+};
+
 template <typename ENTRY>
 using ROW_ACCESSOR = ROW_ACCESSOR_IMPL<ENTRY, HasRowFunction<ENTRY>(0)>;
 
@@ -167,6 +174,13 @@ struct COL_ACCESSOR_IMPL<ENTRY, true> {
   // Can not return a reference to a temporary.
   static const T_COL GetCol(const ENTRY& entry) { return entry.col(); }
   static void SetCol(ENTRY& entry, CF<T_COL> col) { entry.set_col(col); }
+};
+
+template <typename ROW, typename COL>
+struct COL_ACCESSOR_IMPL<std::pair<ROW, COL>, false> {
+  typedef COL T_COL;
+  static CF<T_COL> GetCol(const std::pair<COL, COL>& entry) { return entry.second; }
+  static void SetCol(std::pair<COL, COL>& entry, CF<T_COL> col) { entry.second = col; }
 };
 
 template <typename ENTRY>

--- a/Storage/rest/advanced_hypermedia.h
+++ b/Storage/rest/advanced_hypermedia.h
@@ -64,7 +64,8 @@ inline AdvancedHypermediaRESTRecordResponse<T> FormatAsAdvancedHypermediaRecord(
                                                                                 const INPUT& input,
                                                                                 bool set_success = true) {
   AdvancedHypermediaRESTRecordResponse<T> response;
-  const std::string key_as_string = current::ToString(current::storage::sfinae::GetKey(record));
+  const std::string key_as_string = current::ToString(
+      PerStorageFieldType<current::decay<decltype(input.field)>>::ExtractOrComposeKey(record));
   if (set_success) {
     response.success = true;
   }
@@ -130,7 +131,7 @@ struct AdvancedHypermedia : Hypermedia {
         uint64_t i = 0;
         bool has_previous_page = false;
         bool has_next_page = false;
-        for (const auto& element : input.field) {
+        for (const auto& element : PerStorageFieldType<PARTICULAR_FIELD>::Iterate(input.field)) {
           if (i >= query_i && i < query_i + query_n) {
             response.data.push_back(FormatAsAdvancedHypermediaRecord<T_BRIEF_ENTRY>(element, input, false));
           } else if (i < query_i) {

--- a/Storage/rest/sfinae.h
+++ b/Storage/rest/sfinae.h
@@ -59,6 +59,18 @@ struct BRIEF_OF_T_IMPL<T, true> {
 template <typename T>
 using BRIEF_OF_T = typename BRIEF_OF_T_IMPL<T, Has_T_BRIEF<T>(0)>::type;
 
+// TODO(dkorolev) + TODO(mzhurovich): Rename it into something `POST`-related, like `POSTKey()`?
+// TODO(dkorolev) + TODO(mzhurovich): Perhaps have it a `const` function returning the calculated key instead?
+template <typename T>
+constexpr bool HasInitializeOwnKey(char) {
+  return false;
+}
+
+template <typename T>
+constexpr auto HasInitializeOwnKey(int) -> decltype(std::declval<T>().InitializeOwnKey(), bool()) {
+  return true;
+}
+
 }  // namespace sfinae
 }  // namespace rest
 }  // namespace storage


### PR DESCRIPTION
Hi @mzhurovich 

REST is functional for matrices now, for some degree of "functional". Two bits of mess are:

1. `ToString` and `FromString`. They now support `std::pair<>`-s. I tried to compile CTFO too, which would probably coincide with extending `{To/From}String` and/or migrating to the proper `Serialize` altogether. In person in 12+ hours.

2. I've moved `HasInitializeOwnKey` to be `ENABLE_IF`-guarded. Now, for types that do not expose this method, `POST` would return `"Method not allowed"`. Let's decide what's the best logic here.

3. Helpers for "REST" "behavior". Not sure if the name is best. On the bright side, it does the job.

PTAL && thanks!
Dima