### PR TITLE
RipCurrent Tweaks.

### DIFF
--- a/Bricks/rtti/dispatcher.h
+++ b/Bricks/rtti/dispatcher.h
@@ -37,7 +37,7 @@ namespace rtti {
 template <typename BASE, typename DERIVED, typename... TAIL>
 struct RuntimeDispatcher {
   typedef BASE base_t;
-  typedef DERIVED deriver_t;
+  typedef DERIVED derived_t;
   template <typename T, typename PROCESSOR>
   static void DispatchCall(const T &x, PROCESSOR &c) {
     if (const DERIVED *d = dynamic_cast<const DERIVED *>(&x)) {
@@ -59,7 +59,7 @@ struct RuntimeDispatcher {
 template <typename BASE, typename DERIVED>
 struct RuntimeDispatcher<BASE, DERIVED> {
   typedef BASE base_t;
-  typedef DERIVED deriver_t;
+  typedef DERIVED derived_t;
   template <typename T, typename PROCESSOR>
   static void DispatchCall(const T &x, PROCESSOR &c) {
     if (const DERIVED *d = dynamic_cast<const DERIVED *>(&x)) {
@@ -93,6 +93,29 @@ struct RuntimeTypeListDispatcher;
 
 template <typename BASE, typename... TYPES>
 struct RuntimeTypeListDispatcher<BASE, TypeListImpl<TYPES...>> : RuntimeDispatcher<BASE, TYPES...> {};
+
+template <typename BASE>
+struct RuntimeTypeListDispatcher<BASE, TypeListImpl<>> {
+  typedef BASE base_t;
+  template <typename T, typename PROCESSOR>
+  static void DispatchCall(const T &x, PROCESSOR &c) {
+    const BASE *b = dynamic_cast<const BASE *>(&x);
+    if (b) {
+      c(*b);
+    } else {
+      CURRENT_THROW(UnrecognizedPolymorphicType());
+    }
+  }
+  template <typename T, typename PROCESSOR>
+  static void DispatchCall(T &x, PROCESSOR &c) {
+    BASE *b = dynamic_cast<BASE *>(&x);
+    if (b) {
+      c(*b);
+    } else {
+      CURRENT_THROW(UnrecognizedPolymorphicType());
+    }
+  }
+};
 
 }  // namespace current::rtti
 }  // namespace current

--- a/Bricks/rtti/test.cc
+++ b/Bricks/rtti/test.cc
@@ -229,6 +229,8 @@ TEST(RuntimeDispatcher, ImmutableWithTypeListTypeListDispatching) {
   const OtherBase& rother = other;
   RTTITestProcessor p;
   EXPECT_EQ("", p.s);
+  current::rtti::RuntimeTypeListDispatcher<Base, TypeListImpl<>>::DispatchCall(rbase, p);
+  EXPECT_EQ("const Base&", p.s);
   current::rtti::RuntimeTypeListDispatcher<Base, TypeListImpl<Foo, Bar, Baz>>::DispatchCall(rbase, p);
   EXPECT_EQ("const Base&", p.s);
   current::rtti::RuntimeTypeListDispatcher<Base, TypeListImpl<Foo, Bar, Baz>>::DispatchCall(rfoo, p);
@@ -255,6 +257,8 @@ TEST(RuntimeDispatcher, MutableWithTypeListTypeListDispatching) {
   OtherBase& rother = other;
   RTTITestProcessor p;
   EXPECT_EQ("", p.s);
+  current::rtti::RuntimeTypeListDispatcher<Base, TypeListImpl<>>::DispatchCall(rbase, p);
+  EXPECT_EQ("Base&", p.s);
   current::rtti::RuntimeTypeListDispatcher<Base, TypeListImpl<Foo, Bar, Baz>>::DispatchCall(rbase, p);
   EXPECT_EQ("Base&", p.s);
   current::rtti::RuntimeTypeListDispatcher<Base, TypeListImpl<Foo, Bar, Baz>>::DispatchCall(rfoo, p);

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -84,7 +84,6 @@ RIPCURRENT_NODE(RCBaz, ripcurrent::LHS<Integer>, ripcurrent::RHS<>) {
 }  // namespace ripcurrent_unittest
 
 // clang-format on
-
 TEST(RipCurrent, SingleEdgeFlow) {
   using namespace ripcurrent_unittest;
 
@@ -415,8 +414,10 @@ RIPCURRENT_NODE(RCFoo2, ripcurrent::LHS<>, RHS_Integer_String) {
 #define RCFoo2(...) RIPCURRENT_MACRO(RCFoo2, __VA_ARGS__)
 
 RIPCURRENT_NODE(RCBar2, LHS_Integer_String, RHS_Integer_String) {
+  const int k;
+  RCBar2(int k = 101) : k(k) {}
   void f(Integer x) {
-    emit(Integer(x.value * 1001001));
+    emit(Integer(x.value * k));
   }
   void f(String x) {
     emit(String("Yo? " + x.value + " Yo!"));
@@ -456,15 +457,18 @@ TEST(RipCurrent, CustomTypesFlow) {
   {
     std::vector<std::string> result;
     (RCFoo2() | RCBaz2(std::ref(result))).RipCurrent().Sync();
-    EXPECT_EQ("'Answer',42", Join(result, ','));
+    EXPECT_EQ("'Answer', 42", Join(result, ", "));
   }
 
-#if 0
-// TODO(dkorolev): Make this work.
   {
     std::vector<std::string> result;
     (RCFoo2() | RCBar2() | RCBaz2(std::ref(result))).RipCurrent().Sync();
-    EXPECT_EQ("'Yo? Answer Yo!',424242", Join(result, ','));
+    EXPECT_EQ("'Yo? Answer Yo!', 4242", Join(result, ", "));
   }
-#endif
+
+  {
+    std::vector<std::string> result;
+    (RCFoo2() | RCBar2() | RCBar2(10001) | RCBaz2(std::ref(result))).RipCurrent().Sync();
+    EXPECT_EQ("'Yo? Yo? Answer Yo! Yo!', 42424242", Join(result, ", "));
+  }
 }


### PR DESCRIPTION
Baby steps -- object ownership is still an open conversation, but the functionality converges.

Refactored the "initialize that field of the other class before it's being initialized" part into a singleton, looks safer and cleaner now.