### PR TITLE
Update MakefileImpl

### DIFF
--- a/scripts/MakefileImpl
+++ b/scripts/MakefileImpl
@@ -49,7 +49,7 @@ default: all
 	if [ -f test.cc ] ; then \
 		make test ;\
 	else \
-		find .current/ -perm +111 -type f -exec "{}" ";" ; \
+		find .current/ -perm /111 -type f -exec "{}" ";" ; \
 	fi
 
 test: .current/test


### PR DESCRIPTION
"find -perm +111" doesn't work at least in find 4.7.0 and +mode is considered deprecated. Manual suggests using /mode instead (and it works).