### PR TITLE
Integers are Doubles too.

### DIFF
--- a/TypeSystem/Serialization/json/primitives.h
+++ b/TypeSystem/Serialization/json/primitives.h
@@ -100,9 +100,9 @@ struct DeserializeImpl<json::JSONParser<JSON_FORMAT>,
 template <class JSON_FORMAT>
 struct DeserializeImpl<json::JSONParser<JSON_FORMAT>, float> {
   static void DoDeserialize(json::JSONParser<JSON_FORMAT>& json_parser, float& destination) {
-    if (json_parser && json_parser.Current().IsDouble()) {
+    if (json_parser && json_parser.Current().IsNumber()) {
       destination = static_cast<float>(json_parser.Current().GetDouble());
-    } else if (!json::JSONPatchMode<JSON_FORMAT>::value || (json_parser && !(json_parser.Current().IsDouble()))) {
+    } else if (!json::JSONPatchMode<JSON_FORMAT>::value || (json_parser && !(json_parser.Current().IsNumber()))) {
       throw JSONSchemaException("float", json_parser);  // LCOV_EXCL_LINE
     }
   }
@@ -112,9 +112,9 @@ struct DeserializeImpl<json::JSONParser<JSON_FORMAT>, float> {
 template <class JSON_FORMAT>
 struct DeserializeImpl<json::JSONParser<JSON_FORMAT>, double> {
   static void DoDeserialize(json::JSONParser<JSON_FORMAT>& json_parser, double& destination) {
-    if (json_parser && json_parser.Current().IsDouble()) {
+    if (json_parser && json_parser.Current().IsNumber()) {
       destination = json_parser.Current().GetDouble();
-    } else if (!json::JSONPatchMode<JSON_FORMAT>::value || (json_parser && !json_parser.Current().IsDouble())) {
+    } else if (!json::JSONPatchMode<JSON_FORMAT>::value || (json_parser && !json_parser.Current().IsNumber())) {
       throw JSONSchemaException("double", json_parser);  // LCOV_EXCL_LINE
     }
   }

--- a/TypeSystem/Serialization/test.cc
+++ b/TypeSystem/Serialization/test.cc
@@ -60,6 +60,14 @@ CURRENT_STRUCT(Serializable) {
   bool operator<(const Serializable& rhs) const { return i < rhs.i; }
 };
 
+CURRENT_STRUCT(Int) {
+  CURRENT_FIELD(x, int32_t, 0);
+};
+
+CURRENT_STRUCT(Double) {
+  CURRENT_FIELD(x, double, 0);
+};
+
 CURRENT_STRUCT(ComplexSerializable) {
   CURRENT_FIELD(j, uint64_t);
   CURRENT_FIELD(q, std::string);
@@ -1193,6 +1201,14 @@ TEST(Serialization, PatchObjectWithJSON) {
 
   PatchObjectWithJSON(s, "{\"c\":null}");
   EXPECT_FALSE(Exists(s.c));
+}
+
+TEST(Serialization, IntegerZeroIsADouble) {
+  using namespace serialization_test;
+
+  EXPECT_EQ("{\"x\":0}", JSON(Int()));
+  EXPECT_EQ("{\"x\":0.0}", JSON(Double()));
+  EXPECT_EQ(0, ParseJSON<Double>(JSON(Int())).x);
 }
 
 #endif  // CURRENT_TYPE_SYSTEM_SERIALIZATION_TEST_CC


### PR DESCRIPTION
The fix for:
```

{"success":false,"message":null,"error":{"name":"ParseJSONError","message":"Invalid JSON in request body.","details":{"error_details":"Expected double for `avg_blah_blah`, got: 0"}}}

```
