### PR TITLE
HTTP Scope Refactoring

### DIFF
--- a/Blocks/HTTP/docu/client/docu_02httpclient_01_test.cc
+++ b/Blocks/HTTP/docu/client/docu_02httpclient_01_test.cc
@@ -35,8 +35,8 @@ DEFINE_int32(docu_net_client_port_01, PickPortForUnitTest(), "");
 using current::strings::Printf;
 
 TEST(Docu, HTTPClient01A) {
-HTTP(FLAGS_docu_net_client_port_01).ResetAllHandlers();
-HTTP(FLAGS_docu_net_client_port_01).Register("/ok", [](Request r) { r("OK"); });
+const auto scope =
+  HTTP(FLAGS_docu_net_client_port_01).Register("/ok", [](Request r) { r("OK"); });
 #if 1
 EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_01))).body);
 #else
@@ -46,8 +46,8 @@ EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_
 }
   
 TEST(Docu, HTTPClient01B) {
-HTTP(FLAGS_docu_net_client_port_01).ResetAllHandlers();
-HTTP(FLAGS_docu_net_client_port_01).Register("/ok", [](Request r) { r("OK"); });
+const auto scope =
+  HTTP(FLAGS_docu_net_client_port_01).Register("/ok", [](Request r) { r("OK"); });
   // More fields.
 #if 1
 const auto response = HTTP(GET(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_01)));

--- a/Blocks/HTTP/docu/client/docu_02httpclient_02_test.cc
+++ b/Blocks/HTTP/docu/client/docu_02httpclient_02_test.cc
@@ -39,8 +39,8 @@ CURRENT_STRUCT(SimpleType) {
 };
 
 TEST(Docu, HTTPClient02) {
-HTTP(FLAGS_docu_net_client_port_02).ResetAllHandlers();
-HTTP(FLAGS_docu_net_client_port_02).Register("/ok", [](Request r) { r("OK"); });
+const auto scope =
+  HTTP(FLAGS_docu_net_client_port_02).Register("/ok", [](Request r) { r("OK"); });
 #if 1
 EXPECT_EQ("OK", HTTP(POST(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_02), "BODY", "text/plain")).body);
 EXPECT_EQ("OK", HTTP(POST(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_02), SimpleType())).body);

--- a/Blocks/HTTP/docu/server/docu_03httpserver_01_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_01_test.cc
@@ -36,9 +36,8 @@ using current::strings::Printf;
 
 TEST(Docu, HTTPServer01) {
 const auto port = FLAGS_docu_net_server_port_01;
-HTTP(port).ResetAllHandlers();
   // Simple "OK" endpoint.
-  HTTP(port).Register("/ok", [](Request r) {
+  const auto scope = HTTP(port).Register("/ok", [](Request r) {
     r("OK");
   });
 EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", port))).body);

--- a/Blocks/HTTP/docu/server/docu_03httpserver_02_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_02_test.cc
@@ -38,7 +38,7 @@ TEST(Docu, HTTPServer02) {
 const auto port = FLAGS_docu_net_server_port_02;
 HTTP(port).ResetAllHandlers();
   // Accessing input fields.
-  HTTP(port).Register("/demo", [](Request r) {
+  const auto scope = HTTP(port).Register("/demo", [](Request r) {
     r(r.url.query["q"] + ' ' + r.method + ' ' + r.body);
   });
 EXPECT_EQ("A POST body", HTTP(POST(Printf("http://localhost:%d/demo?q=A", port), "body", "text/plain")).body);

--- a/Blocks/HTTP/docu/server/docu_03httpserver_02_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_02_test.cc
@@ -36,7 +36,6 @@ using current::strings::Printf;
 
 TEST(Docu, HTTPServer02) {
 const auto port = FLAGS_docu_net_server_port_02;
-HTTP(port).ResetAllHandlers();
   // Accessing input fields.
   const auto scope = HTTP(port).Register("/demo", [](Request r) {
     r(r.url.query["q"] + ' ' + r.method + ' ' + r.body);

--- a/Blocks/HTTP/docu/server/docu_03httpserver_03_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_03_test.cc
@@ -38,7 +38,7 @@ TEST(Docu, HTTPServer03) {
 const auto port = FLAGS_docu_net_server_port_03;
 HTTP(port).ResetAllHandlers();
   // Constructing a more complex response.
-  HTTP(port).Register("/found", [](Request r) {
+  const auto scope = HTTP(port).Register("/found", [](Request r) {
     r("Yes.",
       HTTPResponseCode.Accepted,
       "text/html",

--- a/Blocks/HTTP/docu/server/docu_03httpserver_03_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_03_test.cc
@@ -36,7 +36,6 @@ using current::strings::Printf;
 
 TEST(Docu, HTTPServer03) {
 const auto port = FLAGS_docu_net_server_port_03;
-HTTP(port).ResetAllHandlers();
   // Constructing a more complex response.
   const auto scope = HTTP(port).Register("/found", [](Request r) {
     r("Yes.",

--- a/Blocks/HTTP/docu/server/docu_03httpserver_04_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_04_test.cc
@@ -54,7 +54,6 @@ using current::strings::Printf;
   
 TEST(Docu, HTTPServer04) {
 const auto port = FLAGS_docu_net_server_port_04;
-HTTP(port).ResetAllHandlers();
   // Doing Penny-level arithmetics for fun and performance testing.
   const auto scope = HTTP(port).Register("/penny", [](Request r) {
     try {

--- a/Blocks/HTTP/docu/server/docu_03httpserver_04_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_04_test.cc
@@ -56,7 +56,7 @@ TEST(Docu, HTTPServer04) {
 const auto port = FLAGS_docu_net_server_port_04;
 HTTP(port).ResetAllHandlers();
   // Doing Penny-level arithmetics for fun and performance testing.
-  HTTP(port).Register("/penny", [](Request r) {
+  const auto scope = HTTP(port).Register("/penny", [](Request r) {
     try {
       const auto input = ParseJSON<PennyInput>(r.body);
       if (input.op == "add") {

--- a/Blocks/HTTP/docu/server/docu_03httpserver_05_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_05_test.cc
@@ -40,7 +40,7 @@ TEST(Docu, HTTPServer05) {
 const auto port = FLAGS_docu_net_server_port_05;
 HTTP(port).ResetAllHandlers();
   // Returning a potentially unlimited response chunk by chunk.
-  HTTP(port).Register("/chunked", [](Request r) {
+  const auto scope = HTTP(port).Register("/chunked", [](Request r) {
     const size_t n = atoi(r.url.query["n"].c_str());
     const size_t delay_ms = atoi(r.url.query["delay_ms"].c_str());
       

--- a/Blocks/HTTP/docu/server/docu_03httpserver_05_test.cc
+++ b/Blocks/HTTP/docu/server/docu_03httpserver_05_test.cc
@@ -38,7 +38,6 @@ DEFINE_int32(docu_net_server_port_05, PickPortForUnitTest(), "");
 
 TEST(Docu, HTTPServer05) {
 const auto port = FLAGS_docu_net_server_port_05;
-HTTP(port).ResetAllHandlers();
   // Returning a potentially unlimited response chunk by chunk.
   const auto scope = HTTP(port).Register("/chunked", [](Request r) {
     const size_t n = atoi(r.url.query["n"].c_str());

--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -222,11 +222,6 @@ class HTTPServerPOSIX final {
     return scope;
   }
 
-  void ResetAllHandlers() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    handlers_.clear();
-  }
-
   size_t PathHandlersCount() const {
     // NOTE: The total number of handlers is no longer an interesting measure.
     //       Just return the number of distinct paths, which may be path prefixes.

--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -137,7 +137,7 @@ class HTTPServerPOSIX final {
   // Scoped de-registerer of routes, of its own type.
   struct ScopedRegistererDifferentiator {};
   using HTTPRoutesScope = current::AccumulativeScopedDeleter<ScopedRegistererDifferentiator>;
-  using HTTPRoutesScopeEntry = current::AccumulativeScopedDeleter<ScopedRegistererDifferentiator, false>;
+  using HTTPRoutesScopeEntry = HTTPRoutesScope;  // TODO(dkorolev): Eliminate.
 
   // The philosophy of Register(path, handler):
   //
@@ -202,23 +202,24 @@ class HTTPServerPOSIX final {
     }
   }
 
-  void ServeStaticFilesFrom(const std::string& dir, const std::string& route_prefix = "/") {
-    // TODO(dkorolev): Add a scoped version of registerers.
+  HTTPRoutesScope ServeStaticFilesFrom(const std::string& dir, const std::string& route_prefix = "/") {
+    HTTPRoutesScope scope;
     current::FileSystem::ScanDir(
         dir,
-        [this, &dir, &route_prefix](const std::string& file) {
+        [this, &dir, &route_prefix, &scope](const std::string& file) {
           const std::string content_type(current::net::GetFileMimeType(file, ""));
           if (!content_type.empty()) {
             // TODO(dkorolev): Wrap keeping file contents into a singleton
             // that keeps a map from a (SHA256) hash to the contents.
             auto static_file_server = std::make_unique<StaticFileServer>(
                 current::FileSystem::ReadFileAsString(current::FileSystem::JoinPath(dir, file)), content_type);
-            Register(route_prefix + file, *static_file_server);
+            scope += Register(route_prefix + file, *static_file_server);
             static_file_servers_.push_back(std::move(static_file_server));
           } else {
             CURRENT_THROW(current::net::CannotServeStaticFilesOfUnknownMIMEType(file));
           }
         });
+    return scope;
   }
 
   void ResetAllHandlers() {

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -202,6 +202,14 @@ TEST(HTTPAPI, ScopedUnRegister) {
   }
 }
 
+TEST(HTTPAPI, ScopeCanBeAssignedNullPtr) {
+  auto scope = HTTP(FLAGS_net_api_test_port).Register("/are_we_there_yet", [](Request r) { r("So far."); });
+  const string url = Printf("http://localhost:%d/are_we_there_yet", FLAGS_net_api_test_port);
+  EXPECT_EQ(200, static_cast<int>(HTTP(GET(url)).code));
+  scope = nullptr;
+  EXPECT_EQ(404, static_cast<int>(HTTP(GET(url)).code));
+}
+
 TEST(HTTPAPI, URLParameters) {
   const auto scope =
       HTTP(FLAGS_net_api_test_port).Register("/query", [](Request r) { r("x=" + r.url.query["x"]); });

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -93,8 +93,7 @@ TEST(ArchitectureTest, CURRENT_ARCH_UNAME_AS_IDENTIFIER) {
 
 // Test the features of HTTP server.
 TEST(HTTPAPI, Register) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port).Register("/get", [](Request r) { r("OK"); });
+  const auto scope = HTTP(FLAGS_net_api_test_port).Register("/get", [](Request r) { r("OK"); });
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).Register("/get", nullptr), HandlerAlreadyExistsException);
   const string url = Printf("http://localhost:%d/get", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
@@ -105,7 +104,6 @@ TEST(HTTPAPI, Register) {
 }
 
 TEST(HTTPAPI, RegisterExceptions) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).Register("no_slash", nullptr), PathDoesNotStartWithSlash);
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).Register("/wrong_slash/", nullptr), PathEndsWithSlash);
   // The curly brackets are not necessarily wrong, but `URL::IsPathValidToRegister()` is `false` for them.
@@ -116,12 +114,12 @@ TEST(HTTPAPI, RegisterWithURLPathParams) {
   const auto handler =
       [](Request r) { r(r.url.path + " (" + current::strings::Join(r.url_path_args, ", ") + ')'); };
 
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port).Register("/", URLPathArgs::CountMask::Any, handler);
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/user", URLPathArgs::CountMask::One | URLPathArgs::CountMask::Two, handler);
-  HTTP(FLAGS_net_api_test_port).Register("/user/a", URLPathArgs::CountMask::One, handler);
-  HTTP(FLAGS_net_api_test_port).Register("/user/a/1", URLPathArgs::CountMask::None, handler);
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port).Register("/", URLPathArgs::CountMask::Any, handler) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/user", URLPathArgs::CountMask::One | URLPathArgs::CountMask::Two, handler) +
+      HTTP(FLAGS_net_api_test_port).Register("/user/a", URLPathArgs::CountMask::One, handler) +
+      HTTP(FLAGS_net_api_test_port).Register("/user/a/1", URLPathArgs::CountMask::None, handler);
 
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).Register("/", handler), HandlerAlreadyExistsException);
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).Register("/user", URLPathArgs::CountMask::Two, handler),
@@ -168,39 +166,15 @@ TEST(HTTPAPI, RegisterWithURLPathParams) {
   EXPECT_EQ("/ (user, a, 1, blah)", run("/user/a/1/blah/"));
 }
 
-TEST(HTTPAPI, UnRegisterAndReRegister) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
+TEST(HTTPAPI, ScopeLeftHangingThrowsAnException) {
   const string url = Printf("http://localhost:%d/foo", FLAGS_net_api_test_port);
 
   HTTP(FLAGS_net_api_test_port).Register("/foo", [](Request r) { r("bar"); });
-
-  auto tmp_handler = [](Request r) { r("baz"); };
-  ASSERT_THROW(HTTP(FLAGS_net_api_test_port).Register("/foo", tmp_handler), HandlerAlreadyExistsException);
-
-  EXPECT_EQ(200, static_cast<int>(HTTP(GET(url)).code));
-  EXPECT_EQ("bar", HTTP(GET(url)).body);
-  EXPECT_EQ(1u, HTTP(FLAGS_net_api_test_port).PathHandlersCount());
-
-  HTTP(FLAGS_net_api_test_port).Register<ReRegisterRoute::SilentlyUpdateExisting>("/foo", tmp_handler);
-  EXPECT_EQ(200, static_cast<int>(HTTP(GET(url)).code));
-  EXPECT_EQ("baz", HTTP(GET(url)).body);
-
-  // A special failure case to catch: The handler does exists, but with the wrong parameters count mask.
-  ASSERT_THROW(
-      HTTP(FLAGS_net_api_test_port)
-          .Register<ReRegisterRoute::SilentlyUpdateExisting>("/foo", URLPathArgs::CountMask::One, nullptr),
-      HandlerDoesNotExistException);
-  ASSERT_THROW(HTTP(FLAGS_net_api_test_port).UnRegister("/foo", URLPathArgs::CountMask::One),
-               HandlerDoesNotExistException);
-
-  HTTP(FLAGS_net_api_test_port).UnRegister("/foo");
-  EXPECT_EQ(404, static_cast<int>(HTTP(GET(url)).code));
-  EXPECT_EQ(0u, HTTP(FLAGS_net_api_test_port).PathHandlersCount());
-  ASSERT_THROW(HTTP(FLAGS_net_api_test_port).UnRegister("/foo"), HandlerDoesNotExistException);
+  // DIMA
+  // ASSERT_THROW(HTTP(FLAGS_net_api_test_port).UnRegister("/foo"), HandlerDoesNotExistException);
 }
 
 TEST(HTTPAPI, ScopedUnRegister) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   const string url = Printf("http://localhost:%d/foo", FLAGS_net_api_test_port);
 
   {
@@ -229,8 +203,8 @@ TEST(HTTPAPI, ScopedUnRegister) {
 }
 
 TEST(HTTPAPI, URLParameters) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port).Register("/query", [](Request r) { r("x=" + r.url.query["x"]); });
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port).Register("/query", [](Request r) { r("x=" + r.url.query["x"]); });
   EXPECT_EQ("x=", HTTP(GET(Printf("http://localhost:%d/query", FLAGS_net_api_test_port))).body);
   EXPECT_EQ("x=42", HTTP(GET(Printf("http://localhost:%d/query?x=42", FLAGS_net_api_test_port))).body);
   EXPECT_EQ("x=test passed",
@@ -238,22 +212,21 @@ TEST(HTTPAPI, URLParameters) {
 }
 
 TEST(HTTPAPI, HeadersAndCookies) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/headers_and_cookies",
-                [](Request r) {
-                  EXPECT_TRUE(r.headers.Has("Header1"));
-                  EXPECT_TRUE(r.headers.Has("Header2"));
-                  EXPECT_EQ("foo", r.headers["Header1"].value);
-                  EXPECT_EQ("bar", r.headers["Header2"].value);
-                  EXPECT_EQ("x=1; y=2", r.headers.CookiesAsString());
-                  Response response("OK");
-                  response.headers.Set("X-Current-H1", "header1");
-                  response.SetCookie("cookie1", "value1");
-                  response.headers.Set("X-Current-H2", "header2");
-                  response.SetCookie("cookie2", "value2");
-                  r(response);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/headers_and_cookies",
+                                   [](Request r) {
+                                     EXPECT_TRUE(r.headers.Has("Header1"));
+                                     EXPECT_TRUE(r.headers.Has("Header2"));
+                                     EXPECT_EQ("foo", r.headers["Header1"].value);
+                                     EXPECT_EQ("bar", r.headers["Header2"].value);
+                                     EXPECT_EQ("x=1; y=2", r.headers.CookiesAsString());
+                                     Response response("OK");
+                                     response.headers.Set("X-Current-H1", "header1");
+                                     response.SetCookie("cookie1", "value1");
+                                     response.headers.Set("X-Current-H2", "header2");
+                                     response.SetCookie("cookie2", "value2");
+                                     r(response);
+                                   });
   const auto response = HTTP(GET(Printf("http://localhost:%d/headers_and_cookies", FLAGS_net_api_test_port))
                                  .SetHeader("Header1", "foo")
                                  .SetCookie("x", "1")
@@ -268,17 +241,16 @@ TEST(HTTPAPI, HeadersAndCookies) {
 }
 
 TEST(HTTPAPI, ConnectionIPAndPort) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/foo",
-                [](Request r) {
-                  const auto& c = r.connection;
-                  EXPECT_EQ("127.0.0.1", c.LocalIPAndPort().ip);
-                  EXPECT_EQ(FLAGS_net_api_test_port, c.LocalIPAndPort().port);
-                  EXPECT_EQ("127.0.0.1", c.RemoteIPAndPort().ip);
-                  EXPECT_LT(0, c.RemoteIPAndPort().port);
-                  r("bar", HTTPResponseCode.OK);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/foo",
+                                   [](Request r) {
+                                     const auto& c = r.connection;
+                                     EXPECT_EQ("127.0.0.1", c.LocalIPAndPort().ip);
+                                     EXPECT_EQ(FLAGS_net_api_test_port, c.LocalIPAndPort().port);
+                                     EXPECT_EQ("127.0.0.1", c.RemoteIPAndPort().ip);
+                                     EXPECT_LT(0, c.RemoteIPAndPort().port);
+                                     r("bar", HTTPResponseCode.OK);
+                                   });
   const string url = Printf("http://localhost:%d/foo", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(200, static_cast<int>(response.code));
@@ -288,12 +260,12 @@ TEST(HTTPAPI, ConnectionIPAndPort) {
 }
 
 TEST(HTTPAPI, RespondsWithString) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/responds_with_string",
-                [](Request r) {
-                  r("test_string", HTTPResponseCode.OK, "application/json", Headers({{"foo", "bar"}}));
-                });
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/responds_with_string",
+                    [](Request r) {
+                      r("test_string", HTTPResponseCode.OK, "application/json", Headers({{"foo", "bar"}}));
+                    });
   const string url = Printf("http://localhost:%d/responds_with_string", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(200, static_cast<int>(response.code));
@@ -304,16 +276,15 @@ TEST(HTTPAPI, RespondsWithString) {
 }
 
 TEST(HTTPAPI, RespondsWithObject) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/responds_with_object",
-                [](Request r) {
-                  r(HTTPAPITestObject(),
-                    "test_object",
-                    HTTPResponseCode.OK,
-                    "application/json",
-                    Headers({{"foo", "bar"}}));
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/responds_with_object",
+                                   [](Request r) {
+                                     r(HTTPAPITestObject(),
+                                       "test_object",
+                                       HTTPResponseCode.OK,
+                                       "application/json",
+                                       Headers({{"foo", "bar"}}));
+                                   });
   const string url = Printf("http://localhost:%d/responds_with_object", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(200, static_cast<int>(response.code));
@@ -329,8 +300,8 @@ struct GoodStuff {
 };
 
 TEST(HTTPAPI, RespondsWithCustomObject) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port).Register("/dude_this_is_awesome", [](Request r) { r(GoodStuff()); });
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port).Register("/dude_this_is_awesome", [](Request r) { r(GoodStuff()); });
   const string url = Printf("http://localhost:%d/dude_this_is_awesome", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(762, static_cast<int>(response.code));
@@ -342,13 +313,12 @@ TEST(HTTPAPI, RespondsWithCustomObject) {
 #ifndef CURRENT_APPLE
 // Disabled redirect tests for Apple due to implementation specifics -- M.Z.
 TEST(HTTPAPI, Redirect) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/from",
-                [](Request r) {
-                  r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/to"}}));
-                });
-  HTTP(FLAGS_net_api_test_port).Register("/to", [](Request r) { r("Done."); });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/from",
+                                   [](Request r) {
+                                     r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/to"}}));
+                                   }) +
+                     HTTP(FLAGS_net_api_test_port).Register("/to", [](Request r) { r("Done."); });
   // Redirect not allowed by default.
   ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/from", FLAGS_net_api_test_port))),
                HTTPRedirectNotAllowedException);
@@ -360,29 +330,27 @@ TEST(HTTPAPI, Redirect) {
 }
 
 TEST(HTTPAPI, RedirectLoop) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/p1",
-                [](Request r) {
-                  r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/p2"}}));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/p2",
-                [](Request r) {
-                  r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/p3"}}));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/p3",
-                [](Request r) {
-                  r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/p1"}}));
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/p1",
+                                   [](Request r) {
+                                     r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/p2"}}));
+                                   }) +
+                     HTTP(FLAGS_net_api_test_port)
+                         .Register("/p2",
+                                   [](Request r) {
+                                     r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/p3"}}));
+                                   }) +
+                     HTTP(FLAGS_net_api_test_port)
+                         .Register("/p3",
+                                   [](Request r) {
+                                     r("", HTTPResponseCode.Found, "text/html", Headers({{"Location", "/p1"}}));
+                                   });
   ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/p1", FLAGS_net_api_test_port))), HTTPRedirectLoopException);
 }
 #endif
 
 TEST(HTTPAPI, FourOhFour) {
   EXPECT_EQ("<h1>NOT FOUND</h1>\n", DefaultFourOhFourMessage());
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   const string url = Printf("http://localhost:%d/ORLY", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(404, static_cast<int>(response.code));
@@ -391,7 +359,6 @@ TEST(HTTPAPI, FourOhFour) {
 }
 
 TEST(HTTPAPI, HandlerIsCapturedByReference) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   struct Helper {
     size_t counter = 0u;
     void operator()(Request r) {
@@ -403,9 +370,9 @@ TEST(HTTPAPI, HandlerIsCapturedByReference) {
   Helper copy(helper);
   EXPECT_EQ(0u, helper.counter);
   EXPECT_EQ(0u, copy.counter);
-  HTTP(FLAGS_net_api_test_port).Register("/incr", helper);
-  HTTP(FLAGS_net_api_test_port).Register("/incr_same", helper);
-  HTTP(FLAGS_net_api_test_port).Register("/incr_copy", copy);
+  const auto scope = HTTP(FLAGS_net_api_test_port).Register("/incr", helper) +
+                     HTTP(FLAGS_net_api_test_port).Register("/incr_same", helper) +
+                     HTTP(FLAGS_net_api_test_port).Register("/incr_copy", copy);
   EXPECT_EQ("Incremented two.", HTTP(GET(Printf("http://localhost:%d/incr", FLAGS_net_api_test_port))).body);
   EXPECT_EQ(1u, helper.counter);
   EXPECT_EQ(0u, copy.counter);
@@ -420,13 +387,12 @@ TEST(HTTPAPI, HandlerIsCapturedByReference) {
 }
 
 TEST(HTTPAPI, HandlerSupportsStaticMethods) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   struct Static {
     static void Foo(Request r) { r("foo"); }
     static void Bar(Request r) { r("bar"); }
   };
-  HTTP(FLAGS_net_api_test_port).Register("/foo", Static::Foo);
-  HTTP(FLAGS_net_api_test_port).Register("/bar", Static::Bar);
+  const auto scope = HTTP(FLAGS_net_api_test_port).Register("/foo", Static::Foo) +
+                     HTTP(FLAGS_net_api_test_port).Register("/bar", Static::Bar);
   EXPECT_EQ("foo", HTTP(GET(Printf("http://localhost:%d/foo", FLAGS_net_api_test_port))).body);
   EXPECT_EQ("bar", HTTP(GET(Printf("http://localhost:%d/bar", FLAGS_net_api_test_port))).body);
 }
@@ -437,34 +403,34 @@ struct ShouldReduceDelayBetweenChunksSingleton {
 };
 // Test various HTTP client modes.
 TEST(HTTPAPI, GetToFile) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/stars",
-                [](Request r) {
-                  const size_t n = atoi(r.url.query["n"].c_str());
-                  auto response = r.connection.SendChunkedHTTPResponse();
-                  const auto sleep = []() {
-                    const uint64_t delay_between_chunks = []() {
-                      bool& reduce = Singleton<ShouldReduceDelayBetweenChunksSingleton>().yes;
-                      if (!reduce) {
-                        reduce = true;
-                        return 10;
-                      } else {
-                        return 1;
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/stars",
+                    [](Request r) {
+                      const size_t n = atoi(r.url.query["n"].c_str());
+                      auto response = r.connection.SendChunkedHTTPResponse();
+                      const auto sleep = []() {
+                        const uint64_t delay_between_chunks = []() {
+                          bool& reduce = Singleton<ShouldReduceDelayBetweenChunksSingleton>().yes;
+                          if (!reduce) {
+                            reduce = true;
+                            return 10;
+                          } else {
+                            return 1;
+                          }
+                        }();
+                        std::this_thread::sleep_for(std::chrono::milliseconds(delay_between_chunks));
+                      };
+                      sleep();
+                      for (size_t i = 0; i < n; ++i) {
+                        response.Send("*");
+                        sleep();
+                        response.Send(std::vector<char>({'a', 'b'}));
+                        sleep();
+                        response.Send(std::vector<uint8_t>({0x31, 0x32}));
+                        sleep();
                       }
-                    }();
-                    std::this_thread::sleep_for(std::chrono::milliseconds(delay_between_chunks));
-                  };
-                  sleep();
-                  for (size_t i = 0; i < n; ++i) {
-                    response.Send("*");
-                    sleep();
-                    response.Send(std::vector<char>({'a', 'b'}));
-                    sleep();
-                    response.Send(std::vector<uint8_t>({0x31, 0x32}));
-                    sleep();
-                  }
-                });
+                    });
   current::FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const string file_name = FLAGS_net_api_test_tmpdir + "/some_test_file_for_http_get";
   const auto test_file_scope = FileSystem::ScopedRmFile(file_name);
@@ -477,17 +443,16 @@ TEST(HTTPAPI, GetToFile) {
 }
 
 TEST(HTTPAPI, ChunkedResponseWithHeaders) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/chunked_with_header",
-                [](Request r) {
-                  EXPECT_EQ("GET", r.method);
-                  auto response = r.connection.SendChunkedHTTPResponse(
-                      HTTPResponseCode.OK, "text/plain", Headers({{"header", "yeah"}}));
-                  response.Send("A");
-                  response.Send("B");
-                  response.Send("C");
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/chunked_with_header",
+                                   [](Request r) {
+                                     EXPECT_EQ("GET", r.method);
+                                     auto response = r.connection.SendChunkedHTTPResponse(
+                                         HTTPResponseCode.OK, "text/plain", Headers({{"header", "yeah"}}));
+                                     response.Send("A");
+                                     response.Send("B");
+                                     response.Send("C");
+                                   });
   const auto response = HTTP(GET(Printf("http://localhost:%d/chunked_with_header", FLAGS_net_api_test_port)));
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_EQ("ABC", response.body);
@@ -498,16 +463,15 @@ TEST(HTTPAPI, ChunkedResponseWithHeaders) {
 // A hacky way to get back the response chunk by chunk. TODO(dkorolev): `ChunkedGET`.
 TEST(HTTPAPI, GetByChunksPrototype) {
   // Handler returning the result chunk by chunk.
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/chunks",
-                [](Request r) {
-                  auto response = r.connection.SendChunkedHTTPResponse(
-                      HTTPResponseCode.OK, "text/plain", Headers({{"header", "oh-well"}}));
-                  response.Send("1\n");
-                  response.Send("23\n");
-                  response.Send("456\n");
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/chunks",
+                                   [](Request r) {
+                                     auto response = r.connection.SendChunkedHTTPResponse(
+                                         HTTPResponseCode.OK, "text/plain", Headers({{"header", "oh-well"}}));
+                                     response.Send("1\n");
+                                     response.Send("23\n");
+                                     response.Send("456\n");
+                                   });
   const string url = Printf("http://localhost:%d/chunks", FLAGS_net_api_test_port);
   {
     // A conventional GET, ignoring chunk boundaries and concatenating all the data together.
@@ -606,26 +570,24 @@ TEST(HTTPAPI, GetByChunksPrototype) {
 }
 
 TEST(HTTPAPI, PostFromBufferToBuffer) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/post",
-                [](Request r) {
-                  ASSERT_FALSE(r.body.empty());
-                  r("Data: " + r.body);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/post",
+                                   [](Request r) {
+                                     ASSERT_FALSE(r.body.empty());
+                                     r("Data: " + r.body);
+                                   });
   const auto response = HTTP(POST(
       Printf("http://localhost:%d/post", FLAGS_net_api_test_port), "No shit!", "application/octet-stream"));
   EXPECT_EQ("Data: No shit!", response.body);
 }
 
 TEST(HTTPAPI, PostAStringAsString) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/post_string",
-                [](Request r) {
-                  ASSERT_FALSE(r.body.empty());
-                  r(r.body);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/post_string",
+                                   [](Request r) {
+                                     ASSERT_FALSE(r.body.empty());
+                                     r(r.body);
+                                   });
   EXPECT_EQ("std::string",
             HTTP(POST(Printf("http://localhost:%d/post_string", FLAGS_net_api_test_port),
                       std::string("std::string"),
@@ -633,13 +595,12 @@ TEST(HTTPAPI, PostAStringAsString) {
 }
 
 TEST(HTTPAPI, PostAStringAsConstCharPtr) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/post_const_char_ptr",
-                [](Request r) {
-                  ASSERT_FALSE(r.body.empty());
-                  r(r.body);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/post_const_char_ptr",
+                                   [](Request r) {
+                                     ASSERT_FALSE(r.body.empty());
+                                     r(r.body);
+                                   });
   EXPECT_EQ("const char*",
             HTTP(POST(Printf("http://localhost:%d/post_const_char_ptr", FLAGS_net_api_test_port),
                       static_cast<const char*>("const char*"),
@@ -647,39 +608,38 @@ TEST(HTTPAPI, PostAStringAsConstCharPtr) {
 }
 
 TEST(HTTPAPI, RespondWithStringAsString) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/respond_with_std_string",
-                [](Request r) {
-                  EXPECT_EQ("", r.body);
-                  r.connection.SendHTTPResponse(std::string("std::string"), HTTPResponseCode.OK);
-                });
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/respond_with_std_string",
+                    [](Request r) {
+                      EXPECT_EQ("", r.body);
+                      r.connection.SendHTTPResponse(std::string("std::string"), HTTPResponseCode.OK);
+                    });
   EXPECT_EQ(
       "std::string",
       HTTP(POST(Printf("http://localhost:%d/respond_with_std_string", FLAGS_net_api_test_port), "")).body);
 }
 
 TEST(HTTPAPI, RespondWithStringAsConstCharPtr) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/respond_with_const_char_ptr",
-                [](Request r) {
-                  EXPECT_EQ("", r.body);
-                  r.connection.SendHTTPResponse(static_cast<const char*>("const char*"), HTTPResponseCode.OK);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/respond_with_const_char_ptr",
+                                   [](Request r) {
+                                     EXPECT_EQ("", r.body);
+                                     r.connection.SendHTTPResponse(static_cast<const char*>("const char*"),
+                                                                   HTTPResponseCode.OK);
+                                   });
   EXPECT_EQ(
       "const char*",
       HTTP(POST(Printf("http://localhost:%d/respond_with_const_char_ptr", FLAGS_net_api_test_port), "")).body);
 }
 
 TEST(HTTPAPI, RespondWithStringAsStringViaRequestDirectly) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/respond_with_std_string_via_request_directly",
-                [](Request r) {
-                  EXPECT_EQ("", r.body);
-                  r(std::string("std::string"), HTTPResponseCode.OK);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/respond_with_std_string_via_request_directly",
+                                   [](Request r) {
+                                     EXPECT_EQ("", r.body);
+                                     r(std::string("std::string"), HTTPResponseCode.OK);
+                                   });
   EXPECT_EQ("std::string",
             HTTP(POST(Printf("http://localhost:%d/respond_with_std_string_via_request_directly",
                              FLAGS_net_api_test_port),
@@ -687,13 +647,12 @@ TEST(HTTPAPI, RespondWithStringAsStringViaRequestDirectly) {
 }
 
 TEST(HTTPAPI, RespondWithStringAsConstCharPtrViaRequestDirectly) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/respond_with_const_char_ptr_via_request_directly",
-                [](Request r) {
-                  EXPECT_EQ("", r.body);
-                  r(static_cast<const char*>("const char*"), HTTPResponseCode.OK);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/respond_with_const_char_ptr_via_request_directly",
+                                   [](Request r) {
+                                     EXPECT_EQ("", r.body);
+                                     r(static_cast<const char*>("const char*"), HTTPResponseCode.OK);
+                                   });
   EXPECT_EQ("const char*",
             HTTP(POST(Printf("http://localhost:%d/respond_with_const_char_ptr_via_request_directly",
                              FLAGS_net_api_test_port),
@@ -709,7 +668,6 @@ CURRENT_STRUCT(SerializableObject) {
 #ifndef CURRENT_APPLE
 // Disabled for Apple - native code doesn't throw exceptions -- M.Z.
 TEST(HTTPAPI, PostFromInvalidFile) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   current::FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const string non_existent_file_name = FLAGS_net_api_test_tmpdir + "/non_existent_file";
   const auto test_file_scope = FileSystem::ScopedRmFile(non_existent_file_name);
@@ -721,13 +679,12 @@ TEST(HTTPAPI, PostFromInvalidFile) {
 #endif
 
 TEST(HTTPAPI, PostFromFileToBuffer) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/post",
-                [](Request r) {
-                  ASSERT_FALSE(r.body.empty());
-                  r("Voila: " + r.body);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/post",
+                                   [](Request r) {
+                                     ASSERT_FALSE(r.body.empty());
+                                     r("Voila: " + r.body);
+                                   });
   current::FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const string file_name = FLAGS_net_api_test_tmpdir + "/some_input_test_file_for_http_post";
   const auto test_file_scope = FileSystem::ScopedRmFile(file_name);
@@ -739,13 +696,12 @@ TEST(HTTPAPI, PostFromFileToBuffer) {
 }
 
 TEST(HTTPAPI, PostFromBufferToFile) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/post",
-                [](Request r) {
-                  ASSERT_FALSE(r.body.empty());
-                  r("Meh: " + r.body);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/post",
+                                   [](Request r) {
+                                     ASSERT_FALSE(r.body.empty());
+                                     r("Meh: " + r.body);
+                                   });
   current::FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const string file_name = FLAGS_net_api_test_tmpdir + "/some_output_test_file_for_http_post";
   const auto test_file_scope = FileSystem::ScopedRmFile(file_name);
@@ -756,13 +712,12 @@ TEST(HTTPAPI, PostFromBufferToFile) {
 }
 
 TEST(HTTPAPI, PostFromFileToFile) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/post",
-                [](Request r) {
-                  ASSERT_FALSE(r.body.empty());
-                  r("Phew: " + r.body);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/post",
+                                   [](Request r) {
+                                     ASSERT_FALSE(r.body.empty());
+                                     r("Phew: " + r.body);
+                                   });
   current::FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const string request_file_name = FLAGS_net_api_test_tmpdir + "/some_complex_request_test_file_for_http_post";
   const string response_file_name =
@@ -780,14 +735,13 @@ TEST(HTTPAPI, PostFromFileToFile) {
 }
 
 TEST(HTTPAPI, HeadRequest) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/head",
-                [](Request r) {
-                  EXPECT_EQ("HEAD", r.method);
-                  ASSERT_TRUE(r.body.empty());
-                  r("", HTTPResponseCode.OK, "text/html", Headers({{"foo", "bar"}}));
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/head",
+                                   [](Request r) {
+                                     EXPECT_EQ("HEAD", r.method);
+                                     ASSERT_TRUE(r.body.empty());
+                                     r("", HTTPResponseCode.OK, "text/html", Headers({{"foo", "bar"}}));
+                                   });
   const auto response = HTTP(HEAD(Printf("http://localhost:%d/head", FLAGS_net_api_test_port)));
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_TRUE(response.body.empty());
@@ -796,24 +750,23 @@ TEST(HTTPAPI, HeadRequest) {
 }
 
 TEST(HTTPAPI, DeleteRequest) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/delete",
-                [](Request r) {
-                  EXPECT_EQ("DELETE", r.method);
-                  ASSERT_TRUE(r.body.empty());
-                  SerializableObject object;
-                  r(object);
-                });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/delete",
+                                   [](Request r) {
+                                     EXPECT_EQ("DELETE", r.method);
+                                     ASSERT_TRUE(r.body.empty());
+                                     SerializableObject object;
+                                     r(object);
+                                   });
   const auto response = HTTP(DELETE(Printf("http://localhost:%d/delete", FLAGS_net_api_test_port)));
   EXPECT_EQ("42:foo", ParseJSON<SerializableObject>(response.body).AsString());
   EXPECT_EQ(200, static_cast<int>(response.code));
 }
 
 TEST(HTTPAPI, UserAgent) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/ua", [](Request r) { r("TODO(dkorolev): Actually get passed in user agent."); });
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/ua", [](Request r) { r("TODO(dkorolev): Actually get passed in user agent."); });
   const string url = Printf("http://localhost:%d/ua", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url).UserAgent("Blah"));
   EXPECT_EQ(url, response.url);
@@ -839,7 +792,6 @@ TEST(HTTPAPI, InvalidUrl) {
 
 TEST(HTTPAPI, ServeDir) {
   EXPECT_EQ("<h1>METHOD NOT ALLOWED</h1>\n", DefaultMethodNotAllowedMessage());
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const std::string dir = FLAGS_net_api_test_tmpdir + "/static";
   FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
@@ -847,7 +799,7 @@ TEST(HTTPAPI, ServeDir) {
   FileSystem::WriteStringToFile("This is text.", FileSystem::JoinPath(dir, "file.txt").c_str());
   FileSystem::WriteStringToFile("And this: PNG", FileSystem::JoinPath(dir, "file.png").c_str());
   FileSystem::MkDir(FileSystem::JoinPath(dir, "subdir_to_ignore"), FileSystem::MkDirParameters::Silent);
-  HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir);
+  const auto scope = HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir);
   EXPECT_EQ("<h1>HTML</h1>", HTTP(GET(Printf("http://localhost:%d/file.html", FLAGS_net_api_test_port))).body);
   EXPECT_EQ("This is text.", HTTP(GET(Printf("http://localhost:%d/file.txt", FLAGS_net_api_test_port))).body);
   EXPECT_EQ("And this: PNG", HTTP(GET(Printf("http://localhost:%d/file.png", FLAGS_net_api_test_port))).body);
@@ -874,7 +826,6 @@ TEST(HTTPAPI, ServeDir) {
 }
 
 TEST(HTTPAPI, ServeDirOnlyServesFilesOfKnownMIMEType) {
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
   FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const std::string dir = FLAGS_net_api_test_tmpdir + "/wrong_static_files";
   FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
@@ -888,50 +839,51 @@ TEST(HTTPAPI, ServeDirOnlyServesFilesOfKnownMIMEType) {
 TEST(HTTPAPI, ResponseSmokeTest) {
   const auto send_response = [](const Response& response, Request request) { request(response); };
 
-  HTTP(FLAGS_net_api_test_port).ResetAllHandlers();
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response1", [send_response](Request r) { send_response(Response("foo"), std::move(r)); });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response2",
-                [send_response](Request r) {
-                  send_response(Response("bar", HTTPResponseCode.Accepted), std::move(r));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response3",
-                [send_response](Request r) {
-                  send_response(Response("baz", HTTPResponseCode.NotFound, "text/blah"), std::move(r));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response4",
-                [send_response](Request r) {
-                  send_response(Response(SerializableObject(), HTTPResponseCode.Accepted), std::move(r));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response5",
-                [send_response](Request r) {
-                  send_response(Response(SerializableObject(), "meh").Code(HTTPResponseCode.Created),
-                                std::move(r));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response6",
-                [send_response](Request r) {
-                  send_response(Response().Body("OK").Code(HTTPResponseCode.OK), std::move(r));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response7",
-                [send_response](Request r) {
-                  send_response(Response().JSON(SerializableObject(), "magic").Code(HTTPResponseCode.OK),
-                                std::move(r));
-                });
-  HTTP(FLAGS_net_api_test_port)
-      .Register(
-          "/response8",
-          [send_response](Request r) { send_response(Response(HTTPResponseCode.Created), std::move(r)); });
-  HTTP(FLAGS_net_api_test_port)
-      .Register("/response9",
-                [send_response](Request r) {
-                  send_response(Response(), std::move(r));  // Will result in a 500 "INTERNAL SERVER ERROR".
-                });
+  const auto scope =
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response1",
+                    [send_response](Request r) { send_response(Response("foo"), std::move(r)); }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response2",
+                    [send_response](Request r) {
+                      send_response(Response("bar", HTTPResponseCode.Accepted), std::move(r));
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response3",
+                    [send_response](Request r) {
+                      send_response(Response("baz", HTTPResponseCode.NotFound, "text/blah"), std::move(r));
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response4",
+                    [send_response](Request r) {
+                      send_response(Response(SerializableObject(), HTTPResponseCode.Accepted), std::move(r));
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response5",
+                    [send_response](Request r) {
+                      send_response(Response(SerializableObject(), "meh").Code(HTTPResponseCode.Created),
+                                    std::move(r));
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response6",
+                    [send_response](Request r) {
+                      send_response(Response().Body("OK").Code(HTTPResponseCode.OK), std::move(r));
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response7",
+                    [send_response](Request r) {
+                      send_response(Response().JSON(SerializableObject(), "magic").Code(HTTPResponseCode.OK),
+                                    std::move(r));
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register(
+              "/response8",
+              [send_response](Request r) { send_response(Response(HTTPResponseCode.Created), std::move(r)); }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response9",
+                    [send_response](Request r) {
+                      send_response(Response(), std::move(r));  // Will result in a 500 "INTERNAL SERVER ERROR".
+                    });
 
   const auto response1 = HTTP(GET(Printf("http://localhost:%d/response1", FLAGS_net_api_test_port)));
   EXPECT_EQ(200, static_cast<int>(response1.code));

--- a/Bricks/util/accumulative_scoped_deleter.h
+++ b/Bricks/util/accumulative_scoped_deleter.h
@@ -32,6 +32,11 @@ SOFTWARE.
 
 namespace current {
 
+// TODO(dkorolev): Later.
+// enum class AccumulativeScopedDeleterPolicy { GarbageCollect = 0, LeaveHanging = 1, AssertNotLeftHanging = 2
+// };
+// template <class DIFFERENTIATOR, AccumulativeScopedDeleterPolicy POLICY =
+// AccumulativeScopedDeleterPolicy::GarbageCollect>
 template <class DIFFERENTIATOR, bool SHOULD_DELETE = true>
 class AccumulativeScopedDeleter {
  public:

--- a/Bricks/util/accumulative_scoped_deleter.h
+++ b/Bricks/util/accumulative_scoped_deleter.h
@@ -62,6 +62,9 @@ class AccumulativeScopedDeleter {
   // Destruction unregisters previously added instances.
   ~AccumulativeScopedDeleter() { ReleaseCaptured(); }
 
+  // Also enable assigning `nullptr` explicitly.
+  void operator=(std::nullptr_t) { ReleaseCaptured(); }
+
   // Adds an instance, or several instances, erasing them from the `rhs`.
   template <bool B>
   AccumulativeScopedDeleter& operator+=(AccumulativeScopedDeleter<DIFFERENTIATOR, B>&& rhs) {

--- a/Sherlock/test.cc
+++ b/Sherlock/test.cc
@@ -342,12 +342,12 @@ TEST(Sherlock, SubscribeToStreamViaHTTP) {
   auto exposed_stream = current::sherlock::Stream<RecordWithTimestamp>(
       current::sherlock::SherlockNamespaceName("Sherlock", "Transaction"));
   // Expose stream via HTTP.
-  HTTP(FLAGS_sherlock_http_test_port).ResetAllHandlers();
-  HTTP(FLAGS_sherlock_http_test_port).Register("/exposed", exposed_stream);
   const std::string base_url = Printf("http://localhost:%d/exposed", FLAGS_sherlock_http_test_port);
-
-  HTTP(FLAGS_sherlock_http_test_port)
-      .Register("/exposed_more", URLPathArgs::CountMask::None | URLPathArgs::CountMask::One, exposed_stream);
+  const auto scope =
+      HTTP(FLAGS_sherlock_http_test_port).Register("/exposed", exposed_stream) +
+      HTTP(FLAGS_sherlock_http_test_port)
+          .Register(
+              "/exposed_more", URLPathArgs::CountMask::None | URLPathArgs::CountMask::One, exposed_stream);
   const std::string base_url_with_args =
       Printf("http://localhost:%d/exposed_more", FLAGS_sherlock_http_test_port);
 
@@ -665,9 +665,9 @@ TEST(Sherlock, HTTPSubscriptionCanBeTerminated) {
   using namespace sherlock_unittest;
 
   auto exposed_stream = current::sherlock::Stream<Record>();
-  HTTP(FLAGS_sherlock_http_test_port).ResetAllHandlers();
-  HTTP(FLAGS_sherlock_http_test_port).Register("/exposed", exposed_stream);
   const std::string base_url = Printf("http://localhost:%d/exposed", FLAGS_sherlock_http_test_port);
+
+  const auto scope = HTTP(FLAGS_sherlock_http_test_port).Register("/exposed", exposed_stream);
 
   std::atomic_bool keep_publishing(true);
   std::thread slow_publisher([&exposed_stream, &keep_publishing]() {

--- a/examples/EmbeddedDB/db.cc
+++ b/examples/EmbeddedDB/db.cc
@@ -103,7 +103,6 @@ struct UserNicknamesReadModel {
     return current::ss::EntryResponse::More;
   }
 
-  // TODO(dkorolev): Revisit the above calls, they are all wrong.
   current::ss::TerminationResponse Terminate() { return current::ss::TerminationResponse::Terminate; }
 };
 


### PR DESCRIPTION
If this passes Travis tests, this does the job with:
1. Not having HTTP scopes hanging, and
2. Allowing assigning `nullptr` to `HTTPRoutesScope`.