### PR TITLE
`g++` storage `{}`-initialization artifact.

### DIFF
--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -44,7 +44,7 @@ class GenericDictionary {
   using map_t = MAP<key_t, T>;
   using rest_behavior_t = rest::behavior::Dictionary;
 
-  explicit GenericDictionary(MutationJournal& journal) : journal_(journal) {}
+  GenericDictionary(MutationJournal& journal) : journal_(journal) {}
 
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }

--- a/Storage/container/many_to_many.h
+++ b/Storage/container/many_to_many.h
@@ -62,7 +62,7 @@ class GenericManyToMany {
   using DEPRECATED_T_(ROW) = row_t;
   using DEPRECATED_T_(COL) = col_t;
 
-  explicit GenericManyToMany(MutationJournal& journal) : journal_(journal) {}
+  GenericManyToMany(MutationJournal& journal) : journal_(journal) {}
 
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }

--- a/Storage/container/one_to_many.h
+++ b/Storage/container/one_to_many.h
@@ -55,7 +55,7 @@ class GenericOneToMany {
   using transposed_map_t = row_elements_map_t;
   using rest_behavior_t = rest::behavior::Matrix;
 
-  explicit GenericOneToMany(MutationJournal& journal) : journal_(journal) {}
+  GenericOneToMany(MutationJournal& journal) : journal_(journal) {}
 
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }

--- a/Storage/container/one_to_one.h
+++ b/Storage/container/one_to_one.h
@@ -53,7 +53,7 @@ class GenericOneToOne {
   using transposed_map_t = COL_MAP<col_t, const T*>;
   using rest_behavior_t = rest::behavior::Matrix;
 
-  explicit GenericOneToOne(MutationJournal& journal) : journal_(journal) {}
+  GenericOneToOne(MutationJournal& journal) : journal_(journal) {}
 
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }


### PR DESCRIPTION
Aftermath after https://github.com/C5T/Current/commit/6c453bc2df19490c833792409cef09832427498c giving troubles in prod with g++.