### PR TITLE
Storage meta fields access + REST API refactoring.

### DIFF
--- a/Storage/api.h
+++ b/Storage/api.h
@@ -81,8 +81,8 @@ struct RESTfulHandlerGenerator {
       decltype(std::declval<STORAGE>()(::current::storage::FieldEntryTypeExtractor<INDEX>()));
   using T_SPECIFIC_ENTRY_TYPE = typename T_SPECIFIC_ENTRY_TYPE_EXTRACTOR::T_PARTICULAR_FIELD;
 
-  template <class VERB, typename T1, typename T2, typename T3, typename T4>
-  using CustomHandler = typename T_REST_IMPL::template RESTful<VERB, T1, T2, T3, T4>;
+  template <class VERB, typename FIELD, typename ENTRY, typename KEY>
+  using CustomHandler = typename T_REST_IMPL::template RESTful<VERB, FIELD, ENTRY, KEY>;
 
   STORAGE& storage;
   const std::string restful_url_prefix;
@@ -100,26 +100,12 @@ struct RESTfulHandlerGenerator {
     const std::string data_url_component = this->data_url_component;
     const std::string field_name = input_field_name;
 
-    using GETHandler = CustomHandler<GET,
-                                     T_IMMUTABLE_FIELDS,
-                                     T_SPECIFIC_FIELD,
-                                     typename ENTRY_TYPE_WRAPPER::T_ENTRY,
-                                     typename ENTRY_TYPE_WRAPPER::T_KEY>;
-    using POSTHandler = CustomHandler<POST,
-                                      T_MUTABLE_FIELDS,
-                                      T_SPECIFIC_FIELD,
-                                      typename ENTRY_TYPE_WRAPPER::T_ENTRY,
-                                      typename ENTRY_TYPE_WRAPPER::T_KEY>;
-    using PUTHandler = CustomHandler<PUT,
-                                     T_MUTABLE_FIELDS,
-                                     T_SPECIFIC_FIELD,
-                                     typename ENTRY_TYPE_WRAPPER::T_ENTRY,
-                                     typename ENTRY_TYPE_WRAPPER::T_KEY>;
-    using DELETEHandler = CustomHandler<DELETE,
-                                        T_MUTABLE_FIELDS,
-                                        T_SPECIFIC_FIELD,
-                                        typename ENTRY_TYPE_WRAPPER::T_ENTRY,
-                                        typename ENTRY_TYPE_WRAPPER::T_KEY>;
+    using T_ENTRY = typename ENTRY_TYPE_WRAPPER::T_ENTRY;
+    using T_KEY = typename ENTRY_TYPE_WRAPPER::T_KEY;
+    using GETHandler = CustomHandler<GET, T_SPECIFIC_FIELD, T_ENTRY, T_KEY>;
+    using POSTHandler = CustomHandler<POST, T_SPECIFIC_FIELD, T_ENTRY, T_KEY>;
+    using PUTHandler = CustomHandler<PUT, T_SPECIFIC_FIELD, T_ENTRY, T_KEY>;
+    using DELETEHandler = CustomHandler<DELETE, T_SPECIFIC_FIELD, T_ENTRY, T_KEY>;
 
     return STORAGE_HANDLERS_MAP_ENTRY(
         field_name,

--- a/Storage/api_base.h
+++ b/Storage/api_base.h
@@ -48,14 +48,14 @@ struct RESTfulGenericInput {
 
 template <typename STORAGE, typename FIELD>
 struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS = MutableFields<STORAGE>;
-  T_ALL_FIELDS fields;
+  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
+  T_ALL_FIELDS_BY_REFERENCE fields;
   const FIELD& field;
   const std::string field_name;
   const std::string url_key;
 
   RESTfulGETInput(const RESTfulGenericInput<STORAGE>& input,
-                  T_ALL_FIELDS fields,
+                  T_ALL_FIELDS_BY_REFERENCE fields,
                   const FIELD& field,
                   const std::string& field_name,
                   const std::string& url_key)
@@ -65,7 +65,7 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
         field_name(field_name),
         url_key(url_key) {}
   RESTfulGETInput(RESTfulGenericInput<STORAGE>&& input,
-                  T_ALL_FIELDS fields,
+                  T_ALL_FIELDS_BY_REFERENCE fields,
                   const FIELD& field,
                   const std::string& field_name,
                   const std::string& url_key)
@@ -78,14 +78,14 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD, typename ENTRY>
 struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS = MutableFields<STORAGE>;
-  T_ALL_FIELDS fields;
+  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
+  T_ALL_FIELDS_BY_REFERENCE fields;
   FIELD& field;
   const std::string field_name;
   ENTRY& entry;
 
   RESTfulPOSTInput(const RESTfulGenericInput<STORAGE>& input,
-                   T_ALL_FIELDS fields,
+                   T_ALL_FIELDS_BY_REFERENCE fields,
                    FIELD& field,
                    const std::string& field_name,
                    ENTRY& entry)
@@ -95,7 +95,7 @@ struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
         field_name(field_name),
         entry(entry) {}
   RESTfulPOSTInput(RESTfulGenericInput<STORAGE>&& input,
-                   T_ALL_FIELDS fields,
+                   T_ALL_FIELDS_BY_REFERENCE fields,
                    FIELD& field,
                    const std::string& field_name,
                    ENTRY& entry)
@@ -108,8 +108,8 @@ struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD, typename ENTRY, typename KEY>
 struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS = MutableFields<STORAGE>;
-  T_ALL_FIELDS fields;
+  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
+  T_ALL_FIELDS_BY_REFERENCE fields;
   FIELD& field;
   const std::string field_name;
   const KEY& url_key;
@@ -117,7 +117,7 @@ struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
   const KEY& entry_key;
 
   RESTfulPUTInput(const RESTfulGenericInput<STORAGE>& input,
-                  T_ALL_FIELDS fields,
+                  T_ALL_FIELDS_BY_REFERENCE fields,
                   FIELD& field,
                   const std::string& field_name,
                   const KEY& url_key,
@@ -131,7 +131,7 @@ struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
         entry(entry),
         entry_key(entry_key) {}
   RESTfulPUTInput(RESTfulGenericInput<STORAGE>&& input,
-                  T_ALL_FIELDS fields,
+                  T_ALL_FIELDS_BY_REFERENCE fields,
                   FIELD& field,
                   const std::string& field_name,
                   const KEY& url_key,
@@ -148,20 +148,20 @@ struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD, typename KEY>
 struct RESTfulDELETEInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS = MutableFields<STORAGE>;
-  T_ALL_FIELDS fields;
+  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
+  T_ALL_FIELDS_BY_REFERENCE fields;
   FIELD& field;
   const std::string field_name;
   const KEY& key;
 
   RESTfulDELETEInput(const RESTfulGenericInput<STORAGE>& input,
-                     T_ALL_FIELDS fields,
+                     T_ALL_FIELDS_BY_REFERENCE fields,
                      FIELD& field,
                      const std::string& field_name,
                      const KEY& key)
       : RESTfulGenericInput<STORAGE>(input), fields(fields), field(field), field_name(field_name), key(key) {}
   RESTfulDELETEInput(RESTfulGenericInput<STORAGE>&& input,
-                     T_ALL_FIELDS fields,
+                     T_ALL_FIELDS_BY_REFERENCE fields,
                      FIELD& field,
                      const std::string& field_name,
                      const KEY& key)

--- a/Storage/api_base.h
+++ b/Storage/api_base.h
@@ -1,0 +1,179 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Maxim Zhurovich <zhurovich@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_STORAGE_API_BASE_H
+#define CURRENT_STORAGE_API_BASE_H
+
+#include "storage.h"
+
+namespace current {
+namespace storage {
+namespace rest {
+
+template <typename STORAGE>
+struct RESTfulGenericInput {
+  STORAGE& storage;
+  const std::string restful_url_prefix;
+  const std::string data_url_component;
+
+  explicit RESTfulGenericInput(STORAGE& storage) : storage(storage) {}
+  RESTfulGenericInput(STORAGE& storage,
+                      const std::string& restful_url_prefix,
+                      const std::string& data_url_component)
+      : storage(storage), restful_url_prefix(restful_url_prefix), data_url_component(data_url_component) {}
+  RESTfulGenericInput(const RESTfulGenericInput&) = default;
+  RESTfulGenericInput(RESTfulGenericInput&&) = default;
+};
+
+template <typename STORAGE, typename FIELD>
+struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
+  using T_ALL_FIELDS = MutableFields<STORAGE>;
+  T_ALL_FIELDS fields;
+  const FIELD& field;
+  const std::string field_name;
+  const std::string url_key;
+
+  RESTfulGETInput(const RESTfulGenericInput<STORAGE>& input,
+                  T_ALL_FIELDS fields,
+                  const FIELD& field,
+                  const std::string& field_name,
+                  const std::string& url_key)
+      : RESTfulGenericInput<STORAGE>(input),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        url_key(url_key) {}
+  RESTfulGETInput(RESTfulGenericInput<STORAGE>&& input,
+                  T_ALL_FIELDS fields,
+                  const FIELD& field,
+                  const std::string& field_name,
+                  const std::string& url_key)
+      : RESTfulGenericInput<STORAGE>(std::move(input)),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        url_key(url_key) {}
+};
+
+template <typename STORAGE, typename FIELD, typename ENTRY>
+struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
+  using T_ALL_FIELDS = MutableFields<STORAGE>;
+  T_ALL_FIELDS fields;
+  FIELD& field;
+  const std::string field_name;
+  ENTRY& entry;
+
+  RESTfulPOSTInput(const RESTfulGenericInput<STORAGE>& input,
+                   T_ALL_FIELDS fields,
+                   FIELD& field,
+                   const std::string& field_name,
+                   ENTRY& entry)
+      : RESTfulGenericInput<STORAGE>(input),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        entry(entry) {}
+  RESTfulPOSTInput(RESTfulGenericInput<STORAGE>&& input,
+                   T_ALL_FIELDS fields,
+                   FIELD& field,
+                   const std::string& field_name,
+                   ENTRY& entry)
+      : RESTfulGenericInput<STORAGE>(std::move(input)),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        entry(entry) {}
+};
+
+template <typename STORAGE, typename FIELD, typename ENTRY, typename KEY>
+struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
+  using T_ALL_FIELDS = MutableFields<STORAGE>;
+  T_ALL_FIELDS fields;
+  FIELD& field;
+  const std::string field_name;
+  const KEY& url_key;
+  const ENTRY& entry;
+  const KEY& entry_key;
+
+  RESTfulPUTInput(const RESTfulGenericInput<STORAGE>& input,
+                  T_ALL_FIELDS fields,
+                  FIELD& field,
+                  const std::string& field_name,
+                  const KEY& url_key,
+                  const ENTRY& entry,
+                  const KEY& entry_key)
+      : RESTfulGenericInput<STORAGE>(input),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        url_key(url_key),
+        entry(entry),
+        entry_key(entry_key) {}
+  RESTfulPUTInput(RESTfulGenericInput<STORAGE>&& input,
+                  T_ALL_FIELDS fields,
+                  FIELD& field,
+                  const std::string& field_name,
+                  const KEY& url_key,
+                  const ENTRY& entry,
+                  const KEY& entry_key)
+      : RESTfulGenericInput<STORAGE>(std::move(input)),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        url_key(url_key),
+        entry(entry),
+        entry_key(entry_key) {}
+};
+
+template <typename STORAGE, typename FIELD, typename KEY>
+struct RESTfulDELETEInput : RESTfulGenericInput<STORAGE> {
+  using T_ALL_FIELDS = MutableFields<STORAGE>;
+  T_ALL_FIELDS fields;
+  FIELD& field;
+  const std::string field_name;
+  const KEY& key;
+
+  RESTfulDELETEInput(const RESTfulGenericInput<STORAGE>& input,
+                     T_ALL_FIELDS fields,
+                     FIELD& field,
+                     const std::string& field_name,
+                     const KEY& key)
+      : RESTfulGenericInput<STORAGE>(input), fields(fields), field(field), field_name(field_name), key(key) {}
+  RESTfulDELETEInput(RESTfulGenericInput<STORAGE>&& input,
+                     T_ALL_FIELDS fields,
+                     FIELD& field,
+                     const std::string& field_name,
+                     const KEY& key)
+      : RESTfulGenericInput<STORAGE>(std::move(input)),
+        fields(fields),
+        field(field),
+        field_name(field_name),
+        key(key) {}
+};
+
+}  // namespace rest
+}  // namespace storage
+}  // namespace current
+
+#endif  // CURRENT_STORAGE_API_BASE_H

--- a/Storage/base.h
+++ b/Storage/base.h
@@ -180,6 +180,15 @@ struct MutationJournal {
 template <typename BASE>
 struct FieldsBase : BASE {
   MutationJournal current_storage_mutation_journal_;
+  TransactionMetaFields current_storage_transaction_meta_fields_;
+
+  void SetTransactionMetaField(const std::string& key, const std::string& value) {
+    current_storage_transaction_meta_fields_[key] = value;
+  }
+
+  void EraseTransactionMetaField(const std::string& key) {
+    current_storage_transaction_meta_fields_.erase(key);
+  }
 };
 
 // Field tags for REST calls dispatching.

--- a/Storage/base.h
+++ b/Storage/base.h
@@ -180,14 +180,13 @@ struct MutationJournal {
 template <typename BASE>
 struct FieldsBase : BASE {
   MutationJournal current_storage_mutation_journal_;
-  TransactionMetaFields current_storage_transaction_meta_fields_;
 
   void SetTransactionMetaField(const std::string& key, const std::string& value) {
-    current_storage_transaction_meta_fields_[key] = value;
+    current_storage_mutation_journal_.meta_fields[key] = value;
   }
 
   void EraseTransactionMetaField(const std::string& key) {
-    current_storage_transaction_meta_fields_.erase(key);
+    current_storage_mutation_journal_.meta_fields.erase(key);
   }
 };
 

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -423,10 +423,10 @@ struct RESTWithMeta: current::storage::rest::AdvancedHypermedia {
   struct RESTful: SUPER::RESTful<HTTP_VERB, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     using ACTUAL_SUPER = SUPER::RESTful<HTTP_VERB, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY>;
 
-    template <typename F>
-    void Enter(Request request, F&& next, current::storage::TransactionMetaFields& meta_fields) {
-      meta_fields.emplace("who", "unittest");
-      this->ACTUAL_SUPER::template Enter<F>(std::move(request), std::move(next), meta_fields);
+    template <class INPUT>
+    Response Run(const INPUT& input) const {
+      input.fields.SetTransactionMetaField("who", "unittest");
+      return this->ACTUAL_SUPER::template Run<INPUT>(input);
     }
   };
 };

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -42,7 +42,7 @@ SOFTWARE.
 
 #include "../../3rdparty/gtest/gtest.h"
 
-#ifndef _MSC_VER
+#ifndef CURRENT_WINDOWS
 DEFINE_string(client_storage_test_tmpdir,
               ".current",
               "Local path for the test to create temporary files in.");
@@ -416,7 +416,7 @@ TEST(StorageDocumentation, RESTifiedStorageExample) {
 namespace storage_docu {
 
 // Example of custom REST implementation that annotates transactions.
-struct RESTWithMeta: current::storage::rest::AdvancedHypermedia {
+struct RESTWithMeta : current::storage::rest::AdvancedHypermedia {
   using SUPER = current::storage::rest::AdvancedHypermedia;
 
   template <class HTTP_VERB, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
@@ -462,13 +462,12 @@ TEST(StorageDocumentation, RESTFillingTransactionMetaExample) {
       current::strings::Split<current::strings::ByLines>(current::FileSystem::ReadFileAsString(client_storage_file_name));
   ASSERT_EQ(2u, persisted_entries.size());
 
-  const std::string& persisted_add = persisted_entries[0];
-  const size_t tab_pos = persisted_add.find('\t');
-  ASSERT_FALSE(tab_pos == std::string::npos);
-  const auto idx_ts = ParseJSON<idxts_t>(persisted_add.substr(0, persisted_add.find('\t')));
+  const auto add_fields = current::strings::Split(persisted_entries[0], '\t');
+  ASSERT_TRUE(add_fields.size() == 2u);
+  const auto idx_ts = ParseJSON<idxts_t>(add_fields[0]);
   EXPECT_EQ(0u, idx_ts.index);
   EXPECT_EQ(1024, idx_ts.us.count());
-  const auto add_transaction = ParseJSON<TestStorage::T_TRANSACTION>(persisted_add.substr(tab_pos + 1));
+  const auto add_transaction = ParseJSON<TestStorage::T_TRANSACTION>(add_fields[1]);
   EXPECT_EQ(1024, add_transaction.meta.timestamp.count());
   ASSERT_EQ(1u, add_transaction.meta.fields.size());
   EXPECT_EQ("unittest", add_transaction.meta.fields.at("who"));
@@ -482,9 +481,9 @@ TEST(StorageDocumentation, RESTFillingTransactionMetaExample) {
   EXPECT_TRUE(client.straight);
   EXPECT_TRUE(client.male);
 
-  const std::string& persisted_delete = persisted_entries[1];
-  const auto del_transaction =
-      ParseJSON<TestStorage::T_TRANSACTION>(persisted_delete.substr(persisted_delete.find('\t') + 1));
+  const auto del_fields = current::strings::Split(persisted_entries[1], '\t');
+  ASSERT_TRUE(del_fields.size() == 2u);
+  const auto del_transaction = ParseJSON<TestStorage::T_TRANSACTION>(del_fields[1]);
   EXPECT_EQ(2000, del_transaction.meta.timestamp.count());
   ASSERT_EQ(1u, del_transaction.meta.fields.size());
   EXPECT_EQ("unittest", del_transaction.meta.fields.at("who"));

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -419,9 +419,9 @@ namespace storage_docu {
 struct RESTWithMeta: current::storage::rest::AdvancedHypermedia {
   using SUPER = current::storage::rest::AdvancedHypermedia;
 
-  template <class HTTP_VERB, typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful: SUPER::RESTful<HTTP_VERB, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
-    using ACTUAL_SUPER = SUPER::RESTful<HTTP_VERB, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY>;
+  template <class HTTP_VERB, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful: SUPER::RESTful<HTTP_VERB, PARTICULAR_FIELD, ENTRY, KEY> {
+    using ACTUAL_SUPER = SUPER::RESTful<HTTP_VERB, PARTICULAR_FIELD, ENTRY, KEY>;
 
     template <class INPUT>
     Response Run(const INPUT& input) const {

--- a/Storage/persister/file.h
+++ b/Storage/persister/file.h
@@ -57,6 +57,7 @@ class JSONFilePersister<TypeList<TS...>> {
     }
     journal.commit_log.clear();
     journal.rollback_log.clear();
+    journal.meta_fields.clear();
   }
 
   template <typename F>

--- a/Storage/persister/sherlock.h
+++ b/Storage/persister/sherlock.h
@@ -55,7 +55,7 @@ class SherlockStreamPersisterImpl<TypeList<TS...>, PERSISTER> {
         transaction.mutations.emplace_back(std::move(entry));
       }
       transaction.meta.timestamp = current::time::Now();
-      transaction.meta.fields = std::move(journal.meta_fields);
+      std::swap(transaction.meta.fields, journal.meta_fields);
       stream_.Publish(std::move(transaction));
       journal.commit_log.clear();
       journal.rollback_log.clear();

--- a/Storage/rest/advanced_hypermedia.h
+++ b/Storage/rest/advanced_hypermedia.h
@@ -95,7 +95,7 @@ struct AdvancedHypermedia : Hypermedia {
     mutable uint64_t query_n = 10u;  // Default page size.
 
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       const auto& q = request.url.query;
       brief = (q["fields"] == "brief");
       query_i = current::FromString<uint64_t>(q.get("i", current::ToString(query_i)));

--- a/Storage/rest/advanced_hypermedia.h
+++ b/Storage/rest/advanced_hypermedia.h
@@ -80,11 +80,11 @@ inline AdvancedHypermediaRESTRecordResponse<T> FormatAsAdvancedHypermediaRecord(
 struct AdvancedHypermedia : Hypermedia {
   using SUPER = Hypermedia;
 
-  template <class HTTP_VERB, typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful : SUPER::RESTful<HTTP_VERB, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {};
+  template <class HTTP_VERB, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful : SUPER::RESTful<HTTP_VERB, PARTICULAR_FIELD, ENTRY, KEY> {};
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<GET, PARTICULAR_FIELD, ENTRY, KEY> {
     using T_BRIEF_ENTRY = sfinae::BRIEF_OF_T<ENTRY>;
 
     // For per-record view, whether a full or brief format should be used.

--- a/Storage/rest/advanced_hypermedia.h
+++ b/Storage/rest/advanced_hypermedia.h
@@ -95,7 +95,7 @@ struct AdvancedHypermedia : Hypermedia {
     mutable uint64_t query_n = 10u;  // Default page size.
 
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       const auto& q = request.url.query;
       brief = (q["fields"] == "brief");
       query_i = current::FromString<uint64_t>(q.get("i", current::ToString(query_i)));

--- a/Storage/rest/basic.h
+++ b/Storage/rest/basic.h
@@ -87,7 +87,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       WithOptionalKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -114,7 +114,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       if (!request.url_path_args.empty()) {
         request("Should not have resource key in the URL.\n", HTTPResponseCode.BadRequest);
       } else {
@@ -148,7 +148,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<PUT, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -175,7 +175,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>

--- a/Storage/rest/basic.h
+++ b/Storage/rest/basic.h
@@ -87,7 +87,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       WithOptionalKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -114,7 +114,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       if (!request.url_path_args.empty()) {
         request("Should not have resource key in the URL.\n", HTTPResponseCode.BadRequest);
       } else {
@@ -148,7 +148,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<PUT, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -175,7 +175,7 @@ struct Basic {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>

--- a/Storage/rest/basic.h
+++ b/Storage/rest/basic.h
@@ -40,7 +40,7 @@ namespace storage {
 namespace rest {
 
 struct Basic {
-  template <class HTTP_VERB, typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  template <class HTTP_VERB, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful;
 
   static void RegisterTopLevel(HTTPRoutesScope& scope,
@@ -84,8 +84,8 @@ struct Basic {
         std::move(request), next, [&next](Request request) { next(std::move(request), ""); });
   }
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<GET, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       WithOptionalKeyFromURL(std::move(request), std::forward<F>(next));
@@ -111,8 +111,8 @@ struct Basic {
     }
   };
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<POST, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       if (!request.url_path_args.empty()) {
@@ -145,8 +145,8 @@ struct Basic {
     }
   };
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<PUT, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<PUT, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
@@ -172,8 +172,8 @@ struct Basic {
     // LCOV_EXCL_STOP
   };
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<DELETE, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));

--- a/Storage/rest/hypermedia.h
+++ b/Storage/rest/hypermedia.h
@@ -314,6 +314,7 @@ struct Hypermedia {
         const std::string url =
             input.restful_url_prefix + '/' + input.data_url_component + '/' + input.field_name + '/' + url_key;
         HypermediaRESTResourceUpdateResponse response(true);
+        response.resource_url = url;
         if (exists) {
           response.message = "Resource updated.";
           return Response(response, HTTPResponseCode.OK);

--- a/Storage/rest/hypermedia.h
+++ b/Storage/rest/hypermedia.h
@@ -226,7 +226,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       WithOptionalKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -258,7 +258,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       if (!request.url_path_args.empty()) {
         request(ErrorResponseObject(InvalidKeyError("Should not have resource key in the URL.")),
                 HTTPResponseCode.BadRequest);
@@ -302,7 +302,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<PUT, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -337,7 +337,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next) {
+    void Enter(Request request, F&& next, TransactionMetaFields&) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>

--- a/Storage/rest/hypermedia.h
+++ b/Storage/rest/hypermedia.h
@@ -226,7 +226,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       WithOptionalKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -258,7 +258,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       if (!request.url_path_args.empty()) {
         request(ErrorResponseObject(InvalidKeyError("Should not have resource key in the URL.")),
                 HTTPResponseCode.BadRequest);
@@ -302,7 +302,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<PUT, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>
@@ -337,7 +337,7 @@ struct Hypermedia {
   template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
-    void Enter(Request request, F&& next, TransactionMetaFields&) {
+    void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
     }
     template <class INPUT>

--- a/Storage/rest/hypermedia.h
+++ b/Storage/rest/hypermedia.h
@@ -167,7 +167,7 @@ inline HypermediaRESTError ResourceAlreadyExistsError(const std::string& message
 }
 
 struct Hypermedia {
-  template <class HTTP_VERB, typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  template <class HTTP_VERB, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful;
 
   static void RegisterTopLevel(HTTPRoutesScope& scope,
@@ -223,8 +223,8 @@ struct Hypermedia {
         std::move(request), next, [&next](Request request) { next(std::move(request), ""); });
   }
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<GET, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<GET, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       WithOptionalKeyFromURL(std::move(request), std::forward<F>(next));
@@ -255,8 +255,8 @@ struct Hypermedia {
     }
   };
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<POST, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<POST, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       if (!request.url_path_args.empty()) {
@@ -299,8 +299,8 @@ struct Hypermedia {
     }
   };
 
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<PUT, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<PUT, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));
@@ -334,8 +334,8 @@ struct Hypermedia {
                            HTTPResponseCode.BadRequest);
     }
   };
-  template <typename ALL_FIELDS, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
-  struct RESTful<DELETE, ALL_FIELDS, PARTICULAR_FIELD, ENTRY, KEY> {
+  template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
+  struct RESTful<DELETE, PARTICULAR_FIELD, ENTRY, KEY> {
     template <typename F>
     void Enter(Request request, F&& next) {
       WithKeyFromURL(std::move(request), std::forward<F>(next));

--- a/Storage/storage.h
+++ b/Storage/storage.h
@@ -186,6 +186,7 @@ namespace storage {
     using T_FIELDS_BY_REFERENCE = FIELDS&;                                                                   \
     using T_FIELDS_BY_CONST_REFERENCE = const FIELDS&;                                                       \
     using T_TRANSACTION = ::current::storage::Transaction<T_FIELDS_VARIANT>;                                 \
+    using T_TRANSACTION_META_FIELDS = ::current::storage::TransactionMetaFields;                             \
     CURRENT_STORAGE_IMPL_##name& operator=(const CURRENT_STORAGE_IMPL_##name&) = delete;                     \
     template <typename... ARGS>                                                                              \
     CURRENT_STORAGE_IMPL_##name(ARGS&&... args)                                                              \
@@ -202,16 +203,14 @@ namespace storage {
     using T_F_RESULT = typename std::result_of<F(T_FIELDS_BY_REFERENCE)>::type;                              \
     template <typename F>                                                                                    \
     ::current::Future<::current::storage::TransactionResult<T_F_RESULT<F>>, ::current::StrictFuture::Strict> \
-    Transaction(F&& f, ::current::storage::TransactionMetaFields meta_fields =                               \
-                    ::current::storage::TransactionMetaFields()) {                                           \
+    Transaction(F&& f, T_TRANSACTION_META_FIELDS meta_fields = T_TRANSACTION_META_FIELDS()) {                \
       return transaction_policy_.Transaction([&f, this]() { return f(fields_); }, std::move(meta_fields));   \
     }                                                                                                        \
     template <typename F1, typename F2>                                                                      \
     ::current::Future<::current::storage::TransactionResult<void>, ::current::StrictFuture::Strict>          \
     Transaction(F1&& f1,                                                                                     \
                 F2&& f2,                                                                                     \
-                ::current::storage::TransactionMetaFields meta_fields =                                      \
-                    ::current::storage::TransactionMetaFields()) {                                           \
+                T_TRANSACTION_META_FIELDS meta_fields = T_TRANSACTION_META_FIELDS()) {                       \
       return transaction_policy_.Transaction([&f1, this]() { return f1(fields_); },                          \
                                              std::forward<F2>(f2),                                           \
                                              std::move(meta_fields));                                        \

--- a/Storage/storage.h
+++ b/Storage/storage.h
@@ -205,8 +205,8 @@ namespace storage {
     using T_F_RESULT = typename std::result_of<F(T_FIELDS_BY_REFERENCE)>::type;                              \
     template <typename F>                                                                                    \
     ::current::Future<::current::storage::TransactionResult<T_F_RESULT<F>>, ::current::StrictFuture::Strict> \
-    Transaction(F&& f) {                \
-      return transaction_policy_.Transaction([&f, this]() { return f(fields_); });   \
+    Transaction(F&& f) {                                                                                     \
+      return transaction_policy_.Transaction([&f, this]() { return f(fields_); });                           \
     }                                                                                                        \
     template <typename F1, typename F2>                                                                      \
     ::current::Future<::current::storage::TransactionResult<void>, ::current::StrictFuture::Strict>          \

--- a/Storage/storage.h
+++ b/Storage/storage.h
@@ -192,8 +192,7 @@ namespace storage {
     CURRENT_STORAGE_IMPL_##name(ARGS&&... args)                                                              \
         : persister_(std::forward<ARGS>(args)...),                                                           \
           transaction_policy_(persister_,                                                                    \
-                              fields_.current_storage_mutation_journal_,                                     \
-                              fields_.current_storage_transaction_meta_fields_) {                            \
+                              fields_.current_storage_mutation_journal_) {                                   \
       persister_.Replay([this](const T_FIELDS_VARIANT& entry) { entry.Call(fields_); });                     \
     }                                                                                                        \
     template <typename... ARGS>                                                                              \

--- a/Storage/test.cc
+++ b/Storage/test.cc
@@ -508,11 +508,11 @@ TEST(TransactionalStorage, ReplicationViaHTTP) {
   // Perform a couple of transactions.
   {
     current::time::SetNow(std::chrono::microseconds(100));
-    const TransactionMetaFields meta_fields{{"user", "dima"}};
     const auto result = master_storage.Transaction([](MutableFields<Storage> fields) {
       fields.d.Add(Record{"one", 1});
       fields.d.Add(Record{"two", 2});
-    }, meta_fields).Go();
+      fields.SetTransactionMetaField("user", "dima");
+    }).Go();
     EXPECT_TRUE(WasCommitted(result));
   }
   {

--- a/Storage/transaction_policy.h
+++ b/Storage/transaction_policy.h
@@ -45,8 +45,7 @@ class Synchronous final {
  public:
   using T_TRANSACTION = typename PERSISTER::T_TRANSACTION;
 
-  Synchronous(PERSISTER& persister, MutationJournal& journal, TransactionMetaFields& transaction_meta_fields)
-      : persister_(persister), journal_(journal), transaction_meta_fields_(transaction_meta_fields) {}
+  Synchronous(PERSISTER& persister, MutationJournal& journal) : persister_(persister), journal_(journal) {}
 
   ~Synchronous() {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -90,8 +89,6 @@ class Synchronous final {
       // LCOV_EXCL_STOP
     }
     if (successful) {
-      journal_.meta_fields = transaction_meta_fields_;
-      transaction_meta_fields_.clear();
       PersistJournal();
       promise.set_value(TransactionResult<T_RESULT>::Committed(std::move(f_result)));
     }
@@ -127,8 +124,6 @@ class Synchronous final {
       // LCOV_EXCL_STOP
     }
     if (successful) {
-      journal_.meta_fields = transaction_meta_fields_;
-      transaction_meta_fields_.clear();
       PersistJournal();
       promise.set_value(TransactionResult<void>::Committed(OptionalResultExists()));
     }
@@ -150,8 +145,6 @@ class Synchronous final {
     T_RESULT f1_result;
     try {
       f1_result = f1();
-      journal_.meta_fields = transaction_meta_fields_;
-      transaction_meta_fields_.clear();
       PersistJournal();
       f2(std::move(f1_result));
       promise.set_value(TransactionResult<void>::Committed(OptionalResultExists()));
@@ -211,7 +204,6 @@ class Synchronous final {
 
   PERSISTER& persister_;
   MutationJournal& journal_;
-  TransactionMetaFields& transaction_meta_fields_;
   std::mutex mutex_;
   bool destructing_ = false;
 };

--- a/Storage/transaction_policy.h
+++ b/Storage/transaction_policy.h
@@ -45,7 +45,8 @@ class Synchronous final {
  public:
   using T_TRANSACTION = typename PERSISTER::T_TRANSACTION;
 
-  Synchronous(PERSISTER& persister, MutationJournal& journal) : persister_(persister), journal_(journal) {}
+  Synchronous(PERSISTER& persister, MutationJournal& journal, TransactionMetaFields& transaction_meta_fields)
+      : persister_(persister), journal_(journal), transaction_meta_fields_(transaction_meta_fields) {}
 
   ~Synchronous() {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -56,8 +57,7 @@ class Synchronous final {
   using T_F_RESULT = typename std::result_of<F()>::type;
 
   template <typename F, class = ENABLE_IF<!std::is_void<T_F_RESULT<F>>::value>>
-  Future<TransactionResult<T_F_RESULT<F>>, StrictFuture::Strict> Transaction(
-      F&& f, TransactionMetaFields&& meta_fields) {
+  Future<TransactionResult<T_F_RESULT<F>>, StrictFuture::Strict> Transaction(F&& f) {
     using T_RESULT = T_F_RESULT<F>;
     std::lock_guard<std::mutex> lock(mutex_);
     journal_.AssertEmpty();
@@ -90,7 +90,8 @@ class Synchronous final {
       // LCOV_EXCL_STOP
     }
     if (successful) {
-      journal_.meta_fields = std::move(meta_fields);
+      journal_.meta_fields = transaction_meta_fields_;
+      transaction_meta_fields_.clear();
       PersistJournal();
       promise.set_value(TransactionResult<T_RESULT>::Committed(std::move(f_result)));
     }
@@ -98,8 +99,7 @@ class Synchronous final {
   }
 
   template <typename F, class = ENABLE_IF<std::is_void<T_F_RESULT<F>>::value>>
-  Future<TransactionResult<void>, StrictFuture::Strict> Transaction(F&& f,
-                                                                    TransactionMetaFields&& meta_fields) {
+  Future<TransactionResult<void>, StrictFuture::Strict> Transaction(F&& f) {
     std::lock_guard<std::mutex> lock(mutex_);
     journal_.AssertEmpty();
     std::promise<TransactionResult<void>> promise;
@@ -127,7 +127,8 @@ class Synchronous final {
       // LCOV_EXCL_STOP
     }
     if (successful) {
-      journal_.meta_fields = std::move(meta_fields);
+      journal_.meta_fields = transaction_meta_fields_;
+      transaction_meta_fields_.clear();
       PersistJournal();
       promise.set_value(TransactionResult<void>::Committed(OptionalResultExists()));
     }
@@ -136,9 +137,7 @@ class Synchronous final {
 
   // TODO(mz+dk): implement proper logic here (consider rollbacks & exceptions).
   template <typename F1, typename F2, class = ENABLE_IF<!std::is_void<T_F_RESULT<F1>>::value>>
-  Future<TransactionResult<void>, StrictFuture::Strict> Transaction(F1&& f1,
-                                                                    F2&& f2,
-                                                                    TransactionMetaFields&& meta_fields) {
+  Future<TransactionResult<void>, StrictFuture::Strict> Transaction(F1&& f1, F2&& f2) {
     using T_RESULT = T_F_RESULT<F1>;
     std::lock_guard<std::mutex> lock(mutex_);
     journal_.AssertEmpty();
@@ -151,7 +150,8 @@ class Synchronous final {
     T_RESULT f1_result;
     try {
       f1_result = f1();
-      journal_.meta_fields = std::move(meta_fields);
+      journal_.meta_fields = transaction_meta_fields_;
+      transaction_meta_fields_.clear();
       PersistJournal();
       f2(std::move(f1_result));
       promise.set_value(TransactionResult<void>::Committed(OptionalResultExists()));
@@ -211,6 +211,7 @@ class Synchronous final {
 
   PERSISTER& persister_;
   MutationJournal& journal_;
+  TransactionMetaFields& transaction_meta_fields_;
   std::mutex mutex_;
   bool destructing_ = false;
 };


### PR DESCRIPTION
 * Factored out RESTful handlers input parameters
 * Eliminated `ALL_FIELDS` template parameter
 * Reviewed capture in cascaded lambdas
 * Storage meta fields are now added/deleted from within transaction via `{Set/Erase}TransactionMetaField(...)`

Will add storage access for `RegisterTopLevel` tomorrow.