### PR TITLE
`ScopeOwned` begins pwning.

### DIFF
--- a/Blocks/Persistence/exceptions.h
+++ b/Blocks/Persistence/exceptions.h
@@ -27,7 +27,8 @@ SOFTWARE.
 
 #include <chrono>
 
-#include "../../Bricks/exception.h"
+#include "../exceptions.h"
+
 #include "../../Bricks/strings/printf.h"
 
 namespace current {
@@ -67,6 +68,14 @@ struct InvalidIterableRangeException : PersistenceException {
 
 struct NoEntriesPublishedYet : PersistenceException {
   using PersistenceException::PersistenceException;
+};
+
+struct PersistenceMemoryBlockNoLongerAvailable : GracefulShutdownException {
+  using GracefulShutdownException::GracefulShutdownException;
+};
+
+struct PersistenceFileNoLongerAvailable : GracefulShutdownException {
+  using GracefulShutdownException::GracefulShutdownException;
 };
 
 }  // namespace peristence

--- a/Blocks/URL/url.h
+++ b/Blocks/URL/url.h
@@ -36,7 +36,8 @@ SOFTWARE.
 #include <string>
 #include <vector>
 
-#include "../../Bricks/exception.h"
+#include "../exceptions.h"
+
 #include "../../Bricks/strings/printf.h"
 #include "../../Bricks/strings/split.h"
 

--- a/Blocks/exceptions.h
+++ b/Blocks/exceptions.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Maxim Zhurovich <zhurovich@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPREPERSISTENCE OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNEPERSISTENCE FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BLOCKS_EXCEPTIONS_H
+#define BLOCKS_EXCEPTIONS_H
+
+#include "../Bricks/exception.h"
+
+namespace current {
+
+// The base class for exceptions originated from the fact that the desired resource is inaccessble
+// as the scope controlling it has already entered its graceful shutdown mode.
+struct GracefulShutdownException : current::Exception {
+  using current::Exception::Exception;
+};
+
+}  // namespace current
+
+#endif  // BLOCKS_EXCEPTIONS_H


### PR DESCRIPTION
Hi Max,

I started looking into making our Sherlock safer and more error-resilient by replacing `shared_ptr`-s by `ScopeOwned`-s. First small step: iterators over our persisters had `ScopeOwned`-s, but they were stubs. I've added the corresponding logic and tested it.

A small yet open-ended question: exceptions hierarchy. In this change I've added `GracefulShutdownException`into `Blocks`, by creating a top-level `exceptions.h` in `Blocks`. On the grand scheme of things it sounds right, as `Bricks` are supposed to be trivial pieces, while `Blocks` are the big ones. This, however, raises a question whether the exceptions `ScopeOwned` itself throws are trivial- or sophisticated-level, and whether `Bricks/sync` should be in `Blocks`.

For the record, I'm thinking of the following dependencies to be controlled by ScopeOwned. X > Y means Y should be contained in the scope of X.

- [x] Persister > Persister Iterable Range
- [x] Persister Iterable Range > Persister Iterator

- [ ] Stream ( + its Persister) > each Stream Subscriber (here and below I'm assuming Stream simply has Persister as its member)
- [ ] Master Stream ( + its Persister ) > Stream Publisher (the Publisher which can be `std::move()`-d around.)

- [ ] Storage -> Stream::Persister::IterableRange (during the initial replay phase)
- [ ] Following Storage -> (Stream or other) Subscriber (following Storage can be explicitly left with no Subscriber, but if the Subscriber is being destructed without being detached from a Following Storage, the latter should probably die)

- [ ] Master Storage > Persister (Stream or other)

Thanks,
Dima