### PR TITLE
Workaround for VC++ decltype + function constexpr return bug

### DIFF
--- a/TypeSystem/helpers.h
+++ b/TypeSystem/helpers.h
@@ -155,11 +155,11 @@ template <typename OUTPUT = DefaultValueInvokation, typename INPUT>
 auto Value(INPUT&& x) -> decltype(PowerfulValueImplCaller<
     typename std::conditional<std::is_same<OUTPUT, DefaultValueInvokation>::value, INPUT, OUTPUT>::type,
     INPUT,
-    current::sfinae::HasValueImplMethod<INPUT>(0)>::AccessValue(std::declval<INPUT>())) {
+    current::sfinae::ValueImplMethodTest<INPUT>::value>::AccessValue(std::declval<INPUT>())) {
   return PowerfulValueImplCaller<
       typename std::conditional<std::is_same<OUTPUT, DefaultValueInvokation>::value, INPUT, OUTPUT>::type,
       INPUT,
-      current::sfinae::HasValueImplMethod<INPUT>(0)>::AccessValue(std::forward<INPUT>(x));
+      current::sfinae::ValueImplMethodTest<INPUT>::value>::AccessValue(std::forward<INPUT>(x));
 }
 
 // MSVS is not friendly with `ENABLE_IF` as return type, but happy with it as a template parameter. -- D.K.

--- a/TypeSystem/types.h
+++ b/TypeSystem/types.h
@@ -71,6 +71,11 @@ constexpr auto HasExistsImplMethod(int) -> decltype(std::declval<const ENTRY>().
   return true;
 }
 
+template <typename ENTRY>
+struct ExistsImplMethodTest {
+  static constexpr bool value = HasExistsImplMethod<ENTRY>(0);
+};
+
 // Whether a `ValueImpl()` method is defined for a type.
 template <typename ENTRY>
 constexpr bool HasValueImplMethod(char) {
@@ -81,6 +86,11 @@ template <typename ENTRY>
 constexpr auto HasValueImplMethod(int) -> decltype(std::declval<const ENTRY>().ValueImpl(), bool()) {
   return true;
 }
+
+template <typename ENTRY>
+struct ValueImplMethodTest {
+  static constexpr bool value = HasValueImplMethod<ENTRY>(0);
+};
 
 // Whether a `SuccessfulImpl()` method is defined for a type.
 template <typename ENTRY>
@@ -93,6 +103,11 @@ constexpr auto HasSuccessfulImplMethod(int) -> decltype(std::declval<const ENTRY
   return true;
 }
 
+template <typename ENTRY>
+struct SuccessfulImplMethodTest {
+  static constexpr bool value = HasSuccessfulImplMethod<ENTRY>(0);
+};
+
 // Whether an `CheckIntegrityImpl()` method is defined for a type.
 template <typename ENTRY>
 constexpr bool HasCheckIntegrityImplMethod(char) {
@@ -104,6 +119,11 @@ constexpr auto HasCheckIntegrityImplMethod(int)
     -> decltype(std::declval<const ENTRY>().CheckIntegrityImpl(), bool()) {
   return true;
 }
+
+template <typename ENTRY>
+struct CheckIntegrityImplMethodTest {
+  static constexpr bool value = HasCheckIntegrityImplMethod<ENTRY>(0);
+};
 
 }  // namespace sfinae
 }  // namespace current


### PR DESCRIPTION
Another workaround for an MSVC++ bug.