### PR TITLE
A large `T_TYPE` -> `type_t` deprecation.

### DIFF
--- a/Blocks/HTTP/api.h
+++ b/Blocks/HTTP/api.h
@@ -75,7 +75,7 @@ using current::http::HTTP;
 using current::http::Request;
 using current::http::Response;
 using current::http::ReRegisterRoute;
-using HTTPRoutesScope = typename HTTP_IMPL::T_SERVER_IMPL::HTTPRoutesScope;
+using HTTPRoutesScope = typename HTTP_IMPL::server_impl_t::HTTPRoutesScope;
 using HTTPRoutesScopeEntry = current::http::HTTPServerPOSIX::HTTPRoutesScopeEntry;
 
 #endif  // BLOCKS_HTTP_API_H

--- a/Blocks/HTTP/impl/apple_client.h
+++ b/Blocks/HTTP/impl/apple_client.h
@@ -120,9 +120,9 @@ struct ImplWrapper<HTTPClientApple> {
   }
 
   // Parsing the response from within HTTPClientApple.
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS&,
-                                 const T_RESPONSE_PARAMS&,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS&,
+                                 const RESPONSE_PARAMS&,
                                  const HTTPClientApple& response,
                                  HTTPResponse& output) {
     // TODO(dkorolev): Handle redirects in Apple implementation.
@@ -131,17 +131,17 @@ struct ImplWrapper<HTTPClientApple> {
     output.headers = response.response_headers;
   }
 
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& response_params,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& response_params,
                                  const HTTPClientApple& response,
                                  HTTPResponseWithBuffer& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));
     output.body = response.response_body;
   }
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& response_params,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& response_params,
                                  const HTTPClientApple& response,
                                  HTTPResponseWithResultingFileName& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));

--- a/Blocks/HTTP/impl/java_client.h
+++ b/Blocks/HTTP/impl/java_client.h
@@ -270,9 +270,9 @@ struct ImplWrapper<java_wrapper::HTTPClientPlatformWrapper> {
   }
 
   // Parsing the response from within java_wrapper::HTTPClientPlatformWrapper.
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS&,
-                                 const T_RESPONSE_PARAMS&,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS&,
+                                 const RESPONSE_PARAMS&,
                                  const java_wrapper::HTTPClientPlatformWrapper& response,
                                  HTTPResponse& output) {
     output.url = response.url_requested_;
@@ -280,17 +280,17 @@ struct ImplWrapper<java_wrapper::HTTPClientPlatformWrapper> {
     output.url_after_redirects = response.url_received_;
   }
 
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& response_params,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& response_params,
                                  const java_wrapper::HTTPClientPlatformWrapper& response,
                                  HTTPResponseWithBuffer& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));
     output.body = response.server_response_;
   }
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& response_params,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& response_params,
                                  const java_wrapper::HTTPClientPlatformWrapper& response,
                                  HTTPResponseWithResultingFileName& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));

--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -194,9 +194,9 @@ struct ImplWrapper<HTTPClientPOSIX> {
     assert(!save_to_file_request.file_name.empty());
   }
 
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& /*response_params*/,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& /*response_params*/,
                                  const HTTPClientPOSIX& response,
                                  HTTPResponse& output) {
     if (!request_params.allow_redirects && request_params.url != response.response_url_after_redirects_) {
@@ -208,9 +208,9 @@ struct ImplWrapper<HTTPClientPOSIX> {
     output.headers = http_request.headers();
   }
 
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& response_params,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& response_params,
                                  const HTTPClientPOSIX& response,
                                  HTTPResponseWithBuffer& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));
@@ -218,9 +218,9 @@ struct ImplWrapper<HTTPClientPOSIX> {
     output.body = http_request.Body();
   }
 
-  template <typename T_REQUEST_PARAMS, typename T_RESPONSE_PARAMS>
-  inline static void ParseOutput(const T_REQUEST_PARAMS& request_params,
-                                 const T_RESPONSE_PARAMS& response_params,
+  template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
+  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+                                 const RESPONSE_PARAMS& response_params,
                                  const HTTPClientPOSIX& response,
                                  HTTPResponseWithResultingFileName& output) {
     ParseOutput(request_params, response_params, response, static_cast<HTTPResponse&>(output));

--- a/Blocks/SS/pubsub.h
+++ b/Blocks/SS/pubsub.h
@@ -153,7 +153,7 @@ namespace impl {
 
 template <typename TYPE_SUBSCRIBED_TO, typename STREAM_UNDERLYING_VARIANT>
 struct PassEntryToSubscriberIfTypeMatchesImpl {
-  static_assert(TypeListContains<typename STREAM_UNDERLYING_VARIANT::T_TYPELIST, TYPE_SUBSCRIBED_TO>::value,
+  static_assert(TypeListContains<typename STREAM_UNDERLYING_VARIANT::typelist_t, TYPE_SUBSCRIBED_TO>::value,
                 "Subscribing to the type different from the underlying type requires the underlying type"
                 " to be a `Variant<>` containing the subscribed to type as an option.");
 

--- a/Blocks/URL/url.h
+++ b/Blocks/URL/url.h
@@ -317,9 +317,11 @@ struct URLPathArgs {
 
   const std::string& operator[](size_t index) const { return args_.at(args_.size() - 1 - index); }
 
-  using T_ITERATOR = std::vector<std::string>::const_reverse_iterator;
-  T_ITERATOR begin() const { return args_.crbegin(); }
-  T_ITERATOR end() const { return args_.crend(); }
+  using iterator_t = std::vector<std::string>::const_reverse_iterator;
+  using DEPRECATED_T_(ITERATOR) = iterator_t;
+
+  iterator_t begin() const { return args_.crbegin(); }
+  iterator_t end() const { return args_.crend(); }
 
   bool empty() const { return args_.empty(); }
   size_t size() const { return args_.size(); }

--- a/Bricks/net/http/headers/headers.h
+++ b/Bricks/net/http/headers/headers.h
@@ -137,11 +137,15 @@ struct Cookie final {
 
 struct Headers final {
   // An `std::unique_ptr<>` to preserve the address as the map grows. For case-insensitive lookup.
-  using T_HEADERS_MAP = std::map<std::string, std::unique_ptr<Header>, Header::KeyComparator>;
+  using headers_map_t = std::map<std::string, std::unique_ptr<Header>, Header::KeyComparator>;
   // A list preserving the order, pointing to persisted Header-s contained in `std::unique_ptr<>` of `std::map`.
-  using T_HEADERS_LIST = std::vector<std::pair<std::string, Header*>>;
+  using headers_list_t = std::vector<std::pair<std::string, Header*>>;
   // Cookies as a map of `std::string` cookie name into the value of this cookie and extra parameters for it.
-  using T_COOKIES_MAP = std::map<std::string, Cookie>;
+  using cookies_map_t = std::map<std::string, Cookie>;
+
+  using DEPRECATED_T_(HEADERS_MAP) = headers_map_t;
+  using DEPRECATED_T_(HEADERS_LIST) = headers_list_t;
+  using DEPRECATED_T_(COOKIES_MAP) = cookies_map_t;
 
   Headers() = default;
   Headers(Headers&&) = default;
@@ -257,7 +261,7 @@ struct Headers final {
 
   // Allow only const iteration.
   struct Iterator final {
-    typename T_HEADERS_LIST::const_iterator iterator;
+    typename headers_list_t::const_iterator iterator;
 
     bool operator==(const Iterator& rhs) const { return iterator == rhs.iterator; }
     bool operator!=(const Iterator& rhs) const { return iterator != rhs.iterator; }
@@ -336,14 +340,14 @@ struct Headers final {
   }
 
   // `map[header]` either does not exist, or contains a valid `std::unique_ptr<Header>`.
-  T_HEADERS_MAP map;
+  headers_map_t map;
 
   // `list[i]` points to the underlying `Header*` of the `std::unique_ptr<Header>` stored in `map`,
   // respecting the order in which the headers have been added.
-  T_HEADERS_LIST list;
+  headers_list_t list;
 
   // Cookies are just an `std::map<std::string, std::string>`.
-  T_COOKIES_MAP cookies;
+  cookies_map_t cookies;
 };
 
 }  // namespace http

--- a/Bricks/rtti/dispatcher.h
+++ b/Bricks/rtti/dispatcher.h
@@ -36,18 +36,18 @@ namespace rtti {
 
 template <typename BASE, typename DERIVED, typename... TAIL>
 struct RuntimeDispatcher {
-  typedef BASE T_BASE;
-  typedef DERIVED T_DERIVED;
-  template <typename TYPE, typename PROCESSOR>
-  static void DispatchCall(const TYPE &x, PROCESSOR &c) {
+  typedef BASE base_t;
+  typedef DERIVED deriver_t;
+  template <typename T, typename PROCESSOR>
+  static void DispatchCall(const T &x, PROCESSOR &c) {
     if (const DERIVED *d = dynamic_cast<const DERIVED *>(&x)) {
       c(*d);
     } else {
       RuntimeDispatcher<BASE, TAIL...>::DispatchCall(x, c);
     }
   }
-  template <typename TYPE, typename PROCESSOR>
-  static void DispatchCall(TYPE &x, PROCESSOR &c) {
+  template <typename T, typename PROCESSOR>
+  static void DispatchCall(T &x, PROCESSOR &c) {
     if (DERIVED *d = dynamic_cast<DERIVED *>(&x)) {
       c(*d);
     } else {
@@ -58,10 +58,10 @@ struct RuntimeDispatcher {
 
 template <typename BASE, typename DERIVED>
 struct RuntimeDispatcher<BASE, DERIVED> {
-  typedef BASE T_BASE;
-  typedef DERIVED T_DERIVED;
-  template <typename TYPE, typename PROCESSOR>
-  static void DispatchCall(const TYPE &x, PROCESSOR &c) {
+  typedef BASE base_t;
+  typedef DERIVED deriver_t;
+  template <typename T, typename PROCESSOR>
+  static void DispatchCall(const T &x, PROCESSOR &c) {
     if (const DERIVED *d = dynamic_cast<const DERIVED *>(&x)) {
       c(*d);
     } else {
@@ -73,8 +73,8 @@ struct RuntimeDispatcher<BASE, DERIVED> {
       }
     }
   }
-  template <typename TYPE, typename PROCESSOR>
-  static void DispatchCall(TYPE &x, PROCESSOR &c) {
+  template <typename T, typename PROCESSOR>
+  static void DispatchCall(T &x, PROCESSOR &c) {
     if (DERIVED *d = dynamic_cast<DERIVED *>(&x)) {
       c(*d);
     } else {

--- a/Bricks/strings/join.h
+++ b/Bricks/strings/join.h
@@ -64,14 +64,14 @@ inline size_t StringLengthOrOneForChar(T&& param) {
 
 template <bool CAN_GET_LENGTH>
 struct OptionallyReserveOutputBufferImpl {
-  template <typename T_CONTAINER, typename T_SEPARATOR>
-  static void Impl(std::string&, const T_CONTAINER&, T_SEPARATOR&&) {}
+  template <typename CONTAINER, typename SEPARATOR>
+  static void Impl(std::string&, const CONTAINER&, SEPARATOR&&) {}
 };
 
 template <>
 struct OptionallyReserveOutputBufferImpl<true> {
-  template <typename T_CONTAINER, typename T_SEPARATOR>
-  static void Impl(std::string& output, const T_CONTAINER& components, T_SEPARATOR&& separator) {
+  template <typename CONTAINER, typename SEPARATOR>
+  static void Impl(std::string& output, const CONTAINER& components, SEPARATOR&& separator) {
     size_t length = 0;
     for (const auto& cit : components) {
       length += cit.length();
@@ -109,17 +109,15 @@ struct IsContainerOfStrings {
 
 }  // namespace sfinae
 
-template <typename T_CONTAINER, typename T_SEPARATOR>
-void OptionallyReserveOutputBuffer(std::string& output,
-                                   const T_CONTAINER& components,
-                                   T_SEPARATOR&& separator) {
+template <typename CONTAINER, typename SEPARATOR>
+void OptionallyReserveOutputBuffer(std::string& output, const CONTAINER& components, SEPARATOR&& separator) {
   // Note: this implementation does not do `reserve()` for chars, the length of which is always known to be 1.
-  OptionallyReserveOutputBufferImpl<sfinae::IsContainerOfStrings<T_CONTAINER>::value>::Impl(
+  OptionallyReserveOutputBufferImpl<sfinae::IsContainerOfStrings<CONTAINER>::value>::Impl(
       output, components, separator);
 }
 
-template <typename T_CONTAINER, typename T_SEPARATOR>
-std::string Join(const T_CONTAINER& components, T_SEPARATOR&& separator) {
+template <typename CONTAINER, typename SEPARATOR>
+std::string Join(const CONTAINER& components, SEPARATOR&& separator) {
   if (components.empty()) {
     return "";
   } else {
@@ -140,14 +138,14 @@ std::string Join(const T_CONTAINER& components, T_SEPARATOR&& separator) {
 
 }  // namespace impl
 
-template <typename T_CONTAINER, typename T_SEPARATOR>
-std::string Join(const T_CONTAINER& components, T_SEPARATOR&& separator) {
-  return impl::Join(components, std::forward<T_SEPARATOR>(separator));
+template <typename CONTAINER, typename SEPARATOR>
+std::string Join(const CONTAINER& components, SEPARATOR&& separator) {
+  return impl::Join(components, std::forward<SEPARATOR>(separator));
 }
 
-template <typename T_SEPARATOR>
-std::string Join(const std::vector<std::string>& components, T_SEPARATOR&& separator) {
-  return impl::Join(components, std::forward<T_SEPARATOR>(separator));
+template <typename SEPARATOR>
+std::string Join(const std::vector<std::string>& components, SEPARATOR&& separator) {
+  return impl::Join(components, std::forward<SEPARATOR>(separator));
 }
 
 }  // namespace strings

--- a/Bricks/util/future.h
+++ b/Bricks/util/future.h
@@ -38,7 +38,7 @@ namespace current {
 // The default, `Forgiving`, mode does not have this requirement.
 enum class StrictFuture : bool { Forgiving = false, Strict = true };
 
-template <typename T, StrictFuture T_STRICT = StrictFuture::Forgiving>
+template <typename T, StrictFuture STRICTNESS = StrictFuture::Forgiving>
 struct FutureImpl {
   FutureImpl() = delete;
   FutureImpl(std::future<T>&& rhs) : f_(std::move(rhs)), used_(false) {}
@@ -47,7 +47,7 @@ struct FutureImpl {
     rhs.used_ = true;
   }
   ~FutureImpl() {
-    if (T_STRICT == StrictFuture::Strict && !used_) {
+    if (STRICTNESS == StrictFuture::Strict && !used_) {
       std::cerr << "Strict future has been left hanging, while Go(), Wait(), or Detach() must have been called."
                 << std::endl;
       std::exit(-1);
@@ -69,8 +69,8 @@ struct FutureImpl {
   bool used_ = false;
 };
 
-template <StrictFuture T_STRICT>
-struct FutureImpl<void, T_STRICT> {
+template <StrictFuture STRICTNESS>
+struct FutureImpl<void, STRICTNESS> {
   FutureImpl() = delete;
   FutureImpl(std::future<void>&& rhs) : f_(std::move(rhs)), used_(false) {}
   FutureImpl(FutureImpl<void, StrictFuture::Forgiving>&& rhs) : f_(std::move(rhs.f_)), used_(false) {}
@@ -94,8 +94,8 @@ struct FutureImpl<void, T_STRICT> {
 };
 
 // To fight "error: default template arguments may not be used in partial specializations" for `void`.
-template <typename T, StrictFuture T_STRICT = StrictFuture::Forgiving>
-using Future = FutureImpl<T, T_STRICT>;
+template <typename T, StrictFuture STRICTNESS = StrictFuture::Forgiving>
+using Future = FutureImpl<T, STRICTNESS>;
 
 }  // namespace current
 

--- a/Midichlorians/Client/iOS/MidichloriansImpl.h
+++ b/Midichlorians/Client/iOS/MidichloriansImpl.h
@@ -59,7 +59,8 @@ using current::midichlorians::ios::iOSDeviceInfo;
 using current::midichlorians::ios::iOSIdentifyEvent;
 using current::midichlorians::ios::iOSFocusEvent;
 using current::midichlorians::ios::iOSGenericEvent;
-using current::midichlorians::ios::T_IOS_EVENTS;
+using current::midichlorians::ios::DEPRECATED_T_(IOS_EVENTS);
+using current::midichlorians::ios::ios_events_t;
 
 // Define the iOS interface, being comfortably within a C++ header file included exclusively from an `.mm` one.
 @interface MidichloriansImpl : NSObject

--- a/Midichlorians/Client/iOS/MidichloriansImpl.mm
+++ b/Midichlorians/Client/iOS/MidichloriansImpl.mm
@@ -162,8 +162,8 @@ namespace impl {
         // preserving the order.
         // NOTE: In production, a more advanced implementation should be used,
         // with more efficient in-memory message queue and with optionally persistent storage of events.
-        template <class T_SINGLE_THREADED_IMPL>
-        class SimplestThreadSafeWrapper : public T_SINGLE_THREADED_IMPL {
+        template <class SINGLE_THREADED_IMPL>
+        class SimplestThreadSafeWrapper : public SINGLE_THREADED_IMPL {
         public:
             SimplestThreadSafeWrapper() : up_(true), thread_(&SimplestThreadSafeWrapper::Thread, this) {}
             ~SimplestThreadSafeWrapper() {
@@ -202,7 +202,7 @@ namespace impl {
                         }
                     }
                     // Mutex-free section: Process this message.
-                    T_SINGLE_THREADED_IMPL::OnMessage(message);
+                    SINGLE_THREADED_IMPL::OnMessage(message);
                 }
             }
             
@@ -223,12 +223,12 @@ namespace impl {
     using Stats = consumer::POSTviaHTTP;
 
     struct EventsVariantDispatchedAssigner {
-        explicit EventsVariantDispatchedAssigner(Variant<T_IOS_EVENTS>& variant) : variant_(variant) {}
+        explicit EventsVariantDispatchedAssigner(Variant<ios_events_t>& variant) : variant_(variant) {}
 
         template <typename T>
         void operator()(const T& event) { variant_ = event; }
 
-        Variant<T_IOS_EVENTS>& variant_;
+        Variant<ios_events_t>& variant_;
     };
 
 }  // namespace impl
@@ -330,9 +330,9 @@ using namespace current::midichlorians::ios::impl;
 
 + (void)emit:(const iOSBaseEvent &)event {
     Stats &instance = current::Singleton<Stats>();
-    Variant<T_IOS_EVENTS> v;
+    Variant<ios_events_t> v;
     EventsVariantDispatchedAssigner assigner(v);
-    current::metaprogramming::RTTIDynamicCall<T_IOS_EVENTS>(event, assigner);
+    current::metaprogramming::RTTIDynamicCall<ios_events_t>(event, assigner);
     Value<iOSBaseEvent>(v).device_id = instance.GetDeviceId();
     Value<iOSBaseEvent>(v).client_id = instance.GetClientId();
     Value<iOSBaseEvent>(v).user_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current::time::Now());

--- a/Midichlorians/Client/test.cc
+++ b/Midichlorians/Client/test.cc
@@ -52,15 +52,15 @@ DEFINE_string(midichlorians_client_test_http_route, "/log", "HTTP route of the s
 
 class Server {
  public:
-  using T_EVENT_VARIANT = Variant<T_IOS_EVENTS>;
+  using events_variant_t = Variant<ios_events_t>;
 
   Server(int http_port, const std::string& http_route)
       : messages_processed_(0u),
         routes_(HTTP(http_port).Register(http_route,
                                          [this](Request r) {
-                                           T_EVENT_VARIANT event;
+                                           events_variant_t event;
                                            try {
-                                             event = ParseJSON<T_EVENT_VARIANT>(r.body);
+                                             event = ParseJSON<events_variant_t>(r.body);
                                              event.Call(*this);
                                              ++messages_processed_;
                                            } catch (const current::Exception&) {

--- a/Midichlorians/MidichloriansDataDictionary.h
+++ b/Midichlorians/MidichloriansDataDictionary.h
@@ -134,12 +134,14 @@ CURRENT_STRUCT(iOSGenericEvent, iOSBaseEvent) {
 #endif  // COMPILE_MIDICHLORIANS_DATA_DICTIONARY_FOR_IOS_CLIENT
 };
 
-using T_IOS_EVENTS = TypeList<iOSFirstLaunchEvent,
+using ios_events_t = TypeList<iOSFirstLaunchEvent,
                               iOSAppLaunchEvent,
                               iOSDeviceInfo,
                               iOSIdentifyEvent,
                               iOSFocusEvent,
                               iOSGenericEvent>;
+
+using DEPRECATED_T_(IOS_EVENTS) = ios_events_t;
 
 }  // namespace ios
 
@@ -177,8 +179,10 @@ CURRENT_STRUCT(WebGenericEvent, WebBaseEvent) {
       : event_category(category), event_action(action) {}
 };
 
-using T_WEB_EVENTS =
+using web_events_t =
     TypeList<WebEnterEvent, WebExitEvent, WebForegroundEvent, WebBackgroundEvent, WebGenericEvent>;
+
+using DEPRECATED_T_(WEB_EVENTS) = web_events_t;
 
 }  // namespace web
 

--- a/Midichlorians/Server/schema.h
+++ b/Midichlorians/Server/schema.h
@@ -47,12 +47,19 @@ struct TypeListCatImpl<TypeListImpl<LHS...>, TypeListImpl<RHS...>> {
 template <typename... TS>
 using TypeListCat = typename TypeListCatImpl<TS...>::result;
 
-using current::midichlorians::ios::T_IOS_EVENTS;
-using current::midichlorians::web::T_WEB_EVENTS;
+using current::midichlorians::ios::ios_events_t;
+using current::midichlorians::web::web_events_t;
 
-using T_IOS_VARIANT = Variant<T_IOS_EVENTS>;
-using T_WEB_VARIANT = Variant<T_WEB_EVENTS>;
-using T_EVENT_VARIANT = Variant<TypeListCat<T_IOS_EVENTS, T_WEB_EVENTS>>;
+using current::midichlorians::ios::DEPRECATED_T_(IOS_EVENTS);
+using current::midichlorians::web::DEPRECATED_T_(WEB_EVENTS);
+
+using ios_variant_t = Variant<ios_events_t>;
+using web_variant_t = Variant<web_events_t>;
+using event_variant_t = Variant<TypeListCat<ios_events_t, web_events_t>>;
+
+using DEPRECATED_T_(IOS_VARIANT) = ios_variant_t;
+using DEPRECATED_T_(WEB_VARIANT) = web_variant_t;
+using DEPRECATED_T_(EVENT_VARIANT) = event_variant_t;
 
 // clang-format off
 CURRENT_STRUCT(LogEntryBase) {
@@ -67,11 +74,11 @@ CURRENT_STRUCT(TickLogEntry, LogEntryBase){
 };
 
 CURRENT_STRUCT(EventLogEntry, LogEntryBase) {
-  CURRENT_FIELD(event, T_EVENT_VARIANT);
+  CURRENT_FIELD(event, event_variant_t);
   CURRENT_DEFAULT_CONSTRUCTOR(EventLogEntry) {}
-  CURRENT_CONSTRUCTOR(EventLogEntry)(std::chrono::microseconds us, T_WEB_VARIANT&& event)
+  CURRENT_CONSTRUCTOR(EventLogEntry)(std::chrono::microseconds us, web_variant_t&& event)
       : SUPER(us), event(std::move(event)) {}
-  CURRENT_CONSTRUCTOR(EventLogEntry)(std::chrono::microseconds us, T_IOS_VARIANT&& event)
+  CURRENT_CONSTRUCTOR(EventLogEntry)(std::chrono::microseconds us, ios_variant_t&& event)
       : SUPER(us), event(std::move(event)) {}
 };
 
@@ -86,7 +93,8 @@ CURRENT_STRUCT(UnparsableLogEntry, LogEntryBase) {
 };
 // clang-format on
 
-using T_LOG_ENTRY_VARIANT = Variant<TickLogEntry, EventLogEntry, UnparsableLogEntry>;
+using log_entry_variant_t = Variant<TickLogEntry, EventLogEntry, UnparsableLogEntry>;
+using DEPRECATED_T_(LOG_ENTRY_VARIANT) = log_entry_variant_t;
 
 }  // namespace server
 }  // namespace midichlorians

--- a/Midichlorians/Server/server.h
+++ b/Midichlorians/Server/server.h
@@ -97,9 +97,9 @@ class MidichloriansHTTPServer {
   bool ParseBodyLineAsiOSEvent(const std::string& line) {
     using namespace current::midichlorians::ios;
 
-    Variant<T_IOS_EVENTS> ios_event;
+    Variant<ios_events_t> ios_event;
     try {
-      ios_event = ParseJSON<Variant<T_IOS_EVENTS>>(line);
+      ios_event = ParseJSON<Variant<ios_events_t>>(line);
     } catch (const InvalidJSONException&) {
       return false;
     }
@@ -135,7 +135,7 @@ class MidichloriansHTTPServer {
       return false;  // LCOV_EXCL_LINE
     }
 
-    Variant<T_WEB_EVENTS> web_event;
+    Variant<web_events_t> web_event;
     try {
       if (q.at("ea") == "En") {
         web_event = WebEnterEvent();
@@ -163,7 +163,7 @@ class MidichloriansHTTPServer {
   bool ExtractWebBaseEventFields(const std::map<std::string, std::string>& q,
                                  const std::map<std::string, std::string>& h,
                                  const std::map<std::string, current::net::http::Cookie>& c,
-                                 Variant<T_WEB_EVENTS>& web_event) {
+                                 Variant<web_events_t>& web_event) {
     using namespace current::midichlorians::web;
 
     static_cast<void>(c);  // Ignore cookies for now. -- D.K.
@@ -188,9 +188,9 @@ class MidichloriansHTTPServer {
     return true;
   }
 
-  template <typename T_LOG_ENTRY>
-  void PassLogEntryToConsumer(T_LOG_ENTRY&& entry, bool is_valid_entry = true) {
-    T_LOG_ENTRY_VARIANT entry_variant(std::move(entry));
+  template <typename LOG_ENTRY>
+  void PassLogEntryToConsumer(LOG_ENTRY&& entry, bool is_valid_entry = true) {
+    log_entry_variant_t entry_variant(std::move(entry));
     entry_variant.Call(log_entry_consumer_);
     if (is_valid_entry) {
       ++events_pushed_;

--- a/Midichlorians/Server/test.cc
+++ b/Midichlorians/Server/test.cc
@@ -169,7 +169,7 @@ TEST(MidichloriansServer, iOSEventsFromCPPSmokeTest) {
   current::time::SetNow(std::chrono::microseconds(12000));
   iOSAppLaunchEvent launch_event;
   launch_event.user_ms = std::chrono::milliseconds(1);
-  T_IOS_VARIANT event1(std::move(launch_event));
+  ios_variant_t event1(std::move(launch_event));
   const auto response1 = HTTP(POST(server_url, JSON(event1) + "\nblah"));
   EXPECT_EQ(200, static_cast<int>(response1.code));
   EXPECT_EQ("OK\n", response1.body);
@@ -186,11 +186,11 @@ TEST(MidichloriansServer, iOSEventsFromCPPSmokeTest) {
   iOSIdentifyEvent identify_event;
   identify_event.user_ms = std::chrono::milliseconds(42);
   identify_event.client_id = "unit_test";
-  T_IOS_VARIANT event2(std::move(identify_event));
+  ios_variant_t event2(std::move(identify_event));
   iOSFocusEvent focus_event;
   focus_event.user_ms = std::chrono::milliseconds(50);
   focus_event.gained_focus = true;
-  T_IOS_VARIANT event3(std::move(focus_event));
+  ios_variant_t event3(std::move(focus_event));
   const auto response2 = HTTP(POST(server_url, JSON(event2) + "\nmeh\n" + JSON(event3)));
   EXPECT_EQ(200, static_cast<int>(response2.code));
   EXPECT_EQ("OK\n", response2.body);

--- a/Sherlock/sherlock.h
+++ b/Sherlock/sherlock.h
@@ -118,13 +118,13 @@ using DEFAULT_PERSISTENCE_LAYER = current::persistence::Memory<ENTRY>;
 template <typename ENTRY, template <typename> class PERSISTENCE_LAYER = DEFAULT_PERSISTENCE_LAYER>
 class StreamImpl {
  public:
-  using T_ENTRY = ENTRY;
-  using T_PERSISTENCE_LAYER = PERSISTENCE_LAYER<ENTRY>;
+  using entry_t = ENTRY;
+  using persistence_layer_t = PERSISTENCE_LAYER<ENTRY>;
 
   // The inner structure containing all the data required for the stream to function.
   // TODO(dkorolev): Make it a `ScopeOwnedByMe` type of thing.
   struct StreamData {
-    T_PERSISTENCE_LAYER persistence;
+    persistence_layer_t persistence;
 
     current::WaitableTerminateSignalBulkNotifier notifier;
     std::mutex mutex;
@@ -340,10 +340,10 @@ class StreamImpl {
   // can be `std::move()`-d into the subscriber thread. It can be `Join()`-ed or `Detach()`-ed.
   // The order of two template parameters is flipped to provide the default value for `TYPE_SUBSCRIBED_TO`,
   // in case the user chooses to specialize `{Async/Sync}SubscriberScope<SINGLE_TEMPLATE_PARAMETER>` directly.
-  template <typename F, typename TYPE_SUBSCRIBED_TO = T_ENTRY>
+  template <typename F, typename TYPE_SUBSCRIBED_TO = entry_t>
   using AsyncSubscriberScope = GenericSubscriberScope<F, TYPE_SUBSCRIBED_TO, std::unique_ptr<F>, true>;
 
-  template <typename TYPE_SUBSCRIBED_TO = T_ENTRY, typename F>
+  template <typename TYPE_SUBSCRIBED_TO = entry_t, typename F>
   AsyncSubscriberScope<F, TYPE_SUBSCRIBED_TO> Subscribe(std::unique_ptr<F>&& subscriber) {
     static_assert(current::ss::IsStreamSubscriber<F, TYPE_SUBSCRIBED_TO>::value, "");
     return AsyncSubscriberScope<F, TYPE_SUBSCRIBED_TO>(data_, std::move(subscriber));
@@ -353,11 +353,11 @@ class StreamImpl {
   // should ensure to terminate itself, when initiated from within the destructor of `SyncSubscriberScope`.
   // Note that the destructor of `SyncSubscriberScope` will wait until the subscriber terminates, thus,
   // not terminating as requested may result in the calling thread blocking for an unbounded amount of time.
-  template <typename F, typename TYPE_SUBSCRIBED_TO = T_ENTRY>
+  template <typename F, typename TYPE_SUBSCRIBED_TO = entry_t>
   using SyncSubscriberScope =
       GenericSubscriberScope<F, TYPE_SUBSCRIBED_TO, std::unique_ptr<F, current::NullDeleter>, false>;
 
-  template <typename TYPE_SUBSCRIBED_TO = T_ENTRY, typename F>
+  template <typename TYPE_SUBSCRIBED_TO = entry_t, typename F>
   SyncSubscriberScope<F, TYPE_SUBSCRIBED_TO> Subscribe(F& subscriber) {
     static_assert(current::ss::IsStreamSubscriber<F, TYPE_SUBSCRIBED_TO>::value, "");
     return SyncSubscriberScope<F, TYPE_SUBSCRIBED_TO>(data_,
@@ -392,7 +392,7 @@ class StreamImpl {
   // TODO(dkorolev): Have this co-own the Stream.
   void operator()(Request r) { ServeDataViaHTTP(std::move(r)); }
 
-  T_PERSISTENCE_LAYER& InternalExposePersister() { return data_->persistence; }
+  persistence_layer_t& InternalExposePersister() { return data_->persistence; }
 
  private:
   std::shared_ptr<StreamData> data_;

--- a/Storage/api_base.h
+++ b/Storage/api_base.h
@@ -99,14 +99,14 @@ struct RESTfulRegisterTopLevelInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD>
 struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
-  T_ALL_FIELDS_BY_REFERENCE fields;
+  using mutable_fields_t = MutableFields<STORAGE>;
+  mutable_fields_t fields;
   const FIELD& field;
   const std::string field_name;
   const std::string url_key;
 
   RESTfulGETInput(const RESTfulGenericInput<STORAGE>& input,
-                  T_ALL_FIELDS_BY_REFERENCE fields,
+                  mutable_fields_t fields,
                   const FIELD& field,
                   const std::string& field_name,
                   const std::string& url_key)
@@ -116,7 +116,7 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
         field_name(field_name),
         url_key(url_key) {}
   RESTfulGETInput(RESTfulGenericInput<STORAGE>&& input,
-                  T_ALL_FIELDS_BY_REFERENCE fields,
+                  mutable_fields_t fields,
                   const FIELD& field,
                   const std::string& field_name,
                   const std::string& url_key)
@@ -129,14 +129,14 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD, typename ENTRY>
 struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
-  T_ALL_FIELDS_BY_REFERENCE fields;
+  using mutable_fields_t = MutableFields<STORAGE>;
+  mutable_fields_t fields;
   FIELD& field;
   const std::string field_name;
   ENTRY& entry;
 
   RESTfulPOSTInput(const RESTfulGenericInput<STORAGE>& input,
-                   T_ALL_FIELDS_BY_REFERENCE fields,
+                   mutable_fields_t fields,
                    FIELD& field,
                    const std::string& field_name,
                    ENTRY& entry)
@@ -146,7 +146,7 @@ struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
         field_name(field_name),
         entry(entry) {}
   RESTfulPOSTInput(RESTfulGenericInput<STORAGE>&& input,
-                   T_ALL_FIELDS_BY_REFERENCE fields,
+                   mutable_fields_t fields,
                    FIELD& field,
                    const std::string& field_name,
                    ENTRY& entry)
@@ -159,8 +159,8 @@ struct RESTfulPOSTInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD, typename ENTRY, typename KEY>
 struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
-  T_ALL_FIELDS_BY_REFERENCE fields;
+  using mutable_fields_t = MutableFields<STORAGE>;
+  mutable_fields_t fields;
   FIELD& field;
   const std::string field_name;
   const KEY& url_key;
@@ -168,7 +168,7 @@ struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
   const KEY& entry_key;
 
   RESTfulPUTInput(const RESTfulGenericInput<STORAGE>& input,
-                  T_ALL_FIELDS_BY_REFERENCE fields,
+                  mutable_fields_t fields,
                   FIELD& field,
                   const std::string& field_name,
                   const KEY& url_key,
@@ -182,7 +182,7 @@ struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
         entry(entry),
         entry_key(entry_key) {}
   RESTfulPUTInput(RESTfulGenericInput<STORAGE>&& input,
-                  T_ALL_FIELDS_BY_REFERENCE fields,
+                  mutable_fields_t fields,
                   FIELD& field,
                   const std::string& field_name,
                   const KEY& url_key,
@@ -199,20 +199,20 @@ struct RESTfulPUTInput : RESTfulGenericInput<STORAGE> {
 
 template <typename STORAGE, typename FIELD, typename KEY>
 struct RESTfulDELETEInput : RESTfulGenericInput<STORAGE> {
-  using T_ALL_FIELDS_BY_REFERENCE = MutableFields<STORAGE>;
-  T_ALL_FIELDS_BY_REFERENCE fields;
+  using mutable_fields_t = MutableFields<STORAGE>;
+  mutable_fields_t fields;
   FIELD& field;
   const std::string field_name;
   const KEY& key;
 
   RESTfulDELETEInput(const RESTfulGenericInput<STORAGE>& input,
-                     T_ALL_FIELDS_BY_REFERENCE fields,
+                     mutable_fields_t fields,
                      FIELD& field,
                      const std::string& field_name,
                      const KEY& key)
       : RESTfulGenericInput<STORAGE>(input), fields(fields), field(field), field_name(field_name), key(key) {}
   RESTfulDELETEInput(RESTfulGenericInput<STORAGE>&& input,
-                     T_ALL_FIELDS_BY_REFERENCE fields,
+                     mutable_fields_t fields,
                      FIELD& field,
                      const std::string& field_name,
                      const KEY& key)

--- a/Storage/base.h
+++ b/Storage/base.h
@@ -61,19 +61,19 @@ struct FieldNameByIndex {};
 template <int N>
 struct ImmutableFieldByIndex {};
 
-template <int N, typename T_RETVAL>
+template <int N, typename RETVAL>
 struct ImmutableFieldByIndexAndReturn {};
 
 template <int N>
 struct MutableFieldByIndex {};
 
-template <int N, typename T_RETVAL>
+template <int N, typename RETVAL>
 struct MutableFieldByIndexAndReturn {};
 
 template <int N>
 struct FieldNameAndTypeByIndex {};
 
-template <int N, typename T_RETVAL>
+template <int N, typename RETVAL>
 struct FieldNameAndTypeByIndexAndReturn {};
 
 template <typename T>
@@ -87,7 +87,8 @@ struct FieldEntryTypeExtractor {};
 
 template <typename T>
 struct StorageExtractedFieldType {
-  using T_PARTICULAR_FIELD = T;
+  using particular_field_t = T;
+  using DEPRECATED_T_(PARTICULAR_FIELD) = T;
 };
 
 template <typename T>
@@ -99,15 +100,20 @@ template <typename T>
 struct FieldUnderlyingTypesWrapper {
   // The entry type itself.
   // For template-specialize user-defined API code with the specific entry underlying type.
-  using T_ENTRY = typename T::T_ENTRY;
+  using entry_t = typename T::entry_t;
 
   // For the RESTful API to understand URLs.
   // Map key type for dictionaries, `size_t` for vectors, etc.
-  using T_KEY = typename T::T_KEY;
+  using key_t = typename T::key_t;
 
   // For reflection.
-  using T_UPDATE_EVENT = typename T::T_UPDATE_EVENT;
-  using T_DELETE_EVENT = typename T::T_DELETE_EVENT;
+  using update_event_t = typename T::update_event_t;
+  using delete_event_t = typename T::delete_event_t;
+
+  using DEPRECATED_T_(ENTRY) = entry_t;
+  using DEPRECATED_T_(KEY) = key_t;
+  using DEPRECATED_T_(UPDATE_EVENT) = update_event_t;
+  using DEPRECATED_T_(DELETE_EVENT) = delete_event_t;
 };
 
 // Fields declaration and counting.
@@ -137,8 +143,10 @@ struct FieldCounter {
 // Helper class to get the corresponding persisted types for each of the storage fields.
 template <typename UPDATE_EVENT, typename DELETE_EVENT>
 struct FieldInfo {
-  using T_UPDATE_EVENT = UPDATE_EVENT;
-  using T_DELETE_EVENT = DELETE_EVENT;
+  using update_event_t = UPDATE_EVENT;
+  using delete_event_t = DELETE_EVENT;
+  using DEPRECATED_T_(UPDATE_EVENT) = update_event_t;
+  using DEPRECATED_T_(DELETE_EVENT) = delete_event_t;
 };
 
 // Persisted types list generator.
@@ -147,8 +155,8 @@ struct TypeListMapperImpl;
 
 template <typename FIELDS, int... NS>
 struct TypeListMapperImpl<FIELDS, current::variadic_indexes::indexes<NS...>> {
-  using result = TypeList<typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::T_UPDATE_EVENT...,
-                          typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::T_DELETE_EVENT...>;
+  using result = TypeList<typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::update_event_t...,
+                          typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::delete_event_t...>;
 };
 
 template <typename FIELDS, int COUNT>

--- a/Storage/container/one_to_one.h
+++ b/Storage/container/one_to_one.h
@@ -38,19 +38,19 @@ namespace storage {
 namespace container {
 
 template <typename T,
-          typename T_UPDATE_EVENT,
-          typename T_DELETE_EVENT,
+          typename UPDATE_EVENT,
+          typename DELETE_EVENT,
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericOneToOne {
  public:
-  using T_ROW = sfinae::ENTRY_ROW_TYPE<T>;
-  using T_COL = sfinae::ENTRY_COL_TYPE<T>;
-  using T_KEY = std::pair<T_ROW, T_COL>;
-  using T_ELEMENTS_MAP = std::unordered_map<T_KEY, std::unique_ptr<T>, CurrentHashFunction<T_KEY>>;
-  using T_FORWARD_MAP = ROW_MAP<T_ROW, const T*>;
-  using T_TRANSPOSED_MAP = COL_MAP<T_COL, const T*>;
-  using T_REST_BEHAVIOR = rest::behavior::Matrix;
+  using row_t = sfinae::ENTRY_ROW_TYPE<T>;
+  using col_t = sfinae::ENTRY_COL_TYPE<T>;
+  using key_t = std::pair<row_t, col_t>;
+  using elements_map_t = std::unordered_map<key_t, std::unique_ptr<T>, CurrentHashFunction<key_t>>;
+  using forward_map_t = ROW_MAP<row_t, const T*>;
+  using transposed_map_t = COL_MAP<col_t, const T*>;
+  using rest_behavior_t = rest::behavior::Matrix;
 
   explicit GenericOneToOne(MutationJournal& journal) : journal_(journal) {}
 
@@ -66,7 +66,7 @@ class GenericOneToOne {
     const auto it = map_.find(key);
     if (it != map_.end()) {
       const T& previous_object = *(it->second);
-      journal_.LogMutation(T_UPDATE_EVENT(object),
+      journal_.LogMutation(UPDATE_EVENT(object),
                            [this, key, previous_object]() { DoAdd(key, previous_object); });
     } else {
       const auto it_row = forward_.find(row);
@@ -78,11 +78,11 @@ class GenericOneToOne {
         const T& previous_object_same_col = *(it_col->second);
         const auto key_same_row = std::make_pair(row, sfinae::GetCol(previous_object_same_row));
         const auto key_same_col = std::make_pair(sfinae::GetRow(previous_object_same_col), col);
-        journal_.LogMutation(T_DELETE_EVENT(previous_object_same_row),
+        journal_.LogMutation(DELETE_EVENT(previous_object_same_row),
                              [this, key_same_row, previous_object_same_row]() {
                                DoAdd(key_same_row, previous_object_same_row);
                              });
-        journal_.LogMutation(T_DELETE_EVENT(previous_object_same_col),
+        journal_.LogMutation(DELETE_EVENT(previous_object_same_col),
                              [this, key_same_col, previous_object_same_col]() {
                                DoAdd(key_same_col, previous_object_same_col);
                              });
@@ -92,49 +92,49 @@ class GenericOneToOne {
         const T& previous_object = row_occupied ? *(it_row->second) : *(it_col->second);
         const auto previous_key =
             std::make_pair(sfinae::GetRow(previous_object), sfinae::GetCol(previous_object));
-        journal_.LogMutation(T_DELETE_EVENT(previous_object),
+        journal_.LogMutation(DELETE_EVENT(previous_object),
                              [this, previous_key, previous_object]() { DoAdd(previous_key, previous_object); });
         DoErase(previous_key);
       }
-      journal_.LogMutation(T_UPDATE_EVENT(object), [this, key]() { DoErase(key); });
+      journal_.LogMutation(UPDATE_EVENT(object), [this, key]() { DoErase(key); });
     }
     DoAdd(key, object);
   }
 
-  void Erase(const T_KEY& key) {
+  void Erase(const key_t& key) {
     const auto it = map_.find(key);
     if (it != map_.end()) {
       const T& previous_object = *(it->second);
-      journal_.LogMutation(T_DELETE_EVENT(previous_object),
+      journal_.LogMutation(DELETE_EVENT(previous_object),
                            [this, key, previous_object]() { DoAdd(key, previous_object); });
       DoErase(key);
     }
   }
-  void Erase(sfinae::CF<T_ROW> row, sfinae::CF<T_COL> col) { Erase(std::make_pair(row, col)); }
+  void Erase(sfinae::CF<row_t> row, sfinae::CF<col_t> col) { Erase(std::make_pair(row, col)); }
 
-  void EraseRow(sfinae::CF<T_ROW> row) {
+  void EraseRow(sfinae::CF<row_t> row) {
     const auto it = forward_.find(row);
     if (it != forward_.end()) {
       const T previous_object = *(it->second);
       const auto key = std::make_pair(row, sfinae::GetCol(previous_object));
-      journal_.LogMutation(T_DELETE_EVENT(previous_object),
+      journal_.LogMutation(DELETE_EVENT(previous_object),
                            [this, key, previous_object]() { DoAdd(key, previous_object); });
       DoErase(key);
     }
   }
 
-  void EraseCol(sfinae::CF<T_COL> col) {
+  void EraseCol(sfinae::CF<col_t> col) {
     const auto it = transposed_.find(col);
     if (it != transposed_.end()) {
       const T previous_object = *(it->second);
       const auto key = std::make_pair(sfinae::GetRow(previous_object), col);
-      journal_.LogMutation(T_DELETE_EVENT(previous_object),
+      journal_.LogMutation(DELETE_EVENT(previous_object),
                            [this, key, previous_object]() { DoAdd(key, previous_object); });
       DoErase(key);
     }
   }
 
-  ImmutableOptional<T> operator[](const T_KEY& key) const {
+  ImmutableOptional<T> operator[](const key_t& key) const {
     const auto it = map_.find(key);
     if (it != map_.end()) {
       return ImmutableOptional<T>(FromBarePointer(), it->second.get());
@@ -142,10 +142,10 @@ class GenericOneToOne {
       return nullptr;
     }
   }
-  ImmutableOptional<T> Get(sfinae::CF<T_ROW> row, sfinae::CF<T_COL> col) const {
+  ImmutableOptional<T> Get(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const {
     return operator[](std::make_pair(row, col));
   }
-  ImmutableOptional<T> GetEntryFromRow(sfinae::CF<T_ROW> row) const {
+  ImmutableOptional<T> GetEntryFromRow(sfinae::CF<row_t> row) const {
     const auto it = forward_.find(row);
     if (it != forward_.end()) {
       return ImmutableOptional<T>(FromBarePointer(), it->second);
@@ -153,7 +153,7 @@ class GenericOneToOne {
       return nullptr;
     }
   }
-  ImmutableOptional<T> GetEntryFromCol(sfinae::CF<T_COL> col) const {
+  ImmutableOptional<T> GetEntryFromCol(sfinae::CF<col_t> col) const {
     const auto it = transposed_.find(col);
     if (it != transposed_.end()) {
       return ImmutableOptional<T>(FromBarePointer(), it->second);
@@ -162,61 +162,61 @@ class GenericOneToOne {
     }
   }
 
-  bool DoesNotConflict(const T_KEY& key) const {
+  bool DoesNotConflict(const key_t& key) const {
     return forward_.find(key.first) == forward_.end() && transposed_.find(key.second) == transposed_.end();
   }
-  bool DoesNotConflict(sfinae::CF<T_ROW> row, sfinae::CF<T_COL> col) const {
+  bool DoesNotConflict(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const {
     return DoesNotConflict(std::make_pair(row, col));
   }
 
-  void operator()(const T_UPDATE_EVENT& e) {
+  void operator()(const UPDATE_EVENT& e) {
     const auto row = sfinae::GetRow(e.data);
     const auto col = sfinae::GetCol(e.data);
     DoAdd(std::make_pair(row, col), e.data);
   }
-  void operator()(const T_DELETE_EVENT& e) { DoErase(std::make_pair(e.key.first, e.key.second)); }
+  void operator()(const DELETE_EVENT& e) { DoErase(std::make_pair(e.key.first, e.key.second)); }
 
-  template <typename T_MAP>
+  template <typename MAP>
   struct MapAccessor final {
-    using T_KEY = typename T_MAP::key_type;
-    const T_MAP& map_;
+    using key_t = typename MAP::key_type;
+    const MAP& map_;
 
     struct Iterator final {
-      using T_ITERATOR = typename T_MAP::const_iterator;
-      T_ITERATOR iterator_;
-      explicit Iterator(T_ITERATOR iterator) : iterator_(iterator) {}
+      using iterator_t = typename MAP::const_iterator;
+      iterator_t iterator_;
+      explicit Iterator(iterator_t iterator) : iterator_(iterator) {}
       void operator++() { ++iterator_; }
       bool operator==(const Iterator& rhs) const { return iterator_ == rhs.iterator_; }
       bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
-      sfinae::CF<T_KEY> key() const { return iterator_->first; }
+      sfinae::CF<key_t> key() const { return iterator_->first; }
       const T& operator*() const { return *iterator_->second; }
       const T* operator->() const { return iterator_->second; }
     };
 
-    explicit MapAccessor(const T_MAP& map) : map_(map) {}
+    explicit MapAccessor(const MAP& map) : map_(map) {}
 
     bool Empty() const { return map_.empty(); }
 
     size_t Size() const { return map_.size(); }
 
-    bool Has(const T_KEY& x) const { return map_.find(x) != map_.end(); }
+    bool Has(const key_t& x) const { return map_.find(x) != map_.end(); }
 
     Iterator begin() const { return Iterator(map_.cbegin()); }
     Iterator end() const { return Iterator(map_.cend()); }
   };
 
-  const MapAccessor<T_FORWARD_MAP> Rows() const { return MapAccessor<T_FORWARD_MAP>(forward_); }
+  const MapAccessor<forward_map_t> Rows() const { return MapAccessor<forward_map_t>(forward_); }
 
-  const MapAccessor<T_TRANSPOSED_MAP> Cols() const { return MapAccessor<T_TRANSPOSED_MAP>(transposed_); }
+  const MapAccessor<transposed_map_t> Cols() const { return MapAccessor<transposed_map_t>(transposed_); }
 
   struct Iterator final {
-    using T_ITERATOR = typename T_ELEMENTS_MAP::const_iterator;
-    T_ITERATOR iterator_;
-    explicit Iterator(T_ITERATOR iterator) : iterator_(iterator) {}
+    using iterator_t = typename elements_map_t::const_iterator;
+    iterator_t iterator_;
+    explicit Iterator(iterator_t iterator) : iterator_(iterator) {}
     void operator++() { ++iterator_; }
     bool operator==(const Iterator& rhs) const { return iterator_ == rhs.iterator_; }
     bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
-    sfinae::CF<T_KEY> key() const { return iterator_->first; }
+    sfinae::CF<key_t> key() const { return iterator_->first; }
     const T& operator*() const { return *iterator_->second; }
     const T* operator->() const { return iterator_->second; }
   };
@@ -224,30 +224,30 @@ class GenericOneToOne {
   Iterator end() const { return Iterator(map_.end()); }
 
  private:
-  void DoErase(const T_KEY& key) {
+  void DoErase(const key_t& key) {
     forward_.erase(key.first);
     transposed_.erase(key.second);
     map_.erase(key);
   }
 
-  void DoAdd(const T_KEY& key, const T& object) {
+  void DoAdd(const key_t& key, const T& object) {
     auto& placeholder = map_[key];
     placeholder = std::make_unique<T>(object);
     forward_[key.first] = placeholder.get();
     transposed_[key.second] = placeholder.get();
   }
 
-  T_ELEMENTS_MAP map_;
-  T_FORWARD_MAP forward_;
-  T_TRANSPOSED_MAP transposed_;
+  elements_map_t map_;
+  forward_map_t forward_;
+  transposed_map_t transposed_;
   MutationJournal& journal_;
 };
 
-template <typename T, typename T_UPDATE_EVENT, typename T_DELETE_EVENT>
-using UnorderedOneToOne = GenericOneToOne<T, T_UPDATE_EVENT, T_DELETE_EVENT, Unordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedOneToOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
 
-template <typename T, typename T_UPDATE_EVENT, typename T_DELETE_EVENT>
-using OrderedOneToOne = GenericOneToOne<T, T_UPDATE_EVENT, T_DELETE_EVENT, Ordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedOneToOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
 
 }  // namespace container
 

--- a/Storage/container/sfinae.h
+++ b/Storage/container/sfinae.h
@@ -53,17 +53,17 @@ struct KEY_ACCESSOR_IMPL {};
 
 template <typename ENTRY>
 struct KEY_ACCESSOR_IMPL<ENTRY, false> {
-  typedef decltype(std::declval<ENTRY>().key) T_KEY;
-  static CF<T_KEY> GetKey(const ENTRY& entry) { return entry.key; }
-  static void SetKey(ENTRY& entry, T_KEY key) { entry.key = key; }
+  typedef decltype(std::declval<ENTRY>().key) key_t;
+  static CF<key_t> GetKey(const ENTRY& entry) { return entry.key; }
+  static void SetKey(ENTRY& entry, key_t key) { entry.key = key; }
 };
 
 template <typename ENTRY>
 struct KEY_ACCESSOR_IMPL<ENTRY, true> {
-  typedef decltype(std::declval<ENTRY>().key()) T_KEY;
+  typedef decltype(std::declval<ENTRY>().key()) key_t;
   // Can not return a reference to a temporary.
-  static const T_KEY GetKey(const ENTRY& entry) { return entry.key(); }
-  static void SetKey(ENTRY& entry, CF<T_KEY> key) { entry.set_key(key); }
+  static const key_t GetKey(const ENTRY& entry) { return entry.key(); }
+  static void SetKey(ENTRY& entry, CF<key_t> key) { entry.set_key(key); }
 };
 
 #ifndef CURRENT_WINDOWS
@@ -81,12 +81,12 @@ using KEY_ACCESSOR = typename KEY_ACCESSOR_FOR_HANDICAPPED<ENTRY>::type;
 #endif  // CURRENT_WINDOWS
 
 template <typename ENTRY>
-typename KEY_ACCESSOR<ENTRY>::T_KEY GetKey(const ENTRY& entry) {
+typename KEY_ACCESSOR<ENTRY>::key_t GetKey(const ENTRY& entry) {
   return KEY_ACCESSOR<ENTRY>::GetKey(entry);
 }
 
 template <typename ENTRY>
-using ENTRY_KEY_TYPE = current::decay<typename KEY_ACCESSOR<ENTRY>::T_KEY>;
+using ENTRY_KEY_TYPE = current::decay<typename KEY_ACCESSOR<ENTRY>::key_t>;
 
 template <typename ENTRY>
 void SetKey(ENTRY& entry, CF<ENTRY_KEY_TYPE<ENTRY>> key) {
@@ -112,36 +112,36 @@ struct ROW_ACCESSOR_IMPL {};
 
 template <typename ENTRY>
 struct ROW_ACCESSOR_IMPL<ENTRY, false> {
-  typedef decltype(std::declval<ENTRY>().row) T_ROW;
-  static CF<T_ROW> GetRow(const ENTRY& entry) { return entry.row; }
-  static void SetRow(ENTRY& entry, CF<T_ROW> row) { entry.row = row; }
+  typedef decltype(std::declval<ENTRY>().row) row_t;
+  static CF<row_t> GetRow(const ENTRY& entry) { return entry.row; }
+  static void SetRow(ENTRY& entry, CF<row_t> row) { entry.row = row; }
 };
 
 template <typename ENTRY>
 struct ROW_ACCESSOR_IMPL<ENTRY, true> {
-  typedef decltype(std::declval<ENTRY>().row()) T_ROW;
+  typedef decltype(std::declval<ENTRY>().row()) row_t;
   // Can not return a reference to a temporary.
-  static const T_ROW GetRow(const ENTRY& entry) { return entry.row(); }
-  static void SetRow(ENTRY& entry, CF<T_ROW> row) { entry.set_row(row); }
+  static const row_t GetRow(const ENTRY& entry) { return entry.row(); }
+  static void SetRow(ENTRY& entry, CF<row_t> row) { entry.set_row(row); }
 };
 
 template <typename ROW, typename COL>
 struct ROW_ACCESSOR_IMPL<std::pair<ROW, COL>, false> {
-  typedef ROW T_ROW;
-  static CF<T_ROW> GetRow(const std::pair<ROW, COL>& entry) { return entry.first; }
-  static void SetRow(std::pair<ROW, COL>& entry, CF<T_ROW> row) { entry.first = row; }
+  typedef ROW row_t;
+  static CF<row_t> GetRow(const std::pair<ROW, COL>& entry) { return entry.first; }
+  static void SetRow(std::pair<ROW, COL>& entry, CF<row_t> row) { entry.first = row; }
 };
 
 template <typename ENTRY>
 using ROW_ACCESSOR = ROW_ACCESSOR_IMPL<ENTRY, HasRowFunction<ENTRY>(0)>;
 
 template <typename ENTRY>
-typename ROW_ACCESSOR<ENTRY>::T_ROW GetRow(const ENTRY& entry) {
+typename ROW_ACCESSOR<ENTRY>::row_t GetRow(const ENTRY& entry) {
   return ROW_ACCESSOR<ENTRY>::GetRow(entry);
 }
 
 template <typename ENTRY>
-using ENTRY_ROW_TYPE = current::decay<typename ROW_ACCESSOR<ENTRY>::T_ROW>;
+using ENTRY_ROW_TYPE = current::decay<typename ROW_ACCESSOR<ENTRY>::row_t>;
 
 template <typename ENTRY>
 void SetRow(ENTRY& entry, CF<ENTRY_ROW_TYPE<ENTRY>> row) {
@@ -163,36 +163,36 @@ struct COL_ACCESSOR_IMPL {};
 
 template <typename ENTRY>
 struct COL_ACCESSOR_IMPL<ENTRY, false> {
-  typedef decltype(std::declval<ENTRY>().col) T_COL;
-  static CF<T_COL> GetCol(const ENTRY& entry) { return entry.col; }
-  static void SetCol(ENTRY& entry, T_COL col) { entry.col = col; }
+  typedef decltype(std::declval<ENTRY>().col) col_t;
+  static CF<col_t> GetCol(const ENTRY& entry) { return entry.col; }
+  static void SetCol(ENTRY& entry, col_t col) { entry.col = col; }
 };
 
 template <typename ENTRY>
 struct COL_ACCESSOR_IMPL<ENTRY, true> {
-  typedef decltype(std::declval<ENTRY>().col()) T_COL;
+  typedef decltype(std::declval<ENTRY>().col()) col_t;
   // Can not return a reference to a temporary.
-  static const T_COL GetCol(const ENTRY& entry) { return entry.col(); }
-  static void SetCol(ENTRY& entry, CF<T_COL> col) { entry.set_col(col); }
+  static const col_t GetCol(const ENTRY& entry) { return entry.col(); }
+  static void SetCol(ENTRY& entry, CF<col_t> col) { entry.set_col(col); }
 };
 
 template <typename ROW, typename COL>
 struct COL_ACCESSOR_IMPL<std::pair<ROW, COL>, false> {
-  typedef COL T_COL;
-  static CF<T_COL> GetCol(const std::pair<COL, COL>& entry) { return entry.second; }
-  static void SetCol(std::pair<COL, COL>& entry, CF<T_COL> col) { entry.second = col; }
+  typedef COL col_t;
+  static CF<col_t> GetCol(const std::pair<COL, COL>& entry) { return entry.second; }
+  static void SetCol(std::pair<COL, COL>& entry, CF<col_t> col) { entry.second = col; }
 };
 
 template <typename ENTRY>
 using COL_ACCESSOR = COL_ACCESSOR_IMPL<ENTRY, HasColFunction<ENTRY>(0)>;
 
 template <typename ENTRY>
-typename COL_ACCESSOR<ENTRY>::T_COL GetCol(const ENTRY& entry) {
+typename COL_ACCESSOR<ENTRY>::col_t GetCol(const ENTRY& entry) {
   return COL_ACCESSOR<ENTRY>::GetCol(entry);
 }
 
 template <typename ENTRY>
-using ENTRY_COL_TYPE = current::decay<typename COL_ACCESSOR<ENTRY>::T_COL>;
+using ENTRY_COL_TYPE = current::decay<typename COL_ACCESSOR<ENTRY>::col_t>;
 
 template <typename ENTRY>
 void SetCol(ENTRY& entry, CF<ENTRY_COL_TYPE<ENTRY>> col) {

--- a/Storage/docu/docu_2_code.cc
+++ b/Storage/docu/docu_2_code.cc
@@ -198,7 +198,7 @@ TEST(StorageDocumentation, BasicUsage) {
     const auto persisted_idx_ts = ParseJSON<idxts_t>(line.substr(0, tab_pos));
     EXPECT_EQ(index, persisted_idx_ts.index);
     EXPECT_EQ(timestamp, persisted_idx_ts.us);
-    return ParseJSON<ExampleStorage::T_TRANSACTION>(line.substr(tab_pos + 1));
+    return ParseJSON<ExampleStorage::transaction_t>(line.substr(tab_pos + 1));
   };
 
   {

--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -75,7 +75,7 @@ CURRENT_STRUCT(Client, BriefClient) {
 
   CURRENT_CONSTRUCTOR(Client)(ClientID key = ClientID::INVALID) : SUPER(key) {}
 
-  using T_BRIEF = BriefClient;
+  using brief_t = BriefClient;
 };
 
 CURRENT_STORAGE_FIELD_ENTRY(OrderedDictionary, Client, PersistedClient);
@@ -467,7 +467,7 @@ TEST(StorageDocumentation, RESTFillingTransactionMetaExample) {
   const auto idx_ts = ParseJSON<idxts_t>(add_fields[0]);
   EXPECT_EQ(0u, idx_ts.index);
   EXPECT_EQ(1024, idx_ts.us.count());
-  const auto add_transaction = ParseJSON<TestStorage::T_TRANSACTION>(add_fields[1]);
+  const auto add_transaction = ParseJSON<TestStorage::transaction_t>(add_fields[1]);
   EXPECT_EQ(1024, add_transaction.meta.timestamp.count());
   ASSERT_EQ(1u, add_transaction.meta.fields.size());
   EXPECT_EQ("unittest", add_transaction.meta.fields.at("who"));
@@ -483,7 +483,7 @@ TEST(StorageDocumentation, RESTFillingTransactionMetaExample) {
 
   const auto del_fields = current::strings::Split(persisted_entries[1], '\t');
   ASSERT_TRUE(del_fields.size() == 2u);
-  const auto del_transaction = ParseJSON<TestStorage::T_TRANSACTION>(del_fields[1]);
+  const auto del_transaction = ParseJSON<TestStorage::transaction_t>(del_fields[1]);
   EXPECT_EQ(2000, del_transaction.meta.timestamp.count());
   ASSERT_EQ(1u, del_transaction.meta.fields.size());
   EXPECT_EQ("unittest", del_transaction.meta.fields.at("who"));

--- a/Storage/persister/file.h
+++ b/Storage/persister/file.h
@@ -42,8 +42,11 @@ class JSONFilePersister;
 template <typename... TS>
 class JSONFilePersister<TypeList<TS...>, NoCustomPersisterParam> {
  public:
-  using T_VARIANT = Variant<TS...>;
-  using T_TRANSACTION = std::vector<T_VARIANT>;  // Mock to make it compile.
+  using variant_t = Variant<TS...>;
+  using transaction_t = std::vector<variant_t>;  // Mock to make it compile.
+
+  using DEPRECATED_T_(VARIANT) = variant_t;
+  using DEPRECATED_T_(TRANSACTION) = transaction_t;
 
   explicit JSONFilePersister(const std::string& filename) : filename_(filename) {}
 
@@ -53,7 +56,7 @@ class JSONFilePersister<TypeList<TS...>, NoCustomPersisterParam> {
       throw StorageCannotAppendToFileException(filename_);  // LCOV_EXCL_LINE
     }
     for (auto&& entry : journal.commit_log) {
-      os << JSON(T_VARIANT(std::move(entry))) << '\n';
+      os << JSON(variant_t(std::move(entry))) << '\n';
     }
     journal.commit_log.clear();
     journal.rollback_log.clear();
@@ -65,7 +68,7 @@ class JSONFilePersister<TypeList<TS...>, NoCustomPersisterParam> {
     std::ifstream is(filename_);
     if (is.good()) {
       for (std::string line; std::getline(is, line);) {
-        f(std::move(ParseJSON<T_VARIANT>(line)));
+        f(std::move(ParseJSON<variant_t>(line)));
       }
     }
   }

--- a/Storage/persister/sherlock.h
+++ b/Storage/persister/sherlock.h
@@ -41,27 +41,30 @@ class SherlockStreamPersisterImpl;
 template <template <typename> class UNDERLYING_PERSISTER, typename STREAM_RECORD_TYPE, typename... TS>
 class SherlockStreamPersisterImpl<TypeList<TS...>, UNDERLYING_PERSISTER, STREAM_RECORD_TYPE> {
  public:
-  using T_VARIANT = Variant<TS...>;
-  using T_TRANSACTION = Transaction<T_VARIANT>;
-  using T_SHERLOCK_ENTRY =
+  using variant_t = Variant<TS...>;
+  using transaction_t = Transaction<variant_t>;
+  using sherlock_entry_t =
       typename std::conditional<std::is_same<STREAM_RECORD_TYPE, NoCustomPersisterParam>::value,
-                                T_TRANSACTION,
+                                transaction_t,
                                 STREAM_RECORD_TYPE>::type;
-  using T_SHERLOCK = sherlock::Stream<T_SHERLOCK_ENTRY, UNDERLYING_PERSISTER>;
+  using sherlock_t = sherlock::Stream<sherlock_entry_t, UNDERLYING_PERSISTER>;
+
+  using DEPRECATED_T_(VARIANT) = variant_t;
+  using DEPRECATED_T_(TRANSACTION) = transaction_t;
 
   template <typename... ARGS>
   explicit SherlockStreamPersisterImpl(ARGS&&... args)
-      : stream_owned_if_any_(std::make_unique<sherlock::Stream<T_SHERLOCK_ENTRY, UNDERLYING_PERSISTER>>(
+      : stream_owned_if_any_(std::make_unique<sherlock::Stream<sherlock_entry_t, UNDERLYING_PERSISTER>>(
             std::forward<ARGS>(args)...)),
         stream_used_(*stream_owned_if_any_.get()) {}
 
   // TODO(dkorolev): `ScopeOwnedBySomeoneElse<>` ?
-  explicit SherlockStreamPersisterImpl(T_SHERLOCK& stream_owned_by_someone_else)
+  explicit SherlockStreamPersisterImpl(sherlock_t& stream_owned_by_someone_else)
       : stream_used_(stream_owned_by_someone_else) {}
 
   void PersistJournal(MutationJournal& journal) {
     if (!journal.commit_log.empty()) {
-      T_TRANSACTION transaction;
+      transaction_t transaction;
       for (auto&& entry : journal.commit_log) {
         transaction.mutations.emplace_back(std::move(entry));
       }
@@ -78,8 +81,8 @@ class SherlockStreamPersisterImpl<TypeList<TS...>, UNDERLYING_PERSISTER, STREAM_
     // TODO(dkorolev) + TODO(mzhurovich): Perhaps `Replay()` should happen automatically,
     // during construction, in a blocking way?
     for (const auto& stream_record : stream_used_.InternalExposePersister().Iterate()) {
-      if (Exists<T_TRANSACTION>(stream_record.entry)) {
-        const T_TRANSACTION& transaction = Value<T_TRANSACTION>(stream_record.entry);
+      if (Exists<transaction_t>(stream_record.entry)) {
+        const transaction_t& transaction = Value<transaction_t>(stream_record.entry);
         for (const auto& mutation : transaction.mutations) {
           f(mutation);
         }
@@ -87,7 +90,7 @@ class SherlockStreamPersisterImpl<TypeList<TS...>, UNDERLYING_PERSISTER, STREAM_
     }
   }
 
-  void ReplayTransaction(T_TRANSACTION&& transaction, current::ss::IndexAndTimestamp idx_ts) {
+  void ReplayTransaction(transaction_t&& transaction, current::ss::IndexAndTimestamp idx_ts) {
     if (stream_used_.Publish(transaction, idx_ts.us).index != idx_ts.index) {
       CURRENT_THROW(current::Exception());  // TODO(dkorolev): Proper exception text.
     }
@@ -97,11 +100,11 @@ class SherlockStreamPersisterImpl<TypeList<TS...>, UNDERLYING_PERSISTER, STREAM_
     handlers_scope_ += HTTP(port).Register(route, URLPathArgs::CountMask::None, stream_used_);
   }
 
-  T_SHERLOCK& InternalExposeStream() { return stream_used_; }
+  sherlock_t& InternalExposeStream() { return stream_used_; }
 
   // `stream_{used/owned}_` are two variables to support both owning and non-owning Storage usage patterns.
-  std::unique_ptr<sherlock::Stream<T_TRANSACTION, UNDERLYING_PERSISTER>> stream_owned_if_any_;
-  T_SHERLOCK& stream_used_;
+  std::unique_ptr<sherlock::Stream<transaction_t, UNDERLYING_PERSISTER>> stream_owned_if_any_;
+  sherlock_t& stream_used_;
 
   HTTPRoutesScope handlers_scope_;
 };

--- a/Storage/rest/advanced_hypermedia.h
+++ b/Storage/rest/advanced_hypermedia.h
@@ -85,7 +85,7 @@ struct AdvancedHypermedia : Hypermedia {
 
   template <typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
   struct RESTful<GET, PARTICULAR_FIELD, ENTRY, KEY> {
-    using T_BRIEF_ENTRY = sfinae::BRIEF_OF_T<ENTRY>;
+    using brief_entry_t = sfinae::BRIEF_OF_T<ENTRY>;
 
     // For per-record view, whether a full or brief format should be used.
     bool brief = false;
@@ -110,7 +110,7 @@ struct AdvancedHypermedia : Hypermedia {
         const ImmutableOptional<ENTRY> result = input.field[current::FromString<KEY>(input.url_key)];
         if (Exists(result)) {
           const auto& value = Value(result);
-          return (brief ? Response(FormatAsAdvancedHypermediaRecord<T_BRIEF_ENTRY>(value, input),
+          return (brief ? Response(FormatAsAdvancedHypermediaRecord<brief_entry_t>(value, input),
                                    HTTPResponseCode.OK)
                         : Response(FormatAsAdvancedHypermediaRecord<ENTRY>(value, input), HTTPResponseCode.OK));
         } else {
@@ -119,9 +119,9 @@ struct AdvancedHypermedia : Hypermedia {
               HTTPResponseCode.NotFound);
         }
       } else {
-        // Collection view. `data` is an array of `AdvancedHypermediaRESTRecordResponse<T_BRIEF_ENTRY>`.
-        using T_DATA_ENTRY = AdvancedHypermediaRESTRecordResponse<T_BRIEF_ENTRY>;
-        AdvancedHypermediaRESTContainerResponse<T_DATA_ENTRY> response;
+        // Collection view. `data` is an array of `AdvancedHypermediaRESTRecordResponse<brief_entry_t>`.
+        using data_entry_t = AdvancedHypermediaRESTRecordResponse<brief_entry_t>;
+        AdvancedHypermediaRESTContainerResponse<data_entry_t> response;
         response.url_directory = input.restful_url_prefix + "/data/" + input.field_name;
         const auto GenPageURL = [&](uint64_t i, uint64_t n) {
           return input.restful_url_prefix + "/data/" + input.field_name + "?i=" + current::ToString(i) + "&n=" +
@@ -133,7 +133,7 @@ struct AdvancedHypermedia : Hypermedia {
         bool has_next_page = false;
         for (const auto& element : PerStorageFieldType<PARTICULAR_FIELD>::Iterate(input.field)) {
           if (i >= query_i && i < query_i + query_n) {
-            response.data.push_back(FormatAsAdvancedHypermediaRecord<T_BRIEF_ENTRY>(element, input, false));
+            response.data.push_back(FormatAsAdvancedHypermediaRecord<brief_entry_t>(element, input, false));
           } else if (i < query_i) {
             has_previous_page = true;
           } else if (i >= query_i + query_n) {

--- a/Storage/rest/hypermedia.h
+++ b/Storage/rest/hypermedia.h
@@ -54,16 +54,16 @@ CURRENT_STRUCT(HypermediaRESTStatus) {
 };
 
 CURRENT_STRUCT(HypermediaRESTError) {
-  using T_DETAILS = std::map<std::string, std::string>;
+  using details_t = std::map<std::string, std::string>;
   CURRENT_FIELD(name, std::string, "");
   CURRENT_FIELD(message, std::string, "");
-  CURRENT_FIELD(details, Optional<T_DETAILS>);
+  CURRENT_FIELD(details, Optional<details_t>);
 
   CURRENT_DEFAULT_CONSTRUCTOR(HypermediaRESTError) {}
   CURRENT_CONSTRUCTOR(HypermediaRESTError)(const std::string& name, const std::string& message)
       : name(name), message(message) {}
   CURRENT_CONSTRUCTOR(HypermediaRESTError)(
-      const std::string& name, const std::string& message, const T_DETAILS& details)
+      const std::string& name, const std::string& message, const details_t& details)
       : name(name), message(message), details(details) {}
 };
 

--- a/Storage/rest/sfinae.h
+++ b/Storage/rest/sfinae.h
@@ -39,7 +39,7 @@ constexpr bool Has_T_BRIEF(char) {
 }
 
 template <typename T>
-constexpr auto Has_T_BRIEF(int) -> decltype(sizeof(typename T::T_BRIEF), bool()) {
+constexpr auto Has_T_BRIEF(int) -> decltype(sizeof(typename T::brief_t), bool()) {
   return true;
 }
 
@@ -53,7 +53,7 @@ struct BRIEF_OF_T_IMPL<T, false> {
 
 template <typename T>
 struct BRIEF_OF_T_IMPL<T, true> {
-  using type = typename T::T_BRIEF;
+  using type = typename T::brief_t;
 };
 
 template <typename T>

--- a/Storage/storage.h
+++ b/Storage/storage.h
@@ -25,14 +25,14 @@ SOFTWARE.
 
 // Current-friendly container types.
 
-// * (Ordered/Unordered)Dictionary<T> <=> std::(map/unordered_map)<T_KEY, T>
+// * (Ordered/Unordered)Dictionary<T> <=> std::(map/unordered_map)<key_t, T>
 //   Empty(), Size(), operator[](key), Erase(key) [, iteration, {lower/upper}_bound].
-//   `T_KEY` is either the type of `T.key` or of `T.get_key()`.
+//   `key_t` is either the type of `T.key` or of `T.get_key()`.
 //
-// * (Ordered/Unordered)Matrix<T> <=> { T_ROW, T_COL } -> T, two `std::(map/unordered_map)<>`-s.
-//   Entries are stored in third `std::unordered_map<std::pair<T_ROW, T_COL>, std::unique_ptr<T>>`.
+// * (Ordered/Unordered)Matrix<T> <=> { row_t, col_t } -> T, two `std::(map/unordered_map)<>`-s.
+//   Entries are stored in third `std::unordered_map<std::pair<row_t, col_t>, std::unique_ptr<T>>`.
 //   Empty(), Size(), Rows()/Cols(), Add(cell), Delete(row, col) [, iteration, {lower/upper}_bound].
-//   `T_ROW` and `T_COL` are either the type of `T.row` / `T.col`, or of `T.get_row()` / `T.get_col()`.
+//   `row_t` and `col_t` are either the type of `T.row` / `T.col`, or of `T.get_row()` / `T.get_col()`.
 //
 // All Current-friendly types support persistence.
 //
@@ -79,13 +79,19 @@ namespace storage {
   };                                                                                         \
   struct entry_name {                                                                        \
     template <typename T, typename E1, typename E2>                                          \
-    using T_FIELD_TYPE = dictionary_type<T, E1, E2>;                                         \
-    using T_ENTRY = entry_type;                                                              \
-    using T_KEY = ::current::storage::sfinae::ENTRY_KEY_TYPE<entry_type>;                    \
-    using T_UPDATE_EVENT = entry_name##Updated;                                              \
-    using T_DELETE_EVENT = entry_name##Deleted;                                              \
-    using T_PERSISTED_EVENT_1 = entry_name##Updated;                                         \
-    using T_PERSISTED_EVENT_2 = entry_name##Deleted;                                         \
+    using field_t = dictionary_type<T, E1, E2>;                                              \
+    using entry_t = entry_type;                                                              \
+    using key_t = ::current::storage::sfinae::ENTRY_KEY_TYPE<entry_type>;                    \
+    using update_event_t = entry_name##Updated;                                              \
+    using delete_event_t = entry_name##Deleted;                                              \
+    using persisted_event_1_t = entry_name##Updated;                                         \
+    using persisted_event_2_t = entry_name##Deleted;                                         \
+    using DEPRECATED_T_(ENTRY) = entry_t;                                                    \
+    using DEPRECATED_T_(KEY) = key_t;                                                        \
+    using DEPRECATED_T_(UPDATE_EVENT) = update_event_t;                                      \
+    using DEPRECATED_T_(DELETE_EVENT) = delete_event_t;                                      \
+    using DEPRECATED_T_(PERSISTED_EVENT_1) = persisted_event_1_t;                            \
+    using DEPRECATED_T_(PERSISTED_EVENT_2) = persisted_event_2_t;                            \
   }
 
 #define CURRENT_STORAGE_FIELD_ENTRY_UnorderedDictionary(entry_type, entry_name) \
@@ -111,15 +117,23 @@ namespace storage {
   };                                                                                    \
   struct entry_name {                                                                   \
     template <typename T, typename E1, typename E2>                                     \
-    using T_FIELD_TYPE = matrix_type<T, E1, E2>;                                        \
-    using T_ENTRY = entry_type;                                                         \
-    using T_ROW = ::current::storage::sfinae::ENTRY_ROW_TYPE<entry_type>;               \
-    using T_COL = ::current::storage::sfinae::ENTRY_COL_TYPE<entry_type>;               \
-    using T_KEY = std::pair<T_ROW, T_COL>;                                              \
-    using T_UPDATE_EVENT = entry_name##Updated;                                         \
-    using T_DELETE_EVENT = entry_name##Deleted;                                         \
-    using T_PERSISTED_EVENT_1 = entry_name##Updated;                                    \
-    using T_PERSISTED_EVENT_2 = entry_name##Deleted;                                    \
+    using field_t = matrix_type<T, E1, E2>;                                             \
+    using entry_t = entry_type;                                                         \
+    using row_t = ::current::storage::sfinae::ENTRY_ROW_TYPE<entry_type>;               \
+    using col_t = ::current::storage::sfinae::ENTRY_COL_TYPE<entry_type>;               \
+    using key_t = std::pair<row_t, col_t>;                                              \
+    using update_event_t = entry_name##Updated;                                         \
+    using delete_event_t = entry_name##Deleted;                                         \
+    using persisted_event_1_t = entry_name##Updated;                                    \
+    using persisted_event_2_t = entry_name##Deleted;                                    \
+    using DEPRECATED_T_(ENTRY) = entry_t;                                               \
+    using DEPRECATED_T_(ROW) = row_t;                                                   \
+    using DEPRECATED_T_(COL) = col_t;                                                   \
+    using DEPRECATED_T_(KEY) = key_t;                                                   \
+    using DEPRECATED_T_(UPDATE_EVENT) = update_event_t;                                 \
+    using DEPRECATED_T_(DELETE_EVENT) = delete_event_t;                                 \
+    using DEPRECATED_T_(PERSISTED_EVENT_1) = persisted_event_1_t;                       \
+    using DEPRECATED_T_(PERSISTED_EVENT_2) = persisted_event_2_t;                       \
   }
 
 #define CURRENT_STORAGE_FIELD_ENTRY_UnorderedMatrix(entry_type, entry_name) \
@@ -164,26 +178,33 @@ using CURRENT_STORAGE_DEFAULT_TRANSACTION_POLICY = transaction_policy::Synchrono
   struct CURRENT_STORAGE_IMPL_##name {                                                                       \
    public:                                                                                                   \
     enum { FIELDS_COUNT = ::current::storage::FieldCounter<FIELDS>::value };                                 \
-    using T_FIELDS_TYPE_LIST = ::current::storage::FieldsTypeList<FIELDS, FIELDS_COUNT>;                     \
-    using T_FIELDS_VARIANT = Variant<T_FIELDS_TYPE_LIST>;                                                    \
-    using T_PERSISTER = PERSISTER<T_FIELDS_TYPE_LIST, CUSTOM_PERSISTER_PARAM>;                               \
+    using fields_type_list_t = ::current::storage::FieldsTypeList<FIELDS, FIELDS_COUNT>;                     \
+    using fields_variant_t = Variant<fields_type_list_t>;                                                    \
+    using persister_t = PERSISTER<fields_type_list_t, CUSTOM_PERSISTER_PARAM>;                               \
+    using DEPRECATED_T_(FIELDS_TYPE_LIST) = fields_type_list_t;                                              \
+    using DEPRECATED_T_(FIELDS_VARIANT) = fields_variant_t;                                                  \
+    using DEPRECATED_T_(PERSISTER) = persister_t;                                                            \
                                                                                                              \
    private:                                                                                                  \
     FIELDS fields_;                                                                                          \
-    T_PERSISTER persister_;                                                                                  \
-    TRANSACTION_POLICY<T_PERSISTER> transaction_policy_;                                                     \
+    persister_t persister_;                                                                                  \
+    TRANSACTION_POLICY<persister_t> transaction_policy_;                                                     \
                                                                                                              \
    public:                                                                                                   \
-    using T_FIELDS_BY_REFERENCE = FIELDS&;                                                                   \
-    using T_FIELDS_BY_CONST_REFERENCE = const FIELDS&;                                                       \
-    using T_TRANSACTION = ::current::storage::Transaction<T_FIELDS_VARIANT>;                                 \
-    using T_TRANSACTION_META_FIELDS = ::current::storage::TransactionMetaFields;                             \
+    using fields_by_ref_t = FIELDS&;                                                                         \
+    using fields_by_cref_t = const FIELDS&;                                                                  \
+    using transaction_t = ::current::storage::Transaction<fields_variant_t>;                                 \
+    using transaction_meta_fields_t = ::current::storage::TransactionMetaFields;                             \
+    using DEPRECATED_T_(FIELDS_BY_REFERENCE) = fields_by_ref_t;                                              \
+    using DEPRECATED_T_(FIELDS_BY_CONST_REFERENCE) = fields_by_cref_t;                                       \
+    using DEPRECATED_T_(TRANSACTION) = transaction_t;                                                        \
+    using DEPRECATED_T_(TRANSACTION_META_FIELDS) = transaction_meta_fields_t;                                \
     CURRENT_STORAGE_IMPL_##name& operator=(const CURRENT_STORAGE_IMPL_##name&) = delete;                     \
     template <typename... ARGS>                                                                              \
     CURRENT_STORAGE_IMPL_##name(ARGS&&... args)                                                              \
         : persister_(std::forward<ARGS>(args)...),                                                           \
           transaction_policy_(persister_, fields_.current_storage_mutation_journal_) {                       \
-      persister_.Replay([this](const T_FIELDS_VARIANT& entry) { entry.Call(fields_); });                     \
+      persister_.Replay([this](const fields_variant_t& entry) { entry.Call(fields_); });                     \
     }                                                                                                        \
     template <typename... ARGS>                                                                              \
     typename std::result_of<FIELDS(ARGS...)>::type operator()(ARGS&&... args) {                              \
@@ -192,9 +213,9 @@ using CURRENT_STORAGE_DEFAULT_TRANSACTION_POLICY = transaction_policy::Synchrono
                                                                                                              \
    public:                                                                                                   \
     template <typename F>                                                                                    \
-    using T_F_RESULT = typename std::result_of<F(T_FIELDS_BY_REFERENCE)>::type;                              \
+    using f_result_t = typename std::result_of<F(fields_by_ref_t)>::type;                                    \
     template <typename F>                                                                                    \
-    ::current::Future<::current::storage::TransactionResult<T_F_RESULT<F>>, ::current::StrictFuture::Strict> \
+    ::current::Future<::current::storage::TransactionResult<f_result_t<F>>, ::current::StrictFuture::Strict> \
     Transaction(F&& f) {                                                                                     \
       return transaction_policy_.Transaction([&f, this]() { return f(fields_); });                           \
     }                                                                                                        \
@@ -203,15 +224,15 @@ using CURRENT_STORAGE_DEFAULT_TRANSACTION_POLICY = transaction_policy::Synchrono
     Transaction(F1&& f1, F2&& f2) {                                                                          \
       return transaction_policy_.Transaction([&f1, this]() { return f1(fields_); }, std::forward<F2>(f2));   \
     }                                                                                                        \
-    void ReplayTransaction(T_TRANSACTION&& transaction, ::current::ss::IndexAndTimestamp idx_ts) {           \
-      transaction_policy_.ReplayTransaction([this](T_FIELDS_VARIANT&& entry) {                               \
+    void ReplayTransaction(transaction_t&& transaction, ::current::ss::IndexAndTimestamp idx_ts) {           \
+      transaction_policy_.ReplayTransaction([this](fields_variant_t&& entry) {                               \
         entry.Call(fields_);                                                                                 \
-      }, std::forward<T_TRANSACTION>(transaction), idx_ts);                                                  \
+      }, std::forward<transaction_t>(transaction), idx_ts);                                                  \
     }                                                                                                        \
     void ExposeRawLogViaHTTP(int port, const std::string& route) {                                           \
       persister_.ExposeRawLogViaHTTP(port, route);                                                           \
     }                                                                                                        \
-    typename std::result_of<decltype(&T_PERSISTER::InternalExposeStream)(T_PERSISTER)>::type                 \
+    typename std::result_of<decltype(&persister_t::InternalExposeStream)(persister_t)>::type                 \
     InternalExposeStream() {                                                                                 \
       return persister_.InternalExposeStream();                                                              \
     }                                                                                                        \
@@ -229,7 +250,7 @@ using CURRENT_STORAGE_DEFAULT_TRANSACTION_POLICY = transaction_policy::Synchrono
 // clang-format on
 
 // A minimalistic `PERSISTER` which compiles with the above `CURRENT_STORAGE_IMPLEMENTATION` macro.
-// Used for the sole purpose of extracting the underlying `T_TRANSACTION` type without extra template magic.
+// Used for the sole purpose of extracting the underlying `transaction_t` type without extra template magic.
 namespace persister {
 
 template <typename TYPELIST, template <typename> class UNDERLYING_PERSISTER, typename STREAM_RECORD_TYPE>
@@ -238,8 +259,10 @@ class NullStoragePersisterImpl;
 template <template <typename> class UNDERLYING_PERSISTER, typename STREAM_RECORD_TYPE, typename... TS>
 class NullStoragePersisterImpl<TypeList<TS...>, UNDERLYING_PERSISTER, STREAM_RECORD_TYPE> {
  public:
-  using T_VARIANT = Variant<TS...>;
-  using T_TRANSACTION = Transaction<T_VARIANT>;
+  using variant_t = Variant<TS...>;
+  using transaction_t = Transaction<variant_t>;
+  using DEPRECATED_T_(VARIANT) = variant_t;
+  using DEPRECATED_T_(TRANSACTION) = transaction_t;
 
   void InternalExposeStream() {}
 };
@@ -252,10 +275,10 @@ using NullStoragePersister = NullStoragePersisterImpl<TYPELIST, NullPersister, S
 
 }  // namespace current::storage::persister
 
-template <template <template <typename...> class, template <typename> class, typename> class T_STORAGE>
-using transaction_t = typename T_STORAGE<persister::NullStoragePersister,
-                                         CURRENT_STORAGE_DEFAULT_TRANSACTION_POLICY,
-                                         CURRENT_STORAGE_DEFAULT_PERSISTER_PARAM>::T_TRANSACTION;
+template <template <template <typename...> class, template <typename> class, typename> class STORAGE>
+using transaction_t = typename STORAGE<persister::NullStoragePersister,
+                                       CURRENT_STORAGE_DEFAULT_TRANSACTION_POLICY,
+                                       CURRENT_STORAGE_DEFAULT_PERSISTER_PARAM>::transaction_t;
 
 #define CURRENT_STORAGE(name)            \
   CURRENT_STORAGE_IMPLEMENTATION(name);  \
@@ -265,118 +288,121 @@ using transaction_t = typename T_STORAGE<persister::NullStoragePersister,
             CURRENT_STORAGE_FIELDS_HELPER<CURRENT_STORAGE_FIELDS_##name<::current::storage::DeclareFields>>>
 
 // clang-format off
-#define CURRENT_STORAGE_FIELD(field_name, entry_name)                                                         \
-  using T_FIELD_CONTAINER_TYPE_##field_name = entry_name::T_FIELD_TYPE<entry_name::T_ENTRY,                   \
-                                                                       entry_name::T_PERSISTED_EVENT_1,       \
-                                                                       entry_name::T_PERSISTED_EVENT_2>;      \
-  using T_ENTRY_TYPE_##field_name = entry_name;                                                               \
-  using T_FIELD_TYPE_##field_name =                                                                           \
-      ::current::storage::Field<INSTANTIATION_TYPE, T_FIELD_CONTAINER_TYPE_##field_name>;                     \
-  constexpr static size_t FIELD_INDEX_##field_name =                                                          \
-      CURRENT_EXPAND_MACRO(__COUNTER__) - CURRENT_STORAGE_FIELD_INDEX_BASE;                                   \
-  ::current::storage::FieldInfo<entry_name::T_PERSISTED_EVENT_1, entry_name::T_PERSISTED_EVENT_2> operator()( \
-      ::current::storage::FieldInfoByIndex<FIELD_INDEX_##field_name>) const {                                 \
-    return ::current::storage::FieldInfo<entry_name::T_PERSISTED_EVENT_1, entry_name::T_PERSISTED_EVENT_2>(); \
-  }                                                                                                           \
-  std::string operator()(::current::storage::FieldNameByIndex<FIELD_INDEX_##field_name>) const {              \
-    return #field_name;                                                                                       \
-  }                                                                                                           \
-  const T_FIELD_TYPE_##field_name& operator()(                                                                \
-      ::current::storage::ImmutableFieldByIndex<FIELD_INDEX_##field_name>) const {                            \
-    return field_name;                                                                                        \
-  }                                                                                                           \
-  template <typename F>                                                                                       \
-  void operator()(::current::storage::ImmutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) const {         \
-    f(field_name);                                                                                            \
-  }                                                                                                           \
-  template <typename F, typename RETVAL>                                                                      \
-  RETVAL operator()(::current::storage::ImmutableFieldByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,     \
-                    F&& f) const {                                                                            \
-    return f(field_name);                                                                                     \
-  }                                                                                                           \
-  template <typename F>                                                                                       \
-  void operator()(::current::storage::MutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) {                 \
-    f(field_name);                                                                                            \
-  }                                                                                                           \
-  T_FIELD_TYPE_##field_name& operator()(::current::storage::MutableFieldByIndex<FIELD_INDEX_##field_name>) {  \
-    return field_name;                                                                                        \
-  }                                                                                                           \
-  template <typename F, typename RETVAL>                                                                      \
-  RETVAL operator()(::current::storage::MutableFieldByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,       \
-                    F&& f) {                                                                                  \
-    return f(field_name);                                                                                     \
-  }                                                                                                           \
-  template <typename F>                                                                                       \
-  void operator()(::current::storage::FieldNameAndTypeByIndex<FIELD_INDEX_##field_name>, F&& f) const {       \
-    f(#field_name,                                                                                            \
-      ::current::storage::StorageFieldTypeSelector<T_FIELD_CONTAINER_TYPE_##field_name>(),                    \
-      ::current::storage::FieldUnderlyingTypesWrapper<entry_name>());                                         \
-  }                                                                                                           \
-  ::current::storage::StorageExtractedFieldType<T_FIELD_CONTAINER_TYPE_##field_name> operator()(              \
-      ::current::storage::FieldTypeExtractor<FIELD_INDEX_##field_name>) const {                               \
-    return ::current::storage::StorageExtractedFieldType<T_FIELD_CONTAINER_TYPE_##field_name>();              \
-  }                                                                                                           \
-  ::current::storage::StorageExtractedFieldType<T_ENTRY_TYPE_##field_name> operator()(                        \
-      ::current::storage::FieldEntryTypeExtractor<FIELD_INDEX_##field_name>) const {                          \
-    return ::current::storage::StorageExtractedFieldType<T_ENTRY_TYPE_##field_name>();                        \
-  }                                                                                                           \
-  template <typename F, typename RETVAL>                                                                      \
-  RETVAL operator()(::current::storage::FieldNameAndTypeByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,   \
-                    F&& f) const {                                                                            \
-    return f(#field_name,                                                                                     \
-             ::current::storage::StorageFieldTypeSelector<T_FIELD_CONTAINER_TYPE_##field_name>(),             \
-             ::current::storage::FieldUnderlyingTypesWrapper<entry_name>());                                  \
-  }                                                                                                           \
-  T_FIELD_TYPE_##field_name field_name = T_FIELD_TYPE_##field_name(current_storage_mutation_journal_);        \
-  void operator()(const entry_name::T_PERSISTED_EVENT_1& e) { field_name(e); }                                \
-  void operator()(const entry_name::T_PERSISTED_EVENT_2& e) { field_name(e); }
+#define CURRENT_STORAGE_FIELD(field_name, entry_name)                                                          \
+  using field_container_##field_name##_t = entry_name::field_t<entry_name::entry_t,                            \
+                                                                       entry_name::persisted_event_1_t,        \
+                                                                       entry_name::persisted_event_2_t>;       \
+  using entry_type_##field_name##_t = entry_name;                                                              \
+  using field_type_##field_name##_t =                                                                          \
+      ::current::storage::Field<INSTANTIATION_TYPE, field_container_##field_name##_t>;                         \
+  using DEPRECATED_T_(ENTRY_TYPE_##field_name) = entry_type_##field_name##_t;                                  \
+  using DEPRECATED_T_(FIELD_TYPE_##field_name) = field_type_##field_name##_t;                                  \
+  using DEPRECATED_T_(FIELD_CONTAINER_TYPE_##field_name) = field_container_##field_name##_t;                   \
+  constexpr static size_t FIELD_INDEX_##field_name =                                                           \
+      CURRENT_EXPAND_MACRO(__COUNTER__) - CURRENT_STORAGE_FIELD_INDEX_BASE;                                    \
+  ::current::storage::FieldInfo<entry_name::persisted_event_1_t, entry_name::persisted_event_2_t> operator()(  \
+      ::current::storage::FieldInfoByIndex<FIELD_INDEX_##field_name>) const {                                  \
+    return ::current::storage::FieldInfo<entry_name::persisted_event_1_t, entry_name::persisted_event_2_t>();  \
+  }                                                                                                            \
+  std::string operator()(::current::storage::FieldNameByIndex<FIELD_INDEX_##field_name>) const {               \
+    return #field_name;                                                                                        \
+  }                                                                                                            \
+  const field_type_##field_name##_t& operator()(                                                               \
+      ::current::storage::ImmutableFieldByIndex<FIELD_INDEX_##field_name>) const {                             \
+    return field_name;                                                                                         \
+  }                                                                                                            \
+  template <typename F>                                                                                        \
+  void operator()(::current::storage::ImmutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) const {          \
+    f(field_name);                                                                                             \
+  }                                                                                                            \
+  template <typename F, typename RETVAL>                                                                       \
+  RETVAL operator()(::current::storage::ImmutableFieldByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,      \
+                    F&& f) const {                                                                             \
+    return f(field_name);                                                                                      \
+  }                                                                                                            \
+  template <typename F>                                                                                        \
+  void operator()(::current::storage::MutableFieldByIndex<FIELD_INDEX_##field_name>, F&& f) {                  \
+    f(field_name);                                                                                             \
+  }                                                                                                            \
+  field_type_##field_name##_t& operator()(::current::storage::MutableFieldByIndex<FIELD_INDEX_##field_name>) { \
+    return field_name;                                                                                         \
+  }                                                                                                            \
+  template <typename F, typename RETVAL>                                                                       \
+  RETVAL operator()(::current::storage::MutableFieldByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,        \
+                    F&& f) {                                                                                   \
+    return f(field_name);                                                                                      \
+  }                                                                                                            \
+  template <typename F>                                                                                        \
+  void operator()(::current::storage::FieldNameAndTypeByIndex<FIELD_INDEX_##field_name>, F&& f) const {        \
+    f(#field_name,                                                                                             \
+      ::current::storage::StorageFieldTypeSelector<field_container_##field_name##_t>(),                        \
+      ::current::storage::FieldUnderlyingTypesWrapper<entry_name>());                                          \
+  }                                                                                                            \
+  ::current::storage::StorageExtractedFieldType<field_container_##field_name##_t> operator()(                  \
+      ::current::storage::FieldTypeExtractor<FIELD_INDEX_##field_name>) const {                                \
+    return ::current::storage::StorageExtractedFieldType<field_container_##field_name##_t>();                  \
+  }                                                                                                            \
+  ::current::storage::StorageExtractedFieldType<entry_type_##field_name##_t> operator()(                       \
+      ::current::storage::FieldEntryTypeExtractor<FIELD_INDEX_##field_name>) const {                           \
+    return ::current::storage::StorageExtractedFieldType<entry_type_##field_name##_t>();                       \
+  }                                                                                                            \
+  template <typename F, typename RETVAL>                                                                       \
+  RETVAL operator()(::current::storage::FieldNameAndTypeByIndexAndReturn<FIELD_INDEX_##field_name, RETVAL>,    \
+                    F&& f) const {                                                                             \
+    return f(#field_name,                                                                                      \
+             ::current::storage::StorageFieldTypeSelector<field_container_##field_name##_t>(),                 \
+             ::current::storage::FieldUnderlyingTypesWrapper<entry_name>());                                   \
+  }                                                                                                            \
+  field_type_##field_name##_t field_name = field_type_##field_name##_t(current_storage_mutation_journal_);     \
+  void operator()(const entry_name::persisted_event_1_t& e) { field_name(e); }                                 \
+  void operator()(const entry_name::persisted_event_2_t& e) { field_name(e); }
 // clang-format on
 
 template <typename STORAGE>
-using MutableFields = typename STORAGE::T_FIELDS_BY_REFERENCE;
+using MutableFields = typename STORAGE::fields_by_ref_t;
 
 template <typename STORAGE>
-using ImmutableFields = typename STORAGE::T_FIELDS_BY_CONST_REFERENCE;
+using ImmutableFields = typename STORAGE::fields_by_cref_t;
 
 template <typename>
 struct PerStorageFieldTypeImpl;
 
 template <typename T>
-using PerStorageFieldType = PerStorageFieldTypeImpl<typename T::T_REST_BEHAVIOR>;
+using PerStorageFieldType = PerStorageFieldTypeImpl<typename T::rest_behavior_t>;
 
 template <>
 struct PerStorageFieldTypeImpl<rest::behavior::Dictionary> {
-  template <typename T_RECORD>
-  static auto ExtractOrComposeKey(const T_RECORD& entry)
-      -> decltype(current::storage::sfinae::GetKey(std::declval<T_RECORD>())) {
+  template <typename RECORD>
+  static auto ExtractOrComposeKey(const RECORD& entry)
+      -> decltype(current::storage::sfinae::GetKey(std::declval<RECORD>())) {
     return current::storage::sfinae::GetKey(entry);
   }
-  template <typename T_DICTIONARY>
-  static const T_DICTIONARY& Iterate(const T_DICTIONARY& dictionary) {
+  template <typename DICTIONARY>
+  static const DICTIONARY& Iterate(const DICTIONARY& dictionary) {
     return dictionary;
   }
 };
 
 template <>
 struct PerStorageFieldTypeImpl<rest::behavior::Matrix> {
-  template <typename T_RECORD>
-  static auto ExtractOrComposeKey(const T_RECORD& entry)
-      -> std::pair<decltype(current::storage::sfinae::GetRow(std::declval<T_RECORD>())),
-                   decltype(current::storage::sfinae::GetCol(std::declval<T_RECORD>()))> {
+  template <typename RECORD>
+  static auto ExtractOrComposeKey(const RECORD& entry)
+      -> std::pair<decltype(current::storage::sfinae::GetRow(std::declval<RECORD>())),
+                   decltype(current::storage::sfinae::GetCol(std::declval<RECORD>()))> {
     return std::make_pair(current::storage::sfinae::GetRow(entry), current::storage::sfinae::GetCol(entry));
   }
-  template <typename T_MATRIX>
+  template <typename MATRIX>
   struct Iterable {
-    const T_MATRIX& matrix;
-    explicit Iterable(const T_MATRIX& matrix) : matrix(matrix) {}
-    using Iterator = typename T_MATRIX::WholeMatrixIterator;
+    const MATRIX& matrix;
+    explicit Iterable(const MATRIX& matrix) : matrix(matrix) {}
+    using Iterator = typename MATRIX::WholeMatrixIterator;
     Iterator begin() const { return matrix.WholeMatrixBegin(); }
     Iterator end() const { return matrix.WholeMatrixEnd(); }
   };
 
-  template <typename T_MATRIX>
-  static Iterable<T_MATRIX> Iterate(const T_MATRIX& matrix) {
-    return Iterable<T_MATRIX>(matrix);
+  template <typename MATRIX>
+  static Iterable<MATRIX> Iterate(const MATRIX& matrix) {
+    return Iterable<MATRIX>(matrix);
   }
 };
 

--- a/Storage/transaction.h
+++ b/Storage/transaction.h
@@ -42,7 +42,7 @@ CURRENT_STRUCT(TransactionMeta) {
 };
 
 CURRENT_STRUCT_T(Transaction) {
-  using T_VARIANT = T;
+  using variant_t = T;
   CURRENT_FIELD(meta, TransactionMeta);
   CURRENT_FIELD(mutations, std::vector<T>);
   CURRENT_USE_FIELD_AS_TIMESTAMP(meta.timestamp);

--- a/Symbols.md
+++ b/Symbols.md
@@ -49,7 +49,7 @@ FileSystem
 
 current::StreamImpl<T>
 
-current::MMQ<T_MESSAGE, T_CONSUMER>
+current::MMQ<MESSAGE, CONSUMER>
 
 current::Chunk, current::ChunkDB.
 

--- a/TypeSystem/Serialization/types/enum.h
+++ b/TypeSystem/Serialization/types/enum.h
@@ -84,11 +84,11 @@ namespace load {
 template <typename T>
 struct LoadFromBinaryImpl<T, ENABLE_IF<std::is_enum<T>::value>> {
   static void Load(std::istream& istream, T& destination) {
-    using T_UNDERLYING = typename std::underlying_type<T>::type;
+    using underlying_t = typename std::underlying_type<T>::type;
     const size_t bytes_read =
-        istream.rdbuf()->sgetn(reinterpret_cast<char*>(std::addressof(destination)), sizeof(T_UNDERLYING));
-    if (bytes_read != sizeof(T_UNDERLYING)) {
-      throw BinaryLoadFromStreamException(sizeof(T_UNDERLYING), bytes_read);  // LCOV_EXCL_LINE
+        istream.rdbuf()->sgetn(reinterpret_cast<char*>(std::addressof(destination)), sizeof(underlying_t));
+    if (bytes_read != sizeof(underlying_t)) {
+      throw BinaryLoadFromStreamException(sizeof(underlying_t), bytes_read);  // LCOV_EXCL_LINE
     }
   }
 };

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -62,7 +62,8 @@ struct SUPER : REFLECTION_HELPER, SUPER_SELECTOR<INSTANTIATION_TYPE, T>::type {
   template <typename... ARGS>
   SUPER(ARGS&&... args)
       : SUPER_SELECTOR<INSTANTIATION_TYPE, T>::type(std::forward<ARGS>(args)...) {}
-  using T_SUPER = typename SUPER_SELECTOR<INSTANTIATION_TYPE, T>::type;
+  using super_t = typename SUPER_SELECTOR<INSTANTIATION_TYPE, T>::type;
+  using DEPRECATED_T_(SUPER) = super_t;
   using REFLECTION_HELPER::CURRENT_STRUCT_NAME;
   using typename REFLECTION_HELPER::CURRENT_FIELD_COUNT_STRUCT;
 #ifdef CURRENT_WINDOWS
@@ -292,22 +293,25 @@ struct CurrentStructFieldsConsistency<T, -1> {
   ::current::reflection::Field<INSTANTIATION_TYPE, CF_TYPE(type)> name{CF_TYPE(value)}; \
   CURRENT_FIELD_REFLECTION(CURRENT_EXPAND_MACRO(__COUNTER__) - CURRENT_FIELD_INDEX_BASE - 1, type, name)
 
-#define CURRENT_USE_FIELD_AS_KEY(field)                                                   \
-  using T_COPY_FREE_KEY_TYPE = current::copy_free<decltype(field)>;                       \
-  const T_COPY_FREE_KEY_TYPE key() const { return field; }                                \
-  void set_key(const T_COPY_FREE_KEY_TYPE new_key_value) const { field = new_key_value; } \
+#define CURRENT_USE_FIELD_AS_KEY(field)                                       \
+  using cf_key_t = current::copy_free<decltype(field)>;                       \
+  using DEPRECATED_T_(COPY_FREE_KEY_TYPE) = cf_key_t;                         \
+  const cf_key_t key() const { return field; }                                \
+  void set_key(const cf_key_t new_key_value) const { field = new_key_value; } \
   using CURRENT_USE_FIELD_AS_KEY_##field##_implemented = void
 
-#define CURRENT_USE_FIELD_AS_ROW(field)                                                   \
-  using T_COPY_FREE_ROW_TYPE = current::copy_free<decltype(field)>;                       \
-  const T_COPY_FREE_ROW_TYPE row() const { return field; }                                \
-  void set_row(const T_COPY_FREE_ROW_TYPE new_row_value) const { field = new_row_value; } \
+#define CURRENT_USE_FIELD_AS_ROW(field)                                       \
+  using cf_row_t = current::copy_free<decltype(field)>;                       \
+  using DEPRECATED_T_(COPY_FREE_ROW_TYPE) = cf_row_t;                         \
+  const cf_row_t row() const { return field; }                                \
+  void set_row(const cf_row_t new_row_value) const { field = new_row_value; } \
   using CURRENT_USE_FIELD_AS_ROW_##field##_implemented = void
 
-#define CURRENT_USE_FIELD_AS_COL(field)                                                   \
-  using T_COPY_FREE_COL_TYPE = current::copy_free<decltype(field)>;                       \
-  const T_COPY_FREE_COL_TYPE col() const { return field; }                                \
-  void set_col(const T_COPY_FREE_COL_TYPE new_col_value) const { field = new_col_value; } \
+#define CURRENT_USE_FIELD_AS_COL(field)                                       \
+  using cf_col_t = current::copy_free<decltype(field)>;                       \
+  using DEPRECATED_T_(COPY_FREE_COL_TYPE) = cf_col_t;                         \
+  const cf_col_t col() const { return field; }                                \
+  void set_col(const cf_col_t new_col_value) const { field = new_col_value; } \
   using CURRENT_USE_FIELD_AS_COL_##field##_implemented = void
 
 #define CURRENT_USE_FIELD_AS_TIMESTAMP(field) \
@@ -372,7 +376,7 @@ template <typename T>
 struct SuperTypeImpl {
   static_assert(IS_CURRENT_STRUCT(T),
                 "`SuperType` must be called with the type defined via `CURRENT_STRUCT` macro.");
-  typedef typename T::T_SUPER type;
+  using type = typename T::super_t;
 };
 
 template <typename T>

--- a/TypeSystem/test.cc
+++ b/TypeSystem/test.cc
@@ -348,8 +348,8 @@ TEST(TypeSystemTest, VariantStaticAsserts) {
   static_assert(is_same_or_compile_error<Variant<Foo>, Variant<TypeList<Foo>>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo>, Variant<SlowTypeList<Foo, Foo>>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo>, Variant<TypeListImpl<Foo>>>::value, "");
-  static_assert(Variant<Foo>::T_TYPELIST_SIZE == 1u, "");
-  static_assert(is_same_or_compile_error<Variant<Foo>::T_TYPELIST, TypeListImpl<Foo>>::value, "");
+  static_assert(Variant<Foo>::typelist_size == 1u, "");
+  static_assert(is_same_or_compile_error<Variant<Foo>::typelist_t, TypeListImpl<Foo>>::value, "");
 
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<Foo, Bar>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<TypeList<Foo, Bar>>>::value, "");
@@ -357,8 +357,8 @@ TEST(TypeSystemTest, VariantStaticAsserts) {
   static_assert(
       is_same_or_compile_error<Variant<Foo, Bar>, Variant<SlowTypeList<Foo, Bar, TypeList<Bar>>>>::value, "");
   static_assert(is_same_or_compile_error<Variant<Foo, Bar>, Variant<TypeListImpl<Foo, Bar>>>::value, "");
-  static_assert(Variant<Foo, Bar>::T_TYPELIST_SIZE == 2u, "");
-  static_assert(is_same_or_compile_error<Variant<Foo, Bar>::T_TYPELIST, TypeListImpl<Foo, Bar>>::value, "");
+  static_assert(Variant<Foo, Bar>::typelist_size == 2u, "");
+  static_assert(is_same_or_compile_error<Variant<Foo, Bar>::typelist_t, TypeListImpl<Foo, Bar>>::value, "");
 }
 
 TEST(TypeSystemTest, VariantCreateAndCopy) {

--- a/TypeSystem/variant.h
+++ b/TypeSystem/variant.h
@@ -140,8 +140,9 @@ struct VariantImpl;
 
 template <typename... TYPES>
 struct VariantImpl<TypeListImpl<TYPES...>> : CurrentVariant {
-  using T_TYPELIST = TypeListImpl<TYPES...>;
-  enum { T_TYPELIST_SIZE = TypeListSize<T_TYPELIST>::value };
+  using typelist_t = TypeListImpl<TYPES...>;
+  using DEPRECATED_T_(TYPELIST) = typelist_t;
+  enum { typelist_size = TypeListSize<typelist_t>::value };
 
   std::unique_ptr<CurrentSuper> object_;
 
@@ -151,16 +152,16 @@ struct VariantImpl<TypeListImpl<TYPES...>> : CurrentVariant {
 
   VariantImpl(std::unique_ptr<CurrentSuper>&& rhs) : object_(std::move(rhs)) {}
 
-  VariantImpl(const VariantImpl<T_TYPELIST>& rhs) { CopyFrom(rhs); }
+  VariantImpl(const VariantImpl<typelist_t>& rhs) { CopyFrom(rhs); }
 
-  VariantImpl(VariantImpl<T_TYPELIST>&& rhs) : object_(std::move(rhs.object_)) {}
+  VariantImpl(VariantImpl<typelist_t>&& rhs) : object_(std::move(rhs.object_)) {}
 
-  VariantImpl& operator=(const VariantImpl<T_TYPELIST>& rhs) {
+  VariantImpl& operator=(const VariantImpl<typelist_t>& rhs) {
     CopyFrom(rhs);
     return *this;
   }
 
-  VariantImpl& operator=(VariantImpl<T_TYPELIST>&& rhs) {
+  VariantImpl& operator=(VariantImpl<typelist_t>&& rhs) {
     object_ = std::move(rhs.object_);
     return *this;
   }
@@ -169,7 +170,7 @@ struct VariantImpl<TypeListImpl<TYPES...>> : CurrentVariant {
             bool ENABLE = !std::is_same<current::decay<X>, VariantImpl<TypeListImpl<TYPES...>>>::value,
             class SFINAE = ENABLE_IF<ENABLE>>
   void operator=(X&& input) {
-    VariantTypeCheckedAssignment<T_TYPELIST>::Perform(std::forward<X>(input), object_);
+    VariantTypeCheckedAssignment<typelist_t>::Perform(std::forward<X>(input), object_);
   }
 
   template <typename... TS>
@@ -182,7 +183,7 @@ struct VariantImpl<TypeListImpl<TYPES...>> : CurrentVariant {
             bool ENABLE = !std::is_same<current::decay<X>, VariantImpl<TypeListImpl<TYPES...>>>::value,
             class SFINAE = ENABLE_IF<ENABLE>>
   VariantImpl(X&& input) {
-    VariantTypeCheckedAssignment<T_TYPELIST>::Perform(std::forward<X>(input), object_);
+    VariantTypeCheckedAssignment<typelist_t>::Perform(std::forward<X>(input), object_);
     CheckIntegrityImpl();
   }
 
@@ -197,19 +198,19 @@ struct VariantImpl<TypeListImpl<TYPES...>> : CurrentVariant {
   template <typename F>
   void Call(F&& f) {
     CheckIntegrityImpl();
-    current::metaprogramming::RTTIDynamicCall<T_TYPELIST>(*object_, std::forward<F>(f));
+    current::metaprogramming::RTTIDynamicCall<typelist_t>(*object_, std::forward<F>(f));
   }
 
   template <typename F>
   void Call(F&& f) const {
     CheckIntegrityImpl();
-    current::metaprogramming::RTTIDynamicCall<T_TYPELIST>(*object_, std::forward<F>(f));
+    current::metaprogramming::RTTIDynamicCall<typelist_t>(*object_, std::forward<F>(f));
   }
 
   // By design, `VariantExistsImpl<T>()` and `VariantValueImpl<T>()` do not check
-  // whether `X` is part of `T_TYPELIST`. More specifically, they pass if `dynamic_cast<>` succeeds,
+  // whether `X` is part of `typelist_t`. More specifically, they pass if `dynamic_cast<>` succeeds,
   // and thus will successfully retrieve a derived type as a base one,
-  // regardless of whether the base one is present in `T_TYPELIST`.
+  // regardless of whether the base one is present in `typelist_t`.
   // Use `Call()` to run a strict check.
 
   bool ExistsImpl() const { return (object_.get() != nullptr); }

--- a/Utils/JSONSchema/infer.h
+++ b/Utils/JSONSchema/infer.h
@@ -64,9 +64,9 @@ struct InferSchemaIncompatibleTypesBase : InferSchemaInputException {
   explicit InferSchemaIncompatibleTypesBase(const std::string& message) : InferSchemaInputException(message) {}
 };
 
-template <typename T_LHS, typename T_RHS>
+template <typename LHS, typename RHS>
 struct InferSchemaIncompatibleTypes : InferSchemaIncompatibleTypesBase {
-  InferSchemaIncompatibleTypes(const T_LHS& lhs, const T_RHS& rhs)
+  InferSchemaIncompatibleTypes(const LHS& lhs, const RHS& rhs)
       : InferSchemaIncompatibleTypesBase("Incompatible types: '" + lhs.HumanReadableType() + "' and '" +
                                          rhs.HumanReadableType() + "'.") {}
 };
@@ -162,23 +162,23 @@ CURRENT_STRUCT(Object) {
 // 2) `CallReduce(const Schema& lhs, const Schema& rhs)` calls the above `Reduce<LHS, RHS>`
 //     for the right underlying types of `lhs` and `rhs` respectively.
 
-template <typename T_LHS, typename T_RHS>
+template <typename LHS, typename RHS>
 struct Reduce {
-  static Schema DoIt(const T_LHS& lhs, const T_RHS& rhs) {
-    using InferSchemaIncompatibleTypesException = InferSchemaIncompatibleTypes<T_LHS, T_RHS>;
+  static Schema DoIt(const LHS& lhs, const RHS& rhs) {
+    using InferSchemaIncompatibleTypesException = InferSchemaIncompatibleTypes<LHS, RHS>;
     CURRENT_THROW(InferSchemaIncompatibleTypesException(lhs, rhs));
   }
 };
 
-template <typename T_LHS>
+template <typename LHS>
 struct RHSExpander {
-  const T_LHS& lhs;
+  const LHS& lhs;
   Schema& result;
-  RHSExpander(const T_LHS& lhs, Schema& result) : lhs(lhs), result(result) {}
+  RHSExpander(const LHS& lhs, Schema& result) : lhs(lhs), result(result) {}
 
-  template <typename T_RHS>
-  void operator()(const T_RHS& rhs) {
-    result = Reduce<T_LHS, T_RHS>::DoIt(lhs, rhs);
+  template <typename RHS>
+  void operator()(const RHS& rhs) {
+    result = Reduce<LHS, RHS>::DoIt(lhs, rhs);
   }
 };
 
@@ -187,9 +187,9 @@ struct LHSExpander {
   Schema& result;
   LHSExpander(const Schema& rhs, Schema& result) : rhs(rhs), result(result) {}
 
-  template <typename T_LHS>
-  void operator()(const T_LHS& lhs) const {
-    rhs.Call(RHSExpander<T_LHS>(lhs, result));
+  template <typename LHS>
+  void operator()(const LHS& lhs) const {
+    rhs.Call(RHSExpander<LHS>(lhs, result));
   }
 };
 

--- a/examples/EventStore/event_store.h
+++ b/examples/EventStore/event_store.h
@@ -45,7 +45,7 @@ struct EventStore final {
 
   using event_store_storage_t =
       CURRENT_STORAGE_TYPE<DB_PERSISTER, current::storage::transaction_policy::Synchronous, stream_type_t>;
-  using full_stream_t = typename event_store_storage_t::T_PERSISTER::T_SHERLOCK;
+  using full_stream_t = typename event_store_storage_t::persister_t::sherlock_t;
 
   using nonstorage_stream_t = current::sherlock::Stream<EXTRA_TYPE, current::persistence::Memory>;
 
@@ -70,7 +70,7 @@ struct EventStore final {
   readonly_stream_follower_t readonly_stream_follower;
   typename full_stream_t::template SyncSubscriberScope<readonly_stream_follower_t, EXTRA_TYPE>
       readonly_stream_follower_scope;
-  const typename nonstorage_stream_t::T_PERSISTENCE_LAYER& readonly_nonstorage_event_log_persister;
+  const typename nonstorage_stream_t::persistence_layer_t& readonly_nonstorage_event_log_persister;
   HTTPRoutesScope http_routes_scope;
 
   template <typename... ARGS>

--- a/examples/Iris/test.cc
+++ b/examples/Iris/test.cc
@@ -133,7 +133,7 @@ TEST(Iris, Demo) {
         .Register("/get",
                   [&api](Request request) {
                     const auto id = current::FromString<size_t>(request.url.query["id"]);
-                    api.Transaction([id](TestDB::T_DATA data) {
+                    api.Transaction([id](TestDB::data_t data) {
                       return yoda::Dictionary<LabeledFlower>::Accessor(data)[id];
                     }, std::move(request));
                   });
@@ -150,7 +150,7 @@ TEST(Iris, Demo) {
                     // In real life this should be a POST.
                     if (!label.empty()) {
                       const LabeledFlower flower(++number_of_flowers, sl, sw, pl, pw, label);
-                      api.Transaction([flower](TestDB::T_DATA data) {
+                      api.Transaction([flower](TestDB::data_t data) {
                         yoda::Dictionary<LabeledFlower>::Mutator(data).Add(flower);
                         return "OK\n";
                       }, std::move(request));
@@ -195,7 +195,7 @@ TEST(Iris, Demo) {
                         request(graph);
                       }
                     };
-                    api.Transaction([x_dim, y_dim](TestDB::T_DATA data) {
+                    api.Transaction([x_dim, y_dim](TestDB::data_t data) {
                       PlotIrises::Info info;
                       for (size_t i = 1; i <= number_of_flowers; ++i) {
                         const LabeledFlower& flower = yoda::Dictionary<LabeledFlower>::Accessor(data)[i];

--- a/port.h
+++ b/port.h
@@ -191,4 +191,10 @@ struct PortForUnitTestPicker {
 #error "Current has not been tested with Java for a while, and would likely require a bit of TLC. Thank you."
 #endif
 
+// We're retiring `T_FOO_BAR` in favor of `foo_bar_t`. In the meantime, we keep the old `T_FOO_BAR` names as well
+// for backwards compatibility. For easier deprecation, everywhere in the code those `using`-s are now
+// `DEPRECATED_T_(FOO) `instead of `T_FOO`.
+// TODO(dkorolev): Finalize the retirement.
+#define DEPRECATED_T_(FOO_BAR) T_##FOO_BAR
+
 #endif


### PR DESCRIPTION
Hi!

Done in a bulk:

1. Renamed all `T_FOO` into `foo_t`.
2. No top-level template parameter starts with `T_` now.
3. Current builds find with `T_DEPRECATED_` disabled (external clients would fail though).

Remains:

1. Deprecate that `T_DEPRECATED_()`.
2. Unify `typedef`-s into `using`-s.

Thanks,
Dima