### PR TITLE
Supported partial or multiple entries per chunk in the `RemoteSubscriberThread`.

### DIFF
--- a/Sherlock/replicator.h
+++ b/Sherlock/replicator.h
@@ -167,7 +167,8 @@ class SubscribableRemoteStream final {
       const std::string combined_data = carried_over_data_ + chunk;
       const auto lines = current::strings::Split<current::strings::ByLines>(combined_data);
       size_t whole_entries_count = lines.size();
-      if (combined_data.back() != '\n') {
+      CURRENT_ASSERT(!combined_data.empty());
+      if (combined_data.back() != '\n' && combined_data.back() != '\r') {
         --whole_entries_count;
         carried_over_data_ = lines.back();
       } else {

--- a/Sherlock/replicator.h
+++ b/Sherlock/replicator.h
@@ -148,6 +148,7 @@ class SubscribableRemoteStream final {
           break;
         } catch (current::Exception&) {
         }
+        unprocessed_data_.clear();
         subscription_id_.MutableScopedAccessor()->clear();
       }
     }
@@ -163,17 +164,22 @@ class SubscribableRemoteStream final {
         return;
       }
 
-      // Expected one entire entry in each chunk,
-      // won't work in case of partial or multiple entries per chunk
-      const auto split = current::strings::Split(chunk, '\t');
-      CURRENT_ASSERT(split.size() == 2u);
-      const auto idxts = ParseJSON<idxts_t>(split[0]);
-      CURRENT_ASSERT(idxts.index == index_);
-      auto entry = ParseJSON<TYPE_SUBSCRIBED_TO>(split[1]);
-      ++index_;
-      if (subscriber_(std::move(entry), idxts, unused_idxts_) == ss::EntryResponse::Done) {
-        CURRENT_THROW(StreamTerminatedBySubscriber());
+      const std::string combined_data = unprocessed_data_ + chunk;
+      const auto lines = current::strings::Split(combined_data, '\n');
+      size_t processed_bytes = 0;
+      for (size_t i = 0, sz = combined_data.back() == '\n' ? lines.size() : lines.size() - 1; i < sz; ++i) {
+        const auto split = current::strings::Split(lines[i], '\t');
+        CURRENT_ASSERT(split.size() == 2u);
+        const auto idxts = ParseJSON<idxts_t>(split[0]);
+        CURRENT_ASSERT(idxts.index == index_);
+        auto entry = ParseJSON<TYPE_SUBSCRIBED_TO>(split[1]);
+        ++index_;
+        processed_bytes += lines[i].length() + 1;
+        if (subscriber_(std::move(entry), idxts, unused_idxts_) == ss::EntryResponse::Done) {
+          CURRENT_THROW(StreamTerminatedBySubscriber());
+        }
       }
+      unprocessed_data_ = combined_data.substr(processed_bytes);
     }
 
     void TerminateSubscription() {
@@ -204,6 +210,7 @@ class SubscribableRemoteStream final {
     current::WaitableAtomic<std::string> subscription_id_;
     std::atomic_bool terminate_subscription_requested_;
     std::thread thread_;
+    std::string unprocessed_data_;
   };
 
   template <typename F, typename TYPE_SUBSCRIBED_TO>

--- a/Sherlock/test.cc
+++ b/Sherlock/test.cc
@@ -867,13 +867,17 @@ TEST(Sherlock, ParseArbitrarilySplittedChunks) {
                 if (r.url.query.has("terminate")) {
                   EXPECT_EQ(r.url.query["terminate"], subscription_id);
                 } else if (r.url.query.has("i")) {
-                  EXPECT_EQ("0", r.url.query["i"]);
+                  const auto ind = current::FromString<uint64_t>(r.url.query["i"]);
                   auto response = r.connection.SendChunkedHTTPResponse(
                       HTTPResponseCode.OK,
                       "text/plain",
                       current::net::http::Headers({{"X-Current-Stream-Subscription-Id", subscription_id}}));
-                  for (const auto& chunk : sherlock_golden_data_chunks) {
-                    response.Send(chunk);
+                  if (ind == 0u) {
+                    for (const auto& chunk : sherlock_golden_data_chunks) {
+                      response.Send(chunk);
+                    }
+                  } else {
+                    EXPECT_EQ(3u, ind);
                   }
                 } else {
                   EXPECT_EQ(1u, r.url_path_args.size());

--- a/Sherlock/test.cc
+++ b/Sherlock/test.cc
@@ -845,7 +845,7 @@ TEST(Sherlock, ParsesFromFile) {
       << d.results_;
 }
 
-TEST(Sherlock, ParseArbitrarilySplittedChunks) {
+TEST(Sherlock, ParseArbitrarilySplitChunks) {
   using namespace sherlock_unittest;
 
   const std::string persistence_file_name = current::FileSystem::JoinPath(FLAGS_sherlock_test_tmpdir, "data");

--- a/Sherlock/test.cc
+++ b/Sherlock/test.cc
@@ -26,6 +26,7 @@ SOFTWARE.
 #define CURRENT_MOCK_TIME
 
 #include "sherlock.h"
+#include "replicator.h"
 
 #include <string>
 #include <atomic>
@@ -763,6 +764,12 @@ const std::string sherlock_golden_data =
     "{\"index\":1,\"us\":200}\t{\"x\":2}\n"
     "{\"index\":2,\"us\":300}\t{\"x\":3}\n";
 
+const std::string sherlock_golden_data_chunks[] = {
+    "{\"index\":0,\"u",
+    "s\":100}\t{\"x\":1}\r",
+    "\n{\"index\":1,\"us\":200}\t{\"x\":2}\n\r\n{\"index\":2,\"us\":300}\t{\"x",
+    "\":3}\n"};
+
 TEST(Sherlock, PersistsToFile) {
   current::time::ResetToZero();
 
@@ -836,6 +843,62 @@ TEST(Sherlock, ParsesFromFile) {
   EXPECT_TRUE(
       CompareValuesMixedWithTerminate(d.results_, expected_values, SherlockTestProcessor::kTerminateStr))
       << d.results_;
+}
+
+TEST(Sherlock, ParseArbitrarilySplittedChunks) {
+  using namespace sherlock_unittest;
+
+  const std::string persistence_file_name = current::FileSystem::JoinPath(FLAGS_sherlock_test_tmpdir, "data");
+  const auto persistence_file_remover = current::FileSystem::ScopedRmFile(persistence_file_name);
+
+  using sherlock_t = current::sherlock::Stream<Record, current::persistence::File>;
+  using RemoteStreamReplicator = current::sherlock::StreamReplicator<sherlock_t>;
+  sherlock_t replicated_stream(persistence_file_name);
+
+  // Simulate subscription to sherlock stream.
+  const auto scope =
+      HTTP(FLAGS_sherlock_http_test_port)
+          .Register(
+              "/log",
+              URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
+              [](Request r) {
+                EXPECT_EQ("GET", r.method);
+                const std::string subscription_id = "fake_subscription";
+                if (r.url.query.has("terminate")) {
+                  EXPECT_EQ(r.url.query["terminate"], subscription_id);
+                } else if (r.url.query.has("i")) {
+                  EXPECT_EQ("0", r.url.query["i"]);
+                  auto response = r.connection.SendChunkedHTTPResponse(
+                      HTTPResponseCode.OK,
+                      "text/plain",
+                      current::net::http::Headers({{"X-Current-Stream-Subscription-Id", subscription_id}}));
+                  for (const auto& chunk : sherlock_golden_data_chunks) {
+                    response.Send(chunk);
+                  }
+                } else {
+                  EXPECT_EQ(1u, r.url_path_args.size());
+                  EXPECT_EQ("schema.simple", r.url_path_args[0]);
+                  r(current::sherlock::SubscribableSherlockSchema(
+                      Value<current::reflection::ReflectedTypeBase>(
+                          current::reflection::Reflector().ReflectType<Record>()).type_id,
+                      "Record",
+                      "Namespace"));
+                }
+              });
+
+  // Replicate data via subscription to the fake stream.
+  current::sherlock::SubscribableRemoteStream<Record> remote_stream(
+      Printf("http://localhost:%d/log", FLAGS_sherlock_http_test_port), "Record", "Namespace");
+  auto replicator = std::make_unique<RemoteStreamReplicator>(replicated_stream);
+
+  {
+    const auto subscriber_scope = remote_stream.Subscribe(*replicator);
+    while (replicated_stream.InternalExposePersister().Size() < 3u) {
+      std::this_thread::yield();
+    }
+  }
+
+  EXPECT_EQ(sherlock_golden_data, current::FileSystem::ReadFileAsString(persistence_file_name));
 }
 
 TEST(Sherlock, SubscribeWithFilterByType) {


### PR DESCRIPTION
CC @dkorolev @mzhurovich 