### PR TITLE
Removed redundant std::move uses

### DIFF
--- a/Blocks/Persistence/test.cc
+++ b/Blocks/Persistence/test.cc
@@ -183,7 +183,7 @@ TEST(PersistenceLayer, File) {
     current::time::SetNow(std::chrono::microseconds(100));
     impl.Publish(StorableString("foo"));
     current::time::SetNow(std::chrono::microseconds(200));
-    impl.Publish(std::move(StorableString("bar")));
+    impl.Publish(StorableString("bar"));
     EXPECT_EQ(2u, impl.Size());
 
     {

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -117,7 +117,7 @@ struct FileSystem {
   }
 
   static inline std::string WriteStringToTmpFile(const std::string& contents) {
-    const std::string file_name = std::move(GenTmpFileName());
+    const std::string file_name = GenTmpFileName();
     WriteStringToFile(contents, file_name.c_str());
     return file_name;
   }

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -574,7 +574,7 @@ class HTTPServerConnection final {
       PrepareHTTPResponseHeader(os, ConnectionKeepAlive, code, content_type, extra_headers);
       os << "Transfer-Encoding: chunked" << kCRLF << kCRLF;
       connection_.BlockingWrite(os.str(), true);
-      return std::move(ChunkedResponseSender(connection_));
+      return ChunkedResponseSender(connection_);
     }
   }
 

--- a/Bricks/sync/test.cc
+++ b/Bricks/sync/test.cc
@@ -56,7 +56,7 @@ TEST(ScopeOwned, MoveConstructScopeOwnedByMe) {
     EXPECT_EQ(0, *x);
     ++*x;
     EXPECT_EQ(1, *x);
-    return std::move(x);
+    return x;
   }());
   EXPECT_EQ(1, *y);
   ++*y;
@@ -132,11 +132,11 @@ TEST(ScopeOwned, ScopeOwnedBySomeoneElseOutlivingTheOwner) {
             y.ExclusiveUseDespitePossiblyDestructing([](Container& container) { ++container.ref; });
           }
         },
-        std::move(ScopeOwnedBySomeoneElse<Container>(x,
-                                                     [&log, &terminating]() {
-                                                       terminating = true;
-                                                       log += "Terminating.\n";
-                                                     })));
+        ScopeOwnedBySomeoneElse<Container>(x,
+                                           [&log, &terminating]() {
+                                             terminating = true;
+                                             log += "Terminating.\n";
+                                           }));
 
     EXPECT_EQ(1u, x.NumberOfActiveFollowers());
     EXPECT_EQ(1u, x.TotalFollowersSpawnedThroughoutLifetime());
@@ -178,7 +178,7 @@ TEST(ScopeOwned, UseInternalIsDestructingGetter) {
       for (int i = 0; i < 1000; ++i) {
         y.ExclusiveUseDespitePossiblyDestructing([](Container& container) { ++container.ref; });
       }
-    }, std::move(ScopeOwnedBySomeoneElse<Container>(x, []() {})));
+    }, ScopeOwnedBySomeoneElse<Container>(x, []() {}));
 
     int extracted_value;
     do {

--- a/Bricks/util/test.cc
+++ b/Bricks/util/test.cc
@@ -588,7 +588,7 @@ TEST(AccumulativeScopedDeleter, DoesNotDeleteWhatShouldStay) {
     std::string tracker;
     {
       AccumulativeScopedDeleter<void> scope =
-          std::move(AccumulativeScopedDeleter<void, false>([&tracker]() { tracker += 'e'; }));
+          AccumulativeScopedDeleter<void, false>([&tracker]() { tracker += 'e'; });
       EXPECT_EQ("", tracker);
     }
     EXPECT_EQ("e", tracker);

--- a/Sherlock/test.cc
+++ b/Sherlock/test.cc
@@ -396,7 +396,7 @@ TEST(Sherlock, SubscribeToStreamViaHTTP) {
     // Explicitly confirm the return type for ths scope is what is should be, no `auto`. -- D.K.
     // This is to fight the trouble with an `unique_ptr<*, NullDeleter>` mistakenly emerging due to internals.
     current::sherlock::StreamImpl<RecordWithTimestamp>::SyncSubscriberScope<RecordsCollector> scope(
-        std::move(exposed_stream.Subscribe(collector)));
+        exposed_stream.Subscribe(collector));
     while (collector.count_ < 4u) {
       ;  // Spin lock.
     }

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -505,7 +505,7 @@ TEST(TypeSystemTest, VariantSmokeTestOneType) {
     EXPECT_EQ(101u, p.VariantValueImpl<Foo>().i);
     EXPECT_EQ(101u, cp.VariantValueImpl<Foo>().i);
 
-    p = std::move(Foo(102u));
+    p = Foo(102u);
     EXPECT_EQ(102u, p.VariantValueImpl<Foo>().i);
     EXPECT_EQ(102u, cp.VariantValueImpl<Foo>().i);
 


### PR DESCRIPTION
Removed redundant `std::move`s, because they cause clang warnings like: `warning: moving a temporary object prevents copy elision`. And because they are redundant :)

CC @dkorolev @mzhurovich 