### PR TITLE
Array format

### DIFF
--- a/Sherlock/pubsub.h
+++ b/Sherlock/pubsub.h
@@ -156,6 +156,8 @@ struct ParsedHTTPRequestParams {
   uint64_t stop_after_bytes = 0u;
   // If set, do not prepend each entry with its index and timestamp followed by a '\t', return data JSONs only.
   bool entries_only = false;
+  // If set, wrap the entries into a large JSON array. Mostly to please JSON-beautifying browser extensions.
+  bool array = false;
 };
 
 inline ParsedHTTPRequestParams ParsePubSubHTTPRequest(const Request& r) {
@@ -209,6 +211,10 @@ inline ParsedHTTPRequestParams ParsePubSubHTTPRequest(const Request& r) {
   if (r.url.query.has("entries_only")) {
     result.entries_only = true;
   }
+  if (r.url.query.has("array")) {
+    result.array = true;
+    result.entries_only = true;  // Obviously, `array` implies `entries_only`.
+  }
 
   return result;
 }
@@ -225,6 +231,7 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
       : data_(data, [this]() { time_to_terminate_ = true; }),
         http_request_(std::move(r)),
         params_(std::move(params)),
+        output_started_(false),
         http_response_(http_request_.SendChunkedResponse(
             HTTPResponseCode.OK,
             current::net::constants::kDefaultJSONContentType,
@@ -250,6 +257,7 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
   // * `EntryResponse` as the return value.
   // It does so to respect the URL parameters of the range of entries to subscribe to.
   ss::EntryResponse operator()(const E& entry, idxts_t current, idxts_t last) {
+    const ss::EntryResponse result = [&, this]() {
     if (time_to_terminate_) {
       return ss::EntryResponse::Done;
     }
@@ -283,6 +291,14 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
       }();
       current_response_size_ += entry_json.length();
       try {
+        if (params_.array) {
+          if (!output_started_) {
+            http_response_("[\n");
+            output_started_ = true;
+          } else {
+            http_response_(",\n");
+          }
+        }
         http_response_(std::move(entry_json));
       } catch (const current::net::NetworkException&) {  // LCOV_EXCL_LINE
         return ss::EntryResponse::Done;                  // LCOV_EXCL_LINE
@@ -304,6 +320,15 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
       }
     }
     return ss::EntryResponse::More;
+    }();
+    if (result == ss::EntryResponse::Done && params_.array) {
+      if (!output_started_) {
+        http_response_("[]\n");
+      } else {
+        http_response_("]\n");
+      }
+    }
+    return result;
   }
 
   // TODO(dkorolev): This is a long shot, but looks right: For type-filtered HTTP subscriptions,
@@ -314,7 +339,12 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
 
   // LCOV_EXCL_START
   ss::TerminationResponse Terminate() {
-    http_response_("{\"error\":\"The subscriber has terminated.\"}\n");
+    static const std::string message = "{\"error\":\"The subscriber has terminated.\"}\n";
+    if (params_.array && output_started_) {
+      http_response_(",\n" + message + "]\n");
+    } else {
+      http_response_(message);
+    }
     return ss::TerminationResponse::Terminate;
   }
   // LCOV_EXCL_STOP
@@ -327,6 +357,9 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
   // `http_request_`:  need to keep the passed in request in scope for the lifetime of the chunked response.
   Request http_request_;
   const ParsedHTTPRequestParams params_;
+  // `output_started_`: will change to `true` is `params_.array` is `true` as the first piece of data
+  // has already been sent, thus triggering the need to close the array at the end.
+  bool output_started_ = false;
   // `http_response_`: the instance of the chunked response object to use.
   current::net::HTTPServerConnection::ChunkedResponseSender http_response_;
   // Current response size in bytes.

--- a/regression_tests/type_system/current_struct.cc
+++ b/regression_tests/type_system/current_struct.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/struct.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -39,3 +41,5 @@ TEST(TypeTest, CurrentStruct) {
   s.x1 = 42u;
   EXPECT_EQ(42u, s.x1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/current_struct_reflection.cc
+++ b/regression_tests/type_system/current_struct_reflection.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Schema/schema.h"
 
 #include "../../Bricks/file/file.h"
@@ -42,3 +44,5 @@ TEST(TypeTest, CurrentStruct) {
   EXPECT_EQ(current::FileSystem::ReadFileAsString("golden/current_struct.cc"),
             schema.GetSchemaInfo().Describe<current::reflection::Language::CPP>(false));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/json_variant_stringify.cc
+++ b/regression_tests/type_system/json_variant_stringify.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Serialization/json.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -37,3 +39,5 @@ TEST(TypeTest, Variant) {
 #include "include/json_variant.cc"
   JSON(v1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/json_variant_stringify_and_parse.cc
+++ b/regression_tests/type_system/json_variant_stringify_and_parse.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Serialization/json.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -37,3 +39,5 @@ TEST(TypeTest, Variant) {
 #include "include/json_variant.cc"
   ParseJSON<variant_t>(JSON(v1));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/json_variant_stringify_and_parse_and_test.cc
+++ b/regression_tests/type_system/json_variant_stringify_and_parse_and_test.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Serialization/json.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -37,3 +39,5 @@ TEST(TypeTest, Variant) {
 #include "include/json_variant.cc"
   EXPECT_EQ(1, Value<Struct1>(ParseJSON<variant_t>(JSON(v1))).x1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/rtti_dynamic_call.cc
+++ b/regression_tests/type_system/rtti_dynamic_call.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/file/file.h"
 #include "../../Bricks/template/rtti_dynamic_call.h"
 #include "../../Bricks/template/typelist.h"
@@ -40,3 +42,5 @@ TEST(TypeTest, RTTIDynamicCall) {
 #include "include/rtti_dynamic_call.cc"
   EXPECT_EQ(call_struct.oss.str(), current::FileSystem::ReadFileAsString("golden/rtti_dynamic_call.output"));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/sherlock_file.cc
+++ b/regression_tests/type_system/sherlock_file.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Sherlock/sherlock.h"
 
 #include "../../Bricks/file/file.h"
@@ -47,3 +49,5 @@ TEST(TypeTest, Sherlock) {
 
   EXPECT_EQ(entries_count, stream.InternalExposePersister().Size());
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/sherlock_memory.cc
+++ b/regression_tests/type_system/sherlock_memory.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Sherlock/sherlock.h"
 
 #include "../../Bricks/file/file.h"
@@ -47,3 +49,5 @@ TEST(TypeTest, Sherlock) {
 
   EXPECT_EQ(entries_count, stream.InternalExposePersister().Size());
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_null_persister.cc
+++ b/regression_tests/type_system/storage_null_persister.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 
 #include "../../Bricks/file/file.h"
@@ -45,3 +47,5 @@ TEST(TypeTest, Storage) {
 
 #include "include/storage.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_sherlock_persister.cc
+++ b/regression_tests/type_system/storage_sherlock_persister.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 #include "../../Storage/persister/sherlock.h"
 
@@ -46,3 +48,5 @@ TEST(TypeTest, Storage) {
 
 #include "include/storage.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_simple_persister.cc
+++ b/regression_tests/type_system/storage_simple_persister.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 
 #include "../../Bricks/file/file.h"
@@ -45,3 +47,5 @@ TEST(TypeTest, Storage) {
 
 #include "include/storage.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/storage_with_subscriber.cc
+++ b/regression_tests/type_system/storage_with_subscriber.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Storage/storage.h"
 #include "../../Storage/persister/sherlock.h"
 
@@ -69,3 +71,5 @@ TEST(TypeTest, Storage) {
 
   EXPECT_EQ(static_cast<size_t>(storage_t::FIELDS_COUNT), subscriber.number_of_mutations);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/struct_fields.cc
+++ b/regression_tests/type_system/struct_fields.cc
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/Schema/schema.h"
 
 #include "../../Bricks/file/file.h"
@@ -44,3 +46,5 @@ TEST(TypeTest, StructFields) {
   foo.z1 = 42u;
   EXPECT_EQ(42u, foo.z1);
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/struct_fields_reflection.cc
+++ b/regression_tests/type_system/struct_fields_reflection.cc
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/struct.h"
 #include "../../TypeSystem/Schema/schema.h"
 #include "../../TypeSystem/Reflection/reflection.h"
@@ -45,3 +47,5 @@ TEST(TypeTest, StructFields) {
   EXPECT_EQ(current::FileSystem::ReadFileAsString("golden/struct_fields.cc"),
             schema.GetSchemaInfo().Describe<current::reflection::Language::CPP>(false));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/typelist.cc
+++ b/regression_tests/type_system/typelist.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/template/typelist.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -36,3 +38,5 @@ TEST(TypeTest, TypeList) {
   using namespace type_test;
 #include "include/typelist.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/typelist_dynamic.cc
+++ b/regression_tests/type_system/typelist_dynamic.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../TypeSystem/struct.h"
 
 #include "../../Bricks/template/mapreduce.h"
@@ -48,3 +50,5 @@ TEST(TypeTest, TypeListImpl) {
 
   static_assert(TypeListSize<STORAGE_TYPES>::value == TypeListSize<DATA_TYPES>::value * 2, "");
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/typelist_impl.cc
+++ b/regression_tests/type_system/typelist_impl.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/template/typelist.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
@@ -36,3 +38,5 @@ TEST(TypeTest, TypeListImpl) {
   using namespace type_test;
 #include "include/typelist_impl.cc"
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE

--- a/regression_tests/type_system/variant.cc
+++ b/regression_tests/type_system/variant.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#ifndef CURRENT_COVERAGE_REPORT_MODE
+
 #include "../../Bricks/file/file.h"
 #include "../../TypeSystem/struct.h"
 
@@ -38,3 +40,5 @@ TEST(TypeTest, Variant) {
 #include "include/variant.cc"
   EXPECT_EQ(call_struct.oss.str(), current::FileSystem::ReadFileAsString("golden/variant.output"));
 }
+
+#endif  // CURRENT_COVERAGE_REPORT_MODE


### PR DESCRIPTION
After https://github.com/C5T/Current/pull/617: Added support for `&array` Sherlock subscription, to add the outer `[]` and the inner `,`-s when returning entries.