### PR TITLE
CURRENT_OBJECT_INTERFACE + CURRENT_FORWARD_METHOD.

### DIFF
--- a/Bricks/util/iterator.h
+++ b/Bricks/util/iterator.h
@@ -67,9 +67,7 @@ struct GenericMapAccessor final {
   iterator_t end() const { return iterator_t(map_.cend()); }
 
   // TODO(dkorolev): Replace this by `Size()` once the REST-related dust settles.
-  int64_t TotalElementsForHypermediaCollectionView() const {
-    return static_cast<int64_t>(Size());
-  }
+  int64_t TotalElementsForHypermediaCollectionView() const { return static_cast<int64_t>(Size()); }
 };
 
 }  // namespace current

--- a/Bricks/util/object_interface.h
+++ b/Bricks/util/object_interface.h
@@ -1,0 +1,53 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BRICKS_UTIL_OBJECT_INTERFACE_H
+#define BRICKS_UTIL_OBJECT_INTERFACE_H
+
+#define CURRENT_OBJECT_INTERFACE(type)                          \
+  template <class>                                              \
+  struct CURRENT_OBJECT_INTERFACE_METHODS_WRAPPER;              \
+  template <class>                                              \
+  class CURRENT_OBJECT_INTERFACE_IMPL_POINTER_CONTAINER;        \
+  template <>                                                   \
+  class CURRENT_OBJECT_INTERFACE_IMPL_POINTER_CONTAINER<type> { \
+   public:                                                      \
+    using CURRENT_IMPLEMENTATION_POINTER_TYPE = type;           \
+                                                                \
+   protected:                                                   \
+    type* CURRENT_IMPLEMENTATION_POINTER;                       \
+  };                                                            \
+  template <>                                                   \
+  struct CURRENT_OBJECT_INTERFACE_METHODS_WRAPPER<type>         \
+      : CURRENT_OBJECT_INTERFACE_IMPL_POINTER_CONTAINER<type>
+
+#define CURRENT_FORWARD_METHOD(method)                                                \
+  template <typename... ARGS>                                                         \
+  typename std::result_of<decltype(&CURRENT_IMPLEMENTATION_POINTER_TYPE::method)(     \
+      CURRENT_IMPLEMENTATION_POINTER_TYPE, ARGS...)>::type                            \
+  method(ARGS&&... args) {                                                            \
+    return this->CURRENT_IMPLEMENTATION_POINTER->method(std::forward<ARGS>(args)...); \
+  }
+
+#endif  // BRICKS_UTIL_OBJECT_INTERFACE_H


### PR DESCRIPTION
`CURRENT_OBJECT_INTERFACE` + `CURRENT_FORWARD_METHOD`.

I kept writing `CURRENT_INTERFACE_METHOD` instead of `CURRENT_EXPOSE_METHOD`, which led me to thinking `EXPOSE` is not the right word. Max, what do you think of `FORWARD` instead?

Thanks,
Dima