### PR TITLE
Storage+Stream perf test.

### DIFF
--- a/examples/Benchmark/Storage/Makefile
+++ b/examples/Benchmark/Storage/Makefile
@@ -1,0 +1,1 @@
+../../../scripts/Makefile

--- a/examples/Benchmark/Storage/replay.cc
+++ b/examples/Benchmark/Storage/replay.cc
@@ -1,6 +1,6 @@
-#include "../../../Bricks/dflags/dflags.h"
+#include <atomic>
 
-//#include "../../../Bricks/file/file.h"
+#include "../../../Bricks/dflags/dflags.h"
 
 #include "schema.h"
 
@@ -11,6 +11,7 @@ DEFINE_int16(sleep,
              10,
              "The time in milliseconds to sleep in the spin-lock while checking "
              "actual replayed entries count.");
+DEFINE_uint16(subs, 0, "The number of dummy stream subscribers.");
 
 inline void GenerateTestData(const std::string& file, uint32_t size) {
   current::FileSystem::RmFile(file, current::FileSystem::RmFileParameters::Silent);
@@ -23,8 +24,54 @@ inline void GenerateTestData(const std::string& file, uint32_t size) {
   }
 }
 
-inline void PerformReplayBenchmark(const std::string& file, std::chrono::milliseconds spin_lock_sleep) {
+template <typename T>
+struct RawLogSubscriberImpl {
+  struct MutationCollector {
+    void operator()(const EntryDictUpdated& e) { crc_ ^= current::CRC32(Value<Entry>(e.data).value); }
+
+    template <typename E>
+    void operator()(const E&) const {}
+
+    uint32_t crc_ = 0u;
+  };
+
+  using EntryResponse = current::ss::EntryResponse;
+  using TerminationResponse = current::ss::TerminationResponse;
+
+  RawLogSubscriberImpl() : entries_seen_(0u) {}
+
+  EntryResponse operator()(const T& transaction, idxts_t, idxts_t) {
+    for (const auto& m : transaction.mutations) {
+      m.Call(mutation_collector_);
+    }
+    ++entries_seen_;
+    return EntryResponse::More;
+  }
+
+  TerminationResponse Terminate() {
+    terminating_ = true;
+    return TerminationResponse::Terminate;
+  }
+
+  EntryResponse EntryResponseIfNoMorePassTypeFilter() const {
+    if (terminating_) {
+      return EntryResponse::Done;
+    } else {
+      return EntryResponse::More;
+    }
+  }
+
+  std::atomic<uint64_t> entries_seen_;
+  bool terminating_ = false;
+  MutationCollector mutation_collector_;
+};
+
+inline void PerformReplayBenchmark(const std::string& file,
+                                   std::chrono::milliseconds spin_lock_sleep,
+                                   uint16_t subscribers_count) {
   using stream_t = typename storage_t::persister_t::sherlock_t;
+  using transaction_t = typename stream_t::entry_t;
+  using subscriber_t = current::ss::StreamSubscriber<RawLogSubscriberImpl<transaction_t>, transaction_t>;
 
   // Owning storage replay.
   {
@@ -32,10 +79,22 @@ inline void PerformReplayBenchmark(const std::string& file, std::chrono::millise
     const auto begin = current::time::Now();
     stream_t stream(file);
     const auto stream_initialized = current::time::Now();
+    std::vector<subscriber_t> subscribers(subscribers_count);
+    std::vector<current::sherlock::SubscriberScope> sub_scopes;
+    if (subscribers_count) {
+      for (size_t i = 0u; i < subscribers_count; ++i) {
+        sub_scopes.emplace_back(std::move(stream.Subscribe(subscribers[i])));
+      }
+    }
+    const auto subscribers_created = current::time::Now();
     storage_t storage(stream);
     const auto end = current::time::Now();
     std::cout << "* Stream initialization: " << (stream_initialized - begin).count() / 1000 << " ms\n";
-    std::cout << "* Storage replay: " << (end - stream_initialized).count() / 1000 << " ms" << std::endl;
+    if (subscribers_count) {
+      std::cout << "* Spawning subscribers: " << (subscribers_created - stream_initialized).count() / 1000
+                << " ms\n";
+    }
+    std::cout << "* Storage replay: " << (end - subscribers_created).count() / 1000 << " ms" << std::endl;
   }
 
   struct PublisherAcquirer {
@@ -53,6 +112,14 @@ inline void PerformReplayBenchmark(const std::string& file, std::chrono::millise
     stream.MovePublisherTo(acquirer);
     const uint64_t stream_size = stream.InternalExposePersister().Size();
     const auto stream_initialized = current::time::Now();
+    std::vector<subscriber_t> subscribers(subscribers_count);
+    std::vector<current::sherlock::SubscriberScope> sub_scopes;
+    if (subscribers_count) {
+      for (size_t i = 0u; i < subscribers_count; ++i) {
+        sub_scopes.emplace_back(std::move(stream.Subscribe(subscribers[i])));
+      }
+    }
+    const auto subscribers_created = current::time::Now();
     uint64_t storage_size = 0u;
     storage_t storage(stream);
     // Spin lock checking the number of imported entries.
@@ -64,7 +131,11 @@ inline void PerformReplayBenchmark(const std::string& file, std::chrono::millise
     }
     const auto end = current::time::Now();
     std::cout << "* Stream initialization: " << (stream_initialized - begin).count() / 1000 << " ms\n";
-    std::cout << "* Storage replay: " << (end - stream_initialized).count() / 1000 << " ms" << std::endl;
+    if (subscribers_count) {
+      std::cout << "* Spawning subscribers: " << (subscribers_created - stream_initialized).count() / 1000
+                << " ms\n";
+    }
+    std::cout << "* Storage replay: " << (end - subscribers_created).count() / 1000 << " ms" << std::endl;
   }
 }
 
@@ -73,6 +144,6 @@ int main(int argc, char** argv) {
   if (FLAGS_gen) {
     GenerateTestData(FLAGS_file, FLAGS_size);
   } else {
-    PerformReplayBenchmark(FLAGS_file, std::chrono::milliseconds(FLAGS_sleep));
+    PerformReplayBenchmark(FLAGS_file, std::chrono::milliseconds(FLAGS_sleep), FLAGS_subs);
   }
 }

--- a/examples/Benchmark/Storage/replay.cc
+++ b/examples/Benchmark/Storage/replay.cc
@@ -4,10 +4,9 @@
 
 #include "schema.h"
 
-DEFINE_string(file, "", "Storage persistence file in Sherlock format to use.");
-DEFINE_bool(gen, false, "Generate test data and save to the file specified by `--file.`");
-DEFINE_uint32(size, 0u, "If `--gen` is set, the number of entries to generate.");
-DEFINE_int16(sleep,
+DEFINE_string(file, ".current/log.json", "Storage persistence file in Sherlock format to use.");
+DEFINE_uint32(gen, 0u, "Set to nonzero to generate this number of entries, overwriting the test data.");
+DEFINE_int16(sleep_ms,
              10,
              "The time in milliseconds to sleep in the spin-lock while checking "
              "actual replayed entries count.");
@@ -142,8 +141,8 @@ inline void PerformReplayBenchmark(const std::string& file,
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
   if (FLAGS_gen) {
-    GenerateTestData(FLAGS_file, FLAGS_size);
+    GenerateTestData(FLAGS_file, FLAGS_gen);
   } else {
-    PerformReplayBenchmark(FLAGS_file, std::chrono::milliseconds(FLAGS_sleep), FLAGS_subs);
+    PerformReplayBenchmark(FLAGS_file, std::chrono::milliseconds(FLAGS_sleep_ms), FLAGS_subs);
   }
 }

--- a/examples/Benchmark/Storage/replay.cc
+++ b/examples/Benchmark/Storage/replay.cc
@@ -74,6 +74,7 @@ CURRENT_STRUCT(Report) {
   CURRENT_FIELD(subs, std::vector<uint16_t>);
   CURRENT_FIELD(owning_storage_replay_ms, std::vector<uint64_t>);
   CURRENT_FIELD(following_storage_replay_ms, std::vector<uint64_t>);
+  CURRENT_FIELD(raw_persister_replay_ms, std::vector<uint64_t>);
 };
 
 inline void PerformReplayBenchmark(const std::string& file,
@@ -151,6 +152,27 @@ inline void PerformReplayBenchmark(const std::string& file,
     }
     std::cout << "* Storage replay: " << (end - subscribers_created).count() / 1000 << " ms" << std::endl;
     report.following_storage_replay_ms.push_back((end - subscribers_created).count() / 1000);
+
+    // Bare persister iteration.
+    {
+      const auto& persister = stream.InternalExposePersister();
+      std::vector<std::thread> threads(subscribers_count);
+      std::atomic_size_t total_mutations(0u);
+      const auto begin = current::time::Now();
+      for (auto& t : threads) {
+        t = std::thread([&]() {
+          for (const auto& e : persister.Iterate(0, stream_size)) {
+            assert(!e.entry.mutations.empty());
+            total_mutations += e.entry.mutations.size();
+          }
+        });
+      }
+      for (auto& t : threads) {
+        t.join();
+      }
+      const auto end = current::time::Now();
+      report.raw_persister_replay_ms.push_back((end - begin).count() / 1000);
+    }
   }
 }
 
@@ -186,7 +208,12 @@ int main(int argc, char** argv) {
             for (size_t i = 0; i < report.subs.size(); ++i) {
               p(report.subs[i], 1e-3 * report.following_storage_replay_ms[i]);
             }
-          }).LineWidth(5).Color("rgb '#0000B9'").Name("Following storage"));
+          }).LineWidth(5).Color("rgb '#0000B9'").Name("Following storage"))
+          .Plot(WithMeta([&report](Plotter p) {
+            for (size_t i = 0; i < report.subs.size(); ++i) {
+              p(report.subs[i], 1e-3 * report.raw_persister_replay_ms[i]);
+            }
+          }).LineWidth(5).Color("rgb '#008080'").Name("Persister iterators"));
         current::FileSystem::WriteStringToFile(png, FLAGS_png.c_str());
       }
     }

--- a/examples/Benchmark/Storage/replay.cc
+++ b/examples/Benchmark/Storage/replay.cc
@@ -1,0 +1,78 @@
+#include "../../../Bricks/dflags/dflags.h"
+
+//#include "../../../Bricks/file/file.h"
+
+#include "schema.h"
+
+DEFINE_string(file, "", "Storage persistence file in Sherlock format to use.");
+DEFINE_bool(gen, false, "Generate test data and save to the file specified by `--file.`");
+DEFINE_uint32(size, 0u, "If `--gen` is set, the number of entries to generate.");
+DEFINE_int16(sleep,
+             10,
+             "The time in milliseconds to sleep in the spin-lock while checking "
+             "actual replayed entries count.");
+
+inline void GenerateTestData(const std::string& file, uint32_t size) {
+  current::FileSystem::RmFile(file, current::FileSystem::RmFileParameters::Silent);
+  storage_t storage(file);
+  for (uint32_t i = 0u; i < size; ++i) {
+    storage.ReadWriteTransaction([i](MutableFields<storage_t> fields) {
+      Entry entry(static_cast<EntryID>(i), current::SHA256(current::ToString(i)));
+      fields.entries.Add(entry);
+    }).Go();
+  }
+}
+
+inline void PerformReplayBenchmark(const std::string& file, std::chrono::milliseconds spin_lock_sleep) {
+  using stream_t = typename storage_t::persister_t::sherlock_t;
+
+  // Owning storage replay.
+  {
+    std::cout << "=== Owning storage ===" << std::endl;
+    const auto begin = current::time::Now();
+    stream_t stream(file);
+    const auto stream_initialized = current::time::Now();
+    storage_t storage(stream);
+    const auto end = current::time::Now();
+    std::cout << "* Stream initialization: " << (stream_initialized - begin).count() / 1000 << " ms\n";
+    std::cout << "* Storage replay: " << (end - stream_initialized).count() / 1000 << " ms" << std::endl;
+  }
+
+  struct PublisherAcquirer {
+    using publisher_t = typename stream_t::publisher_t;
+    void AcceptPublisher(std::unique_ptr<publisher_t> publisher) { publisher_ = std::move(publisher); }
+    std::unique_ptr<publisher_t> publisher_;
+  };
+
+  // Non-owning storage replay.
+  {
+    std::cout << "=== Non-owning storage ===" << std::endl;
+    const auto begin = current::time::Now();
+    stream_t stream(file);
+    PublisherAcquirer acquirer;
+    stream.MovePublisherTo(acquirer);
+    const uint64_t stream_size = stream.InternalExposePersister().Size();
+    const auto stream_initialized = current::time::Now();
+    uint64_t storage_size = 0u;
+    storage_t storage(stream);
+    // Spin lock checking the number of imported entries.
+    while (storage_size < stream_size) {
+      storage.ReadOnlyTransaction([&storage_size](ImmutableFields<storage_t> fields) {
+        storage_size = fields.entries.Size();
+      }).Go();
+      std::this_thread::sleep_for(spin_lock_sleep);
+    }
+    const auto end = current::time::Now();
+    std::cout << "* Stream initialization: " << (stream_initialized - begin).count() / 1000 << " ms\n";
+    std::cout << "* Storage replay: " << (end - stream_initialized).count() / 1000 << " ms" << std::endl;
+  }
+}
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+  if (FLAGS_gen) {
+    GenerateTestData(FLAGS_file, FLAGS_size);
+  } else {
+    PerformReplayBenchmark(FLAGS_file, std::chrono::milliseconds(FLAGS_sleep));
+  }
+}

--- a/examples/Benchmark/Storage/schema.h
+++ b/examples/Benchmark/Storage/schema.h
@@ -1,0 +1,17 @@
+#include "../../../Storage/storage.h"
+#include "../../../Storage/persister/sherlock.h"
+
+CURRENT_ENUM(EntryID, uint64_t);
+
+CURRENT_STRUCT(Entry) {
+  CURRENT_FIELD(key, EntryID);
+  CURRENT_FIELD(value, std::string);
+  CURRENT_DEFAULT_CONSTRUCTOR(Entry){};
+  CURRENT_CONSTRUCTOR(Entry)(EntryID id, const std::string& value) : key(id), value(value) {}
+};
+
+CURRENT_STORAGE_FIELD_ENTRY(UnorderedDictionary, Entry, EntryDict);
+
+CURRENT_STORAGE(TestStorage) { CURRENT_STORAGE_FIELD(entries, EntryDict); };
+
+using storage_t = TestStorage<SherlockStreamPersister>;


### PR DESCRIPTION
Confirmed time is CPU time, and it's JSON parsing that eats it up.

```
ubuntu@hetz:~/github/dkorolev/Current/examples/Benchmark/Storage$ wc -l .current/log.json 
500000 .current/log.json
ubuntu@hetz:~/github/dkorolev/Current/examples/Benchmark/Storage$ ls -lash .current/log.json 
142M -rw-rw-r-- 1 ubuntu ubuntu 142M Jul 16 07:10 .current/log.json
ubuntu@hetz:~/github/dkorolev/Current/examples/Benchmark/Storage$  time ./.current/replay
...
real    19m50.027s
user    142m24.901s
sys     1m32.107s
```
user/real ~= 7.2, out of 8 CPUs.

![result](https://cloud.githubusercontent.com/assets/2159447/16893012/bdcd1406-4adc-11e6-899d-e4162343b4ea.png)

Thanks,
Dima

