### PR TITLE
Excluded `regression_tests/type_system` from the top-level `make test`.

### DIFF
--- a/regression_tests/type_system/current_struct.cc
+++ b/regression_tests/type_system/current_struct.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/struct.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -39,3 +41,5 @@ TEST(TypeTest, CurrentStruct) {
   s.x1 = 42u;
   EXPECT_EQ(42u, s.x1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/current_struct_reflection.cc
+++ b/regression_tests/type_system/current_struct_reflection.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Schema/schema.h"
 
 #include "../../Bricks/file/file.h"
@@ -42,3 +44,5 @@ TEST(TypeTest, CurrentStruct) {
   EXPECT_EQ(current::FileSystem::ReadFileAsString("golden/current_struct.cc"),
             schema.GetSchemaInfo().Describe<current::reflection::Language::CPP>(false));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/json_variant_stringify.cc
+++ b/regression_tests/type_system/json_variant_stringify.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Serialization/json.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -37,3 +39,5 @@ TEST(TypeTest, Variant) {
 #include "include/json_variant.cc"
   JSON(v1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/json_variant_stringify_and_parse.cc
+++ b/regression_tests/type_system/json_variant_stringify_and_parse.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Serialization/json.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -37,3 +39,5 @@ TEST(TypeTest, Variant) {
 #include "include/json_variant.cc"
   ParseJSON<variant_t>(JSON(v1));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/json_variant_stringify_and_parse_and_test.cc
+++ b/regression_tests/type_system/json_variant_stringify_and_parse_and_test.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Serialization/json.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -37,3 +39,5 @@ TEST(TypeTest, Variant) {
 #include "include/json_variant.cc"
   EXPECT_EQ(1, Value<Struct1>(ParseJSON<variant_t>(JSON(v1))).x1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/rtti_dynamic_call.cc
+++ b/regression_tests/type_system/rtti_dynamic_call.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/file/file.h"
 #include "../../Bricks/template/rtti_dynamic_call.h"
 #include "../../Bricks/template/typelist.h"
@@ -40,3 +42,5 @@ TEST(TypeTest, RTTIDynamicCall) {
 #include "include/rtti_dynamic_call.cc"
   EXPECT_EQ(call_struct.oss.str(), current::FileSystem::ReadFileAsString("golden/rtti_dynamic_call.output"));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/sherlock_file.cc
+++ b/regression_tests/type_system/sherlock_file.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Sherlock/sherlock.h"
 
 #include "../../Bricks/file/file.h"
@@ -47,3 +49,5 @@ TEST(TypeTest, Sherlock) {
 
   EXPECT_EQ(entries_count, stream.InternalExposePersister().Size());
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/sherlock_memory.cc
+++ b/regression_tests/type_system/sherlock_memory.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Sherlock/sherlock.h"
 
 #include "../../Bricks/file/file.h"
@@ -47,3 +49,5 @@ TEST(TypeTest, Sherlock) {
 
   EXPECT_EQ(entries_count, stream.InternalExposePersister().Size());
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_null_persister.cc
+++ b/regression_tests/type_system/storage_null_persister.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 
 #include "../../Bricks/file/file.h"
@@ -45,3 +47,5 @@ TEST(TypeTest, Storage) {
 
 #include "include/storage.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_sherlock_persister.cc
+++ b/regression_tests/type_system/storage_sherlock_persister.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 #include "../../Storage/persister/sherlock.h"
 
@@ -46,3 +48,5 @@ TEST(TypeTest, Storage) {
 
 #include "include/storage.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_simple_persister.cc
+++ b/regression_tests/type_system/storage_simple_persister.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 
 #include "../../Bricks/file/file.h"
@@ -45,3 +47,5 @@ TEST(TypeTest, Storage) {
 
 #include "include/storage.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_with_subscriber.cc
+++ b/regression_tests/type_system/storage_with_subscriber.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 #include "../../Storage/persister/sherlock.h"
 
@@ -69,3 +71,5 @@ TEST(TypeTest, Storage) {
 
   EXPECT_EQ(static_cast<size_t>(storage_t::FIELDS_COUNT), subscriber.number_of_mutations);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/struct_fields.cc
+++ b/regression_tests/type_system/struct_fields.cc
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Schema/schema.h"
 
 #include "../../Bricks/file/file.h"
@@ -44,3 +46,5 @@ TEST(TypeTest, StructFields) {
   foo.z1 = 42u;
   EXPECT_EQ(42u, foo.z1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/struct_fields_reflection.cc
+++ b/regression_tests/type_system/struct_fields_reflection.cc
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/struct.h"
 #include "../../TypeSystem/Schema/schema.h"
 #include "../../TypeSystem/Reflection/reflection.h"
@@ -45,3 +47,5 @@ TEST(TypeTest, StructFields) {
   EXPECT_EQ(current::FileSystem::ReadFileAsString("golden/struct_fields.cc"),
             schema.GetSchemaInfo().Describe<current::reflection::Language::CPP>(false));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/typelist.cc
+++ b/regression_tests/type_system/typelist.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/template/typelist.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -36,3 +38,5 @@ TEST(TypeTest, TypeList) {
   using namespace type_test;
 #include "include/typelist.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/typelist_dynamic.cc
+++ b/regression_tests/type_system/typelist_dynamic.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/struct.h"
 
 #include "../../Bricks/template/mapreduce.h"
@@ -48,3 +50,5 @@ TEST(TypeTest, TypeListImpl) {
 
   static_assert(TypeListSize<STORAGE_TYPES>::value == TypeListSize<DATA_TYPES>::value * 2, "");
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/typelist_impl.cc
+++ b/regression_tests/type_system/typelist_impl.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/template/typelist.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -36,3 +38,5 @@ TEST(TypeTest, TypeListImpl) {
   using namespace type_test;
 #include "include/typelist_impl.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/variant.cc
+++ b/regression_tests/type_system/variant.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/file/file.h"
 #include "../../TypeSystem/struct.h"
 
@@ -38,3 +40,5 @@ TEST(TypeTest, Variant) {
 #include "include/variant.cc"
   EXPECT_EQ(call_struct.oss.str(), current::FileSystem::ReadFileAsString("golden/variant.output"));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE


### PR DESCRIPTION
Made the top-level `make test` pass.