### PR TITLE
`FromString`: universal references work fine.

### DIFF
--- a/Bricks/strings/test.cc
+++ b/Bricks/strings/test.cc
@@ -140,8 +140,8 @@ TEST(Util, FromString) {
   EXPECT_EQ(65535, static_cast<int>(current::FromString<uint16_t>("65535")));
 
   double tmp_double;
-  EXPECT_EQ(0.1, current::FromString("0.1", tmp_double));
-  EXPECT_EQ(0.1, tmp_double);
+  EXPECT_EQ(0.25, current::FromString("0.25", tmp_double));
+  EXPECT_EQ(0.25, tmp_double);
   EXPECT_EQ(0.5, current::FromString<double>("0.5", tmp_double));
   EXPECT_EQ(0.5, tmp_double);
 

--- a/Bricks/strings/util.h
+++ b/Bricks/strings/util.h
@@ -150,17 +150,15 @@ struct FromStringImpl;
 
 template <typename INPUT, typename OUTPUT>
 struct FromStringImpl<INPUT, OUTPUT, true, false> {
-  template <typename T>
-  static const OUTPUT& Go(T&& input, OUTPUT& output) {
-    output.FromString(std::forward<T>(input));
+  static const OUTPUT& Go(INPUT&& input, OUTPUT& output) {
+    output.FromString(std::forward<INPUT>(input));
     return output;
   }
 };
 
 template <typename INPUT, typename OUTPUT>
 struct FromStringImpl<INPUT, OUTPUT, false, false> {
-  template <typename T>
-  static const OUTPUT& Go(T&& input, OUTPUT& output) {
+  static const OUTPUT& Go(INPUT&& input, OUTPUT& output) {
     std::istringstream is(input);
     if (!(is >> output)) {
       // Default initializer, zero for primitive types.
@@ -172,8 +170,7 @@ struct FromStringImpl<INPUT, OUTPUT, false, false> {
 
 template <typename INPUT, typename OUTPUT>
 struct FromStringImpl<INPUT, OUTPUT, false, true> {
-  template <typename T>
-  static const OUTPUT& Go(T&& input, OUTPUT& output) {
+  static const OUTPUT& Go(INPUT&& input, OUTPUT& output) {
     std::istringstream is(input);
     using underlying_output_t = typename std::underlying_type<OUTPUT>::type;
     underlying_output_t underlying_output;
@@ -197,8 +194,7 @@ struct FromStringImpl<INPUT, bool, false, false> {
 
 template <typename INPUT>
 struct FromStringImpl<INPUT, std::chrono::milliseconds, false, false> {
-  template <typename T>
-  static const std::chrono::milliseconds& Go(T&& input, std::chrono::milliseconds& output) {
+  static const std::chrono::milliseconds& Go(INPUT&& input, std::chrono::milliseconds& output) {
     std::istringstream is(input);
     int64_t underlying_output;
     if (!(is >> underlying_output)) {
@@ -211,8 +207,7 @@ struct FromStringImpl<INPUT, std::chrono::milliseconds, false, false> {
 
 template <typename INPUT>
 struct FromStringImpl<INPUT, std::chrono::microseconds, false, false> {
-  template <typename T>
-  static const std::chrono::microseconds& Go(T&& input, std::chrono::microseconds& output) {
+  static const std::chrono::microseconds& Go(INPUT&& input, std::chrono::microseconds& output) {
     std::istringstream is(input);
     int64_t underlying_output;
     if (!(is >> underlying_output)) {


### PR DESCRIPTION
I've removed additional template parameters for static functions, as I proved them to be redundant.
TL;DR: when we call `FromString` template deduction kicks in and we deal with universal references, so at the moment we call `FromStringImpl<INPUT....>`, `INPUT` argument itself has already the proper type (const or rvalue ref). Thus, coupled with `std::forward` and reference collapsing rules, our `static` functions do their job absolutely fine without extra templatization.