### PR TITLE
RipCurrent syntactic sugar tweaks.

### DIFF
--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -722,14 +722,14 @@ using E2E = SharedCurrent<LHSTypes<>, RHSTypes<>>;
 }  // namespace current
 
 // Macros to wrap user code into RipCurrent building blocks.
-#define RIPCURRENT_NODE(USER_CLASS, LHS_TYPELIST, RHS_TYPELIST)                                                  \
-  struct USER_CLASS##_RIPCURRENT_CLASS_NAME {                                                                    \
-    static const char* RIPCURRENT_CLASS_NAME() { return #USER_CLASS; }                                           \
-  };                                                                                                             \
-  struct USER_CLASS final                                                                                        \
-      : USER_CLASS##_RIPCURRENT_CLASS_NAME,                                                                      \
-        ::current::ripcurrent::UserClassBase<::current::ripcurrent::VoidOrLHS<REMOVE_PARENTHESES(LHS_TYPELIST)>, \
-                                             ::current::ripcurrent::VoidOrRHS<REMOVE_PARENTHESES(RHS_TYPELIST)>, \
+#define RIPCURRENT_NODE(USER_CLASS, LHS_TS, RHS_TS)                                                                \
+  struct USER_CLASS##_RIPCURRENT_CLASS_NAME {                                                                      \
+    static const char* RIPCURRENT_CLASS_NAME() { return #USER_CLASS; }                                             \
+  };                                                                                                               \
+  struct USER_CLASS final                                                                                          \
+      : USER_CLASS##_RIPCURRENT_CLASS_NAME,                                                                        \
+        ::current::ripcurrent::UserClassBase<::current::ripcurrent::VoidOrLHS<CURRENT_REMOVE_PARENTHESES(LHS_TS)>, \
+                                             ::current::ripcurrent::VoidOrRHS<CURRENT_REMOVE_PARENTHESES(RHS_TS)>, \
                                              USER_CLASS>
 
 #define RIPCURRENT_MACRO(USER_CLASS, ...)                                                                    \

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -549,7 +549,7 @@ class UserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER
             NextHandlerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
             std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>>>(std::forward<ARGS_AS_TUPLE>(params))) {}
 
-  class Instance : public InstanceBeingRun<input_t, output_t> {
+  class Instance final : public InstanceBeingRun<input_t, output_t> {
    public:
     virtual ~Instance() = default;
 
@@ -635,7 +635,7 @@ class SharedSequenceImpl<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, VIAType
     into.MarkAs(BlockUsageBit::UsedInLargerBlock);
   }
 
-  class Instance : public InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
+  class Instance final : public InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
    public:
     virtual ~Instance() = default;
 
@@ -672,15 +672,14 @@ class SharedSequenceImpl<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, VIAType
 template <class LHS_TYPELIST, class RHS_TYPELIST, class VIA_TYPELIST>
 class SharedSequence;
 
-template <class LHS_TYPELIST, class RHS_TYPELIST, typename VIA_X, typename... VIA_XS>
-class SharedSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>
+template <class LHS_TYPELIST, class RHS_TYPELIST, typename... VIA_XS>
+class SharedSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_XS...>>
     : public SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> {
  public:
   using base_t = SharedCurrent<LHS_TYPELIST, RHS_TYPELIST>;
-  SharedSequence(SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>> from,
-                 SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST> into)
-      : base_t(
-            std::make_shared<SharedSequenceImpl<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>>(from, into)) {}
+  SharedSequence(SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_XS...>> from,
+                 SharedCurrent<LHSTypes<VIA_XS...>, RHS_TYPELIST> into)
+      : base_t(std::make_shared<SharedSequenceImpl<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_XS...>>>(from, into)){};
 };
 
 // SharedCurrent sequence combiner, `A | B`.

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -226,18 +226,18 @@ class UniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> final : p
   BlockUsageBitMask mask_ = BlockUsageBitMask::Unused;
 };
 
-// `SharedUniqueDefinition` is a helper class for an `std::shared_ptr<UniqueDefinition>`.
+// `SharedDefinition` is a helper class for an `std::shared_ptr<UniqueDefinition>`.
 // The premise is that building blocks that should be used or run can be liberally copied over,
 // with the test that they have been used or run performed at the very end of their lifetime.
 template <class LHS_TYPELIST, class RHS_TYPELIST>
-class SharedUniqueDefinition;
+class SharedDefinition;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES>
-class SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
+class SharedDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
   using impl_t = UniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>;
 
-  SharedUniqueDefinition(Definition definition) : unique_definition_(std::make_shared<impl_t>(definition)) {}
+  SharedDefinition(Definition definition) : unique_definition_(std::make_shared<impl_t>(definition)) {}
   void MarkAs(BlockUsageBit bit) const { unique_definition_->MarkAs(bit); }
 
   // User-facing methods.
@@ -274,7 +274,7 @@ class SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
   void Dismiss() const { MarkAs(BlockUsageBit::Dismissed); }
 
   // For expressive initialized lists of shared instances.
-  const SharedUniqueDefinition& GetUniqueDefinition() const { return *this; }
+  const SharedDefinition& GetUniqueDefinition() const { return *this; }
   const UniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>& GetDefinition() const {
     return *unique_definition_.get();
   }
@@ -345,14 +345,14 @@ class AbstractCurrent;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES>
 class AbstractCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
-    : public SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
+    : public SharedDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
   struct Traits final {
     using input_t = LHSTypes<LHS_TYPES...>;
     using output_t = RHSTypes<RHS_TYPES...>;
   };
 
-  using definition_t = SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>;
+  using definition_t = SharedDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>;
 
   explicit AbstractCurrent(definition_t definition) : definition_t(definition) {}
   virtual ~AbstractCurrent() = default;

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -295,7 +295,8 @@ class EntriesConsumer;
 template <class... LHS_XS>
 class EntriesConsumer<LHSTypes<LHS_XS...>> : public GenericEntriesConsumer {};
 
-class NoEntryShallPassFakeConsumer final : public EntriesConsumer<LHSTypes<>> {
+template <>
+class EntriesConsumer<LHSTypes<>> : public GenericEntriesConsumer {
  public:
   void ConsumeEntry(const CurrentSuper&) override {
     std::cerr << "Not expecting any entries to be sent to a non-consuming \"consumer\".\n";
@@ -384,7 +385,7 @@ class SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
   // User-facing `RipCurrent()` method.
   template <int IN_N = sizeof...(LHS_TYPES), int OUT_N = sizeof...(RHS_TYPES)>
   std::enable_if_t<IN_N == 0 && OUT_N == 0, RipCurrentRunContext> RipCurrent() {
-    SpawnAndRun(std::make_shared<NoEntryShallPassFakeConsumer>());
+    SpawnAndRun(std::make_shared<EntriesConsumer<LHSTypes<>>>());
 
     // TODO(dkorolev): Return proper run context. So far, just require `.Sync()` to be called on it.
     std::ostringstream os;

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -70,29 +70,29 @@ namespace current {
 namespace ripcurrent {
 
 template <typename... TS>
-class LHS;
+class LHSTypes;
 
 template <typename... TS>
-class RHS;
+class RHSTypes;
 
 template <typename... TS>
 struct VoidOrLHSImpl {
-  using type = LHS<TS...>;
+  using type = LHSTypes<TS...>;
 };
 
 template <typename... TS>
 struct VoidOrRHSImpl {
-  using type = RHS<TS...>;
+  using type = RHSTypes<TS...>;
 };
 
 template <>
 struct VoidOrLHSImpl<void> {
-  using type = LHS<>;
+  using type = LHSTypes<>;
 };
 
 template <>
 struct VoidOrRHSImpl<void> {
-  using type = RHS<>;
+  using type = RHSTypes<>;
 };
 
 template <typename... TS>
@@ -102,7 +102,7 @@ template <typename... TS>
 using VoidOrRHS = typename VoidOrRHSImpl<TS...>::type;
 
 template <typename... TS>
-class VIA;
+class VIATypes;
 
 // A singleton wrapping error handling logic, to allow mocking for the unit test.
 class RipCurrentMockableErrorHandler {
@@ -174,7 +174,7 @@ struct Definition {
 };
 
 // `UniqueDefinition` is a `Definition` that:
-// * Templated with `LHS<...>` and `RHS<...>` for strict typing.
+// * Templated with `LHSTypes<...>` and `RHSTypes<...>` for strict typing.
 // * Exposes user-friendly decorators.
 // * Can be marked as used in various ways.
 // * Generates an error upon destructing if it was not marked as used in at least one way.
@@ -185,7 +185,7 @@ template <class LHS_TYPELIST, class RHS_TYPELIST>
 class UniqueDefinition;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES>
-class UniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> final : public Definition {
+class UniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> final : public Definition {
  public:
   // Can be created.
   explicit UniqueDefinition(Definition definition) : Definition(definition) {}
@@ -233,9 +233,9 @@ template <class LHS_TYPELIST, class RHS_TYPELIST>
 class SharedUniqueDefinition;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES>
-class SharedUniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
+class SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
-  using impl_t = UniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>;
+  using impl_t = UniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>;
 
   SharedUniqueDefinition(Definition definition) : unique_definition_(std::make_shared<impl_t>(definition)) {}
   void MarkAs(BlockUsageBit bit) const { unique_definition_->MarkAs(bit); }
@@ -275,7 +275,7 @@ class SharedUniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
 
   // For expressive initialized lists of shared instances.
   const SharedUniqueDefinition& GetUniqueDefinition() const { return *this; }
-  const UniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>& GetDefinition() const {
+  const UniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>& GetDefinition() const {
     return *unique_definition_.get();
   }
 
@@ -293,9 +293,9 @@ template <class LHS_TYPELIST>
 class EntriesConsumer;
 
 template <class... LHS_XS>
-class EntriesConsumer<LHS<LHS_XS...>> : public GenericEntriesConsumer {};
+class EntriesConsumer<LHSTypes<LHS_XS...>> : public GenericEntriesConsumer {};
 
-class NoEntryShallPassFakeConsumer final : public EntriesConsumer<LHS<>> {
+class NoEntryShallPassFakeConsumer final : public EntriesConsumer<LHSTypes<>> {
  public:
   void ConsumeEntry(const CurrentSuper&) override {
     std::cerr << "Not expecting any entries to be sent to a non-consuming \"consumer\".\n";
@@ -332,7 +332,8 @@ template <class LHS_TYPELIST, class RHS_TYPELIST>
 class InstanceBeingRun;
 
 template <class... LHS_TYPES, class... RHS_TYPES>
-class InstanceBeingRun<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> : public EntriesConsumer<LHS<LHS_TYPES...>> {
+class InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
+    : public EntriesConsumer<LHSTypes<LHS_TYPES...>> {
  public:
   virtual ~InstanceBeingRun() = default;
 };
@@ -342,20 +343,20 @@ template <class LHS_TYPELIST, class RHS_TYPELIST>
 class AbstractCurrent;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES>
-class AbstractCurrent<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>
-    : public SharedUniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
+class AbstractCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
+    : public SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
   struct Traits final {
-    using input_t = LHS<LHS_TYPES...>;
-    using output_t = RHS<RHS_TYPES...>;
+    using input_t = LHSTypes<LHS_TYPES...>;
+    using output_t = RHSTypes<RHS_TYPES...>;
   };
 
-  using definition_t = SharedUniqueDefinition<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>;
+  using definition_t = SharedUniqueDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>;
 
   explicit AbstractCurrent(definition_t definition) : definition_t(definition) {}
   virtual ~AbstractCurrent() = default;
-  virtual std::shared_ptr<InstanceBeingRun<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>> SpawnAndRun(
-      std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>>) const = 0;
+  virtual std::shared_ptr<InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>> SpawnAndRun(
+      std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>>) const = 0;
 
   Traits UnderlyingType() const;  // Never called, used from `decltype()`.
 };
@@ -365,18 +366,18 @@ template <class LHS_TYPELIST, class RHS_TYPELIST>
 class SharedCurrent;
 
 template <class... LHS_TYPES, class... RHS_TYPES>
-class SharedCurrent<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>
-    : public AbstractCurrent<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
+class SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
+    : public AbstractCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
-  using input_t = LHS<LHS_TYPES...>;
-  using output_t = RHS<RHS_TYPES...>;
+  using input_t = LHSTypes<LHS_TYPES...>;
+  using output_t = RHSTypes<RHS_TYPES...>;
   using super_t = AbstractCurrent<input_t, output_t>;
 
   explicit SharedCurrent(std::shared_ptr<super_t> spawner)
       : super_t(spawner->GetUniqueDefinition()), shared_impl_spawner_(spawner) {}
 
-  std::shared_ptr<InstanceBeingRun<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>> SpawnAndRun(
-      std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next) const override {
+  std::shared_ptr<InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>> SpawnAndRun(
+      std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next) const override {
     return shared_impl_spawner_->SpawnAndRun(next);
   }
 
@@ -459,7 +460,7 @@ template <class LHS_TYPELIST>
 class NextHandlerContainer;
 
 template <class... NEXT_TYPES>
-class NextHandlerContainer<LHS<NEXT_TYPES...>> : public NextHandlerContainerBase {
+class NextHandlerContainer<LHSTypes<NEXT_TYPES...>> : public NextHandlerContainerBase {
  public:
   NextHandlerContainer() : next_handler_(Singleton<NextHandlersCollection>().template Get<next_handler_t>(this)) {}
   virtual ~NextHandlerContainer() = default;
@@ -471,18 +472,18 @@ class NextHandlerContainer<LHS<NEXT_TYPES...>> : public NextHandlerContainerBase
   }
 
  private:
-  using next_handler_t = EntriesConsumer<LHS<NEXT_TYPES...>>;
-  EntriesConsumer<LHS<NEXT_TYPES...>>* const next_handler_;
+  using next_handler_t = EntriesConsumer<LHSTypes<NEXT_TYPES...>>;
+  EntriesConsumer<LHSTypes<NEXT_TYPES...>>* const next_handler_;
 };
 
 template <typename LHS_TYPELIST, typename RHS_TYPELIST, typename USER_CLASS>
 class NextHandlerInitializer;
 
 template <class... LHS_TYPES, class... RHS_TYPES, typename USER_CLASS>
-class NextHandlerInitializer<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS> final {
+class NextHandlerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> final {
  public:
   template <typename... ARGS>
-  NextHandlerInitializer(std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next, ARGS&&... args)
+  NextHandlerInitializer(std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next, ARGS&&... args)
       : scope_(&impl_, next.get()), impl_(std::forward<ARGS>(args)...) {}
 
   template <typename X>
@@ -510,19 +511,19 @@ template <class LHS_TYPELIST, class RHS_TYPELIST>
 class UserClassTopLevelBase;
 
 template <class... LHS_TYPES, class... RHS_TYPES>
-class UserClassTopLevelBase<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {};
+class UserClassTopLevelBase<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {};
 
 template <class LHS_TYPELIST, class RHS_TYPELIST, typename USER_CLASS>
 class UserClassBase;
 
 template <class... LHS_TYPES, class... RHS_TYPES, typename USER_CLASS>
-class UserClassBase<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>
-    : public UserClassTopLevelBase<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>,
-      public NextHandlerContainer<LHS<RHS_TYPES...>> {
+class UserClassBase<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>
+    : public UserClassTopLevelBase<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>,
+      public NextHandlerContainer<LHSTypes<RHS_TYPES...>> {
  public:
   virtual ~UserClassBase() = default;
-  using input_t = LHS<LHS_TYPES...>;
-  using output_t = RHS<RHS_TYPES...>;
+  using input_t = LHSTypes<LHS_TYPES...>;
+  using output_t = RHSTypes<RHS_TYPES...>;
 };
 
 // Helper code to support the declaration and running of user-defined classes.
@@ -530,48 +531,49 @@ template <class LHS_TYPELIST, class RHS_TYPELIST, typename USER_CLASS>
 class UserClassInstantiator;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES, typename USER_CLASS>
-class UserClassInstantiator<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>
-    : public AbstractCurrent<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
+class UserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>
+    : public AbstractCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
-  static_assert(std::is_base_of<UserClassTopLevelBase<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>, USER_CLASS>::value,
-                "User class for RipCurrent data processor should use `RIPCURRENT_NODE()` + `RIPCURRENT_MACRO()`.");
+  static_assert(
+      std::is_base_of<UserClassTopLevelBase<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>, USER_CLASS>::value,
+      "User class for RipCurrent data processor should use `RIPCURRENT_NODE()` + `RIPCURRENT_MACRO()`.");
 
-  using input_t = LHS<LHS_TYPES...>;
-  using output_t = RHS<RHS_TYPES...>;
+  using input_t = LHSTypes<LHS_TYPES...>;
+  using output_t = RHSTypes<RHS_TYPES...>;
 
   template <class ARGS_AS_TUPLE>
   UserClassInstantiator(Definition definition, ARGS_AS_TUPLE&& params)
       : AbstractCurrent<input_t, output_t>(definition),
         lazy_instance_(current::DelayedInstantiateWithExtraParameterFromTuple<
-            NextHandlerInitializer<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>,
-            std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>>>(std::forward<ARGS_AS_TUPLE>(params))) {}
+            NextHandlerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
+            std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>>>(std::forward<ARGS_AS_TUPLE>(params))) {}
 
   class Instance : public InstanceBeingRun<input_t, output_t> {
    public:
     virtual ~Instance() = default;
 
-    explicit Instance(
-        const current::LazilyInstantiated<NextHandlerInitializer<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>,
-                                          std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>>>& lazy_instance,
-        std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next)
+    explicit Instance(const current::LazilyInstantiated<
+                          NextHandlerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
+                          std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>>>& lazy_instance,
+                      std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next)
         : next_(next), spawned_user_class_instance_(lazy_instance.InstantiateAsUniquePtrWithExtraParameter(next_)) {}
 
     void ConsumeEntry(const CurrentSuper& x) override { spawned_user_class_instance_->Accept(x); }
 
    private:
-    std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next_;
-    std::unique_ptr<NextHandlerInitializer<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>>
+    std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next_;
+    std::unique_ptr<NextHandlerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>>
         spawned_user_class_instance_;
   };
 
   std::shared_ptr<InstanceBeingRun<input_t, output_t>> SpawnAndRun(
-      std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next) const override {
+      std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next) const override {
     return std::make_shared<Instance>(lazy_instance_, next);
   }
 
  private:
-  current::LazilyInstantiated<NextHandlerInitializer<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>,
-                              std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>>> lazy_instance_;
+  current::LazilyInstantiated<NextHandlerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
+                              std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>>> lazy_instance_;
 };
 
 // `SharedUserClassInstantiator` is the `shared_ptr<>` holder of the wrapper class
@@ -583,34 +585,35 @@ template <class LHS_TYPELIST, class RHS_TYPELIST, typename USER_CLASS>
 class SharedUserClassInstantiator;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES, typename USER_CLASS>
-class SharedUserClassInstantiator<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS> {
+class SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> {
  public:
-  typedef UserClassInstantiator<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS> impl_t;
+  typedef UserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> impl_t;
   template <class ARGS_AS_TUPLE>
   SharedUserClassInstantiator(Definition definition, ARGS_AS_TUPLE&& params)
       : shared_spawner_(std::make_shared<impl_t>(definition, std::forward<ARGS_AS_TUPLE>(params))) {}
 
  private:
-  friend class UserClass<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>;
+  friend class UserClass<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>;
   std::shared_ptr<impl_t> shared_spawner_;
 };
 
-// `UserClass<LHS<...>, RHS<...>, IMPL>` initializes `SharedUserClassInstantiator<LHS<...>, RHS<...>, IMPL>`
-// before constructing the parent `SharedCurrent<LHS<...>, RHS<...>>` object, thus allowing
-// the latter to reuse the `shared_ptr<>` containing the user code constructed in the former.
+// `UserClass<LHSTypes<...>, RHSTypes<...>, IMPL>`
+// initializes `SharedUserClassInstantiator<LHSTypes<...>, RHSTypes<...>, IMPL>`
+// before constructing the parent `SharedCurrent<LHSTypes<...>, RHSTypes<...>>` object, thus
+// allowing the latter to reuse the `shared_ptr<>` containing the user code constructed in the former.
 template <class LHS_TYPELIST, class RHS_TYPELIST, typename USER_CLASS>
 class UserClass;
 
 template <typename... LHS_TYPES, typename... RHS_TYPES, typename USER_CLASS>
-class UserClass<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>
-    : public SharedUserClassInstantiator<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS>,
-      public SharedCurrent<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
+class UserClass<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>
+    : public SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
+      public SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
-  typedef SharedUserClassInstantiator<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, USER_CLASS> impl_t;
+  typedef SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> impl_t;
   template <class ARGS_AS_TUPLE>
   UserClass(Definition definition, ARGS_AS_TUPLE&& params)
       : impl_t(definition, std::forward<ARGS_AS_TUPLE>(params)),
-        SharedCurrent<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>(impl_t::shared_spawner_) {}
+        SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>(impl_t::shared_spawner_) {}
 
   // For the `RIPCURRENT_UNDERLYING_TYPE` macro to be able to extract the underlying user-defined type.
   USER_CLASS UnderlyingType() const;
@@ -621,11 +624,11 @@ template <class LHS_TYPELIST, class RHS_TYPELIST, class VIA_TYPELIST>
 class AbstractCurrentSequence;
 
 template <typename LHS_TYPELIST, typename RHS_TYPELIST, typename VIA_X, typename... VIA_XS>
-class AbstractCurrentSequence<LHS_TYPELIST, RHS_TYPELIST, VIA<VIA_X, VIA_XS...>>
+class AbstractCurrentSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>
     : public AbstractCurrent<LHS_TYPELIST, RHS_TYPELIST> {
  public:
-  AbstractCurrentSequence(SharedCurrent<LHS_TYPELIST, RHS<VIA_X, VIA_XS...>> from,
-                          SharedCurrent<LHS<VIA_X, VIA_XS...>, RHS_TYPELIST> into)
+  AbstractCurrentSequence(SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>> from,
+                          SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST> into)
       : AbstractCurrent<LHS_TYPELIST, RHS_TYPELIST>(
             Definition(Definition::Pipe(), from.GetDefinition(), into.GetDefinition())),
         from_(from),
@@ -635,30 +638,31 @@ class AbstractCurrentSequence<LHS_TYPELIST, RHS_TYPELIST, VIA<VIA_X, VIA_XS...>>
   }
 
  protected:
-  const SharedCurrent<LHS_TYPELIST, RHS<VIA_X, VIA_XS...>>& From() const { return from_; }
-  const SharedCurrent<LHS<VIA_X, VIA_XS...>, RHS_TYPELIST>& Into() const { return into_; }
+  const SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>>& From() const { return from_; }
+  const SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST>& Into() const { return into_; }
 
  private:
-  SharedCurrent<LHS_TYPELIST, RHS<VIA_X, VIA_XS...>> from_;
-  SharedCurrent<LHS<VIA_X, VIA_XS...>, RHS_TYPELIST> into_;
+  SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>> from_;
+  SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST> into_;
 };
 
 template <class LHS_TYPELIST, class RHS_TYPELIST, class VIA_TYPELIST>
 class GenericCurrentSequence;
 
 template <class... LHS_TYPES, class... RHS_TYPES, typename VIA_X, typename... VIA_XS>
-class GenericCurrentSequence<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, VIA<VIA_X, VIA_XS...>>
-    : public AbstractCurrentSequence<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, VIA<VIA_X, VIA_XS...>> {
+class GenericCurrentSequence<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, VIATypes<VIA_X, VIA_XS...>>
+    : public AbstractCurrentSequence<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, VIATypes<VIA_X, VIA_XS...>> {
  public:
-  GenericCurrentSequence(SharedCurrent<LHS<LHS_TYPES...>, RHS<VIA_X, VIA_XS...>> from,
-                         SharedCurrent<LHS<VIA_X, VIA_XS...>, RHS<RHS_TYPES...>> into)
-      : AbstractCurrentSequence<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, VIA<VIA_X, VIA_XS...>>(from, into) {}
+  GenericCurrentSequence(SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<VIA_X, VIA_XS...>> from,
+                         SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHSTypes<RHS_TYPES...>> into)
+      : AbstractCurrentSequence<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, VIATypes<VIA_X, VIA_XS...>>(from,
+                                                                                                            into) {}
 
-  class Instance : public InstanceBeingRun<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>> {
+  class Instance : public InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
    public:
     virtual ~Instance() = default;
 
-    Instance(const GenericCurrentSequence* self, std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next)
+    Instance(const GenericCurrentSequence* self, std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next)
         : next_(next), into_(self->Into().SpawnAndRun(next_)), from_(self->From().SpawnAndRun(into_)) {
       self->MarkAs(BlockUsageBit::Run);
     }
@@ -667,13 +671,13 @@ class GenericCurrentSequence<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>, VIA<VIA_X, VI
 
    private:
     // Construction / destruction order matters: { next, into, from }.
-    std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next_;
-    std::shared_ptr<InstanceBeingRun<LHS<VIA_X, VIA_XS...>, RHS<RHS_TYPES...>>> into_;
-    std::shared_ptr<InstanceBeingRun<LHS<LHS_TYPES...>, RHS<VIA_X, VIA_XS...>>> from_;
+    std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next_;
+    std::shared_ptr<InstanceBeingRun<LHSTypes<VIA_X, VIA_XS...>, RHSTypes<RHS_TYPES...>>> into_;
+    std::shared_ptr<InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<VIA_X, VIA_XS...>>> from_;
   };
 
-  std::shared_ptr<InstanceBeingRun<LHS<LHS_TYPES...>, RHS<RHS_TYPES...>>> SpawnAndRun(
-      std::shared_ptr<EntriesConsumer<LHS<RHS_TYPES...>>> next) const override {
+  std::shared_ptr<InstanceBeingRun<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>> SpawnAndRun(
+      std::shared_ptr<EntriesConsumer<LHSTypes<RHS_TYPES...>>> next) const override {
     return std::make_shared<Instance>(this, next);
   }
 };
@@ -684,36 +688,49 @@ template <class LHS_TYPELIST, class RHS_TYPELIST, class VIA_TYPELIST>
 class SubflowSequence;
 
 template <class LHS_TYPELIST, class RHS_TYPELIST, typename VIA_X, typename... VIA_XS>
-class SubflowSequence<LHS_TYPELIST, RHS_TYPELIST, VIA<VIA_X, VIA_XS...>>
+class SubflowSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>
     : public SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> {
  public:
   typedef SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> subflow_t;
-  SubflowSequence(SharedCurrent<LHS_TYPELIST, RHS<VIA_X, VIA_XS...>> from,
-                  SharedCurrent<LHS<VIA_X, VIA_XS...>, RHS_TYPELIST> into)
-      : subflow_t(
-            std::make_shared<GenericCurrentSequence<LHS_TYPELIST, RHS_TYPELIST, VIA<VIA_X, VIA_XS...>>>(from, into)) {}
+  SubflowSequence(SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>> from,
+                  SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST> into)
+      : subflow_t(std::make_shared<GenericCurrentSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>>(
+            from, into)) {}
 };
 
 // SharedCurrent sequence combiner, `A | B`.
 template <class LHS_TYPELIST, class RHS_TYPELIST, typename VIA_X, typename... VIA_XS>
-SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> operator|(SharedCurrent<LHS_TYPELIST, RHS<VIA_X, VIA_XS...>> from,
-                                                    SharedCurrent<LHS<VIA_X, VIA_XS...>, RHS_TYPELIST> into) {
-  return SubflowSequence<LHS_TYPELIST, RHS_TYPELIST, VIA<VIA_X, VIA_XS...>>(from, into);
+SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> operator|(SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>> from,
+                                                    SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST> into) {
+  return SubflowSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>(from, into);
 }
 
+// These typedef are the types the user can directly operate with.
+// All of them can be liberally copied over, since the logic is concealed within the inner `shared_ptr<>`.
+template <typename RHS_TYPELIST>
+using LHS = SharedCurrent<LHSTypes<>, RHS_TYPELIST>;
+
+template <typename LHS_TYPELIST, typename RHS_TYPELIST>
+using VIA = SharedCurrent<LHS_TYPELIST, RHS_TYPELIST>;
+
+template <typename LHS_TYPELIST>
+using RHS = SharedCurrent<LHS_TYPELIST, RHSTypes<>>;
+
+using E2E = SharedCurrent<LHSTypes<>, RHSTypes<>>;
+
 }  // namespace current::ripcurrent
+}  // namespace current
 
 // Macros to wrap user code into RipCurrent building blocks.
-
-#define RIPCURRENT_NODE(USER_CLASS, LHS_TYPELIST, RHS_TYPELIST)                                         \
-  struct USER_CLASS##_RIPCURRENT_CLASS_NAME {                                                           \
-    static const char* RIPCURRENT_CLASS_NAME() { return #USER_CLASS; }                                  \
-  };                                                                                                    \
-  struct USER_CLASS final                                                                               \
-      : USER_CLASS##_RIPCURRENT_CLASS_NAME,                                                             \
-        ::ripcurrent::UserClassBase<::current::ripcurrent::VoidOrLHS<REMOVE_PARENTHESES(LHS_TYPELIST)>, \
-                                    ::current::ripcurrent::VoidOrRHS<REMOVE_PARENTHESES(RHS_TYPELIST)>, \
-                                    USER_CLASS>
+#define RIPCURRENT_NODE(USER_CLASS, LHS_TYPELIST, RHS_TYPELIST)                                                  \
+  struct USER_CLASS##_RIPCURRENT_CLASS_NAME {                                                                    \
+    static const char* RIPCURRENT_CLASS_NAME() { return #USER_CLASS; }                                           \
+  };                                                                                                             \
+  struct USER_CLASS final                                                                                        \
+      : USER_CLASS##_RIPCURRENT_CLASS_NAME,                                                                      \
+        ::current::ripcurrent::UserClassBase<::current::ripcurrent::VoidOrLHS<REMOVE_PARENTHESES(LHS_TYPELIST)>, \
+                                             ::current::ripcurrent::VoidOrRHS<REMOVE_PARENTHESES(RHS_TYPELIST)>, \
+                                             USER_CLASS>
 
 #define RIPCURRENT_MACRO(USER_CLASS, ...)                                                                    \
   ::current::ripcurrent::UserClass<typename USER_CLASS::input_t, typename USER_CLASS::output_t, USER_CLASS>( \
@@ -722,30 +739,5 @@ SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> operator|(SharedCurrent<LHS_TYPELIST, 
 
 // A helper macro to extract the underlying type of the user class, now registered as a RipCurrent block type.
 #define RIPCURRENT_UNDERLYING_TYPE(USER_CLASS) decltype(USER_CLASS.UnderlyingType())
-
-}  // namespace current
-
-// Expose `ripcurrent::{LHS,RHS}` into a global `RipCurrent` namespace.
-namespace ripcurrent {
-template <class LHS_TYPELIST, class RHS_TYPELIST, typename USER_CLASS>
-using UserClassBase = current::ripcurrent::UserClassBase<LHS_TYPELIST, RHS_TYPELIST, USER_CLASS>;
-template <typename... TS>
-using LHS = current::ripcurrent::LHS<TS...>;
-template <typename... TS>
-using RHS = current::ripcurrent::RHS<TS...>;
-}  // namespace ripcurrent
-
-// These typedef are the types the user can directly operate with.
-// All of them can be liberally copied over, since the logic is concealed within the inner `shared_ptr<>`.
-template <typename RHS_TYPELIST>
-using RipCurrentLHS = current::ripcurrent::SharedCurrent<ripcurrent::LHS<>, RHS_TYPELIST>;
-
-template <typename LHS_TYPELIST, typename RHS_TYPELIST>
-using RipCurrentVIA = current::ripcurrent::SharedCurrent<LHS_TYPELIST, RHS_TYPELIST>;
-
-template <typename LHS_TYPELIST>
-using RipCurrentRHS = current::ripcurrent::SharedCurrent<LHS_TYPELIST, ripcurrent::RHS<>>;
-
-using RipCurrent = current::ripcurrent::SharedCurrent<ripcurrent::LHS<>, ripcurrent::RHS<>>;
 
 #endif  // CURRENT_RIPCURRENT_H

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -107,7 +107,7 @@ class VIATypes;
 // A singleton wrapping error handling logic, to allow mocking for the unit test.
 class RipCurrentMockableErrorHandler {
  public:
-  typedef std::function<void(const std::string& error_message)> handler_t;
+  using handler_t = std::function<void(const std::string& error_message)>;
 
   // LCOV_EXCL_START
   RipCurrentMockableErrorHandler()
@@ -174,7 +174,7 @@ struct Definition {
 };
 
 // `UniqueDefinition` is a `Definition` that:
-// * Templated with `LHSTypes<...>` and `RHSTypes<...>` for strict typing.
+// * Is templated with `LHSTypes<...>` and `RHSTypes<...>` for strict typing.
 // * Exposes user-friendly decorators.
 // * Can be marked as used in various ways.
 // * Generates an error upon destructing if it was not marked as used in at least one way.
@@ -587,7 +587,7 @@ class SharedUserClassInstantiator;
 template <typename... LHS_TYPES, typename... RHS_TYPES, typename USER_CLASS>
 class SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> {
  public:
-  typedef UserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> impl_t;
+  using impl_t = UserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>;
   template <class ARGS_AS_TUPLE>
   SharedUserClassInstantiator(Definition definition, ARGS_AS_TUPLE&& params)
       : shared_spawner_(std::make_shared<impl_t>(definition, std::forward<ARGS_AS_TUPLE>(params))) {}
@@ -601,15 +601,12 @@ class SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>
 // initializes `SharedUserClassInstantiator<LHSTypes<...>, RHSTypes<...>, IMPL>`
 // before constructing the parent `SharedCurrent<LHSTypes<...>, RHSTypes<...>>` object, thus
 // allowing the latter to reuse the `shared_ptr<>` containing the user code constructed in the former.
-template <class LHS_TYPELIST, class RHS_TYPELIST, typename USER_CLASS>
-class UserClass;
-
 template <typename... LHS_TYPES, typename... RHS_TYPES, typename USER_CLASS>
 class UserClass<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>
     : public SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
       public SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
  public:
-  typedef SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS> impl_t;
+  using impl_t = SharedUserClassInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>;
   template <class ARGS_AS_TUPLE>
   UserClass(Definition definition, ARGS_AS_TUPLE&& params)
       : impl_t(definition, std::forward<ARGS_AS_TUPLE>(params)),
@@ -691,7 +688,7 @@ template <class LHS_TYPELIST, class RHS_TYPELIST, typename VIA_X, typename... VI
 class SubflowSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>
     : public SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> {
  public:
-  typedef SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> subflow_t;
+  using subflow_t = SharedCurrent<LHS_TYPELIST, RHS_TYPELIST>;
   SubflowSequence(SharedCurrent<LHS_TYPELIST, RHSTypes<VIA_X, VIA_XS...>> from,
                   SharedCurrent<LHSTypes<VIA_X, VIA_XS...>, RHS_TYPELIST> into)
       : subflow_t(std::make_shared<GenericCurrentSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>>(
@@ -705,7 +702,7 @@ SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> operator|(SharedCurrent<LHS_TYPELIST, 
   return SubflowSequence<LHS_TYPELIST, RHS_TYPELIST, VIATypes<VIA_X, VIA_XS...>>(from, into);
 }
 
-// These typedef are the types the user can directly operate with.
+// These `using`-s are the types the user can directly operate with.
 // All of them can be liberally copied over, since the logic is concealed within the inner `shared_ptr<>`.
 template <typename RHS_TYPELIST>
 using LHS = SharedCurrent<LHSTypes<>, RHS_TYPELIST>;

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -58,6 +58,7 @@ SOFTWARE.
 #include <vector>
 
 #include "../TypeSystem/struct.h"
+#include "../TypeSystem/remove_parentheses.h"
 
 #include "../Bricks/rtti/dispatcher.h"
 #include "../Bricks/strings/join.h"
@@ -678,12 +679,14 @@ SharedCurrent<LHS_TYPELIST, RHS_TYPELIST> operator|(SharedCurrent<LHS_TYPELIST, 
 
 // Macros to wrap user code into RipCurrent building blocks.
 
-#define RIPCURRENT_NODE(USER_CLASS, LHS_TYPELIST, RHS_TYPELIST)        \
-  struct USER_CLASS##_RIPCURRENT_CLASS_NAME {                          \
-    static const char* RIPCURRENT_CLASS_NAME() { return #USER_CLASS; } \
-  };                                                                   \
-  struct USER_CLASS final : USER_CLASS##_RIPCURRENT_CLASS_NAME,        \
-                            ::ripcurrent::UserClassBase<LHS_TYPELIST, RHS_TYPELIST, USER_CLASS>
+#define RIPCURRENT_NODE(USER_CLASS, LHS_TYPELIST, RHS_TYPELIST)                                            \
+  struct USER_CLASS##_RIPCURRENT_CLASS_NAME {                                                              \
+    static const char* RIPCURRENT_CLASS_NAME() { return #USER_CLASS; }                                     \
+  };                                                                                                       \
+  struct USER_CLASS final : USER_CLASS##_RIPCURRENT_CLASS_NAME,                                            \
+                            ::ripcurrent::UserClassBase<ripcurrent::LHS<REMOVE_PARENTHESES(LHS_TYPELIST)>, \
+                                                        ripcurrent::RHS<REMOVE_PARENTHESES(RHS_TYPELIST)>, \
+                                                        USER_CLASS>
 
 #define RIPCURRENT_MACRO(USER_CLASS, ...)                                                                    \
   ::current::ripcurrent::UserClass<typename USER_CLASS::input_t, typename USER_CLASS::output_t, USER_CLASS>( \

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -42,7 +42,7 @@ CURRENT_STRUCT(Integer) {
 };
 
 // `RCEmit`: The emitter of events. RHS the integers passed to its constructor.
-RIPCURRENT_NODE(RCEmit, (), Integer) {
+RIPCURRENT_NODE(RCEmit, void, Integer) {
   static std::string UnitTestClassName() { return "RCEmit"; }
   RCEmit() {}  // LCOV_EXCL_LINE
   RCEmit(int a) { emit(Integer(a)); }
@@ -68,7 +68,7 @@ RIPCURRENT_NODE(RCMult, Integer, Integer) {
 #define RCMult(...) RIPCURRENT_MACRO(RCMult, __VA_ARGS__)
 
 // `RCDump`: The destination of events. Collects the output integers.
-RIPCURRENT_NODE(RCDump, Integer, ()) {
+RIPCURRENT_NODE(RCDump, Integer, void) {
   static std::string UnitTestClassName() { return "RCDump"; }
   std::vector<int>* ptr;
   RCDump() : ptr(nullptr) {}  // LCOV_EXCL_LINE

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -42,7 +42,7 @@ CURRENT_STRUCT(Integer) {
 };
 
 // `RCEmit`: The emitter of events. RHS the integers passed to its constructor.
-RIPCURRENT_NODE(RCEmit, ripcurrent::LHS<>, ripcurrent::RHS<Integer>) {
+RIPCURRENT_NODE(RCEmit, (), Integer) {
   static std::string UnitTestClassName() { return "RCEmit"; }
   RCEmit() {}  // LCOV_EXCL_LINE
   RCEmit(int a) { emit(Integer(a)); }
@@ -59,7 +59,7 @@ RIPCURRENT_NODE(RCEmit, ripcurrent::LHS<>, ripcurrent::RHS<Integer>) {
 #define RCEmit(...) RIPCURRENT_MACRO(RCEmit, __VA_ARGS__)
 
 // `RCMult`: The processor of events. Multiplies each integer by what was passed to its constructor.
-RIPCURRENT_NODE(RCMult, ripcurrent::LHS<Integer>, ripcurrent::RHS<Integer>) {
+RIPCURRENT_NODE(RCMult, Integer, Integer) {
   static std::string UnitTestClassName() { return "RCMult"; }
   int k;
   RCMult(int k = 1) : k(k) {}
@@ -68,7 +68,7 @@ RIPCURRENT_NODE(RCMult, ripcurrent::LHS<Integer>, ripcurrent::RHS<Integer>) {
 #define RCMult(...) RIPCURRENT_MACRO(RCMult, __VA_ARGS__)
 
 // `RCDump`: The destination of events. Collects the output integers.
-RIPCURRENT_NODE(RCDump, ripcurrent::LHS<Integer>, ripcurrent::RHS<>) {
+RIPCURRENT_NODE(RCDump, Integer, ()) {
   static std::string UnitTestClassName() { return "RCDump"; }
   std::vector<int>* ptr;
   RCDump() : ptr(nullptr) {}  // LCOV_EXCL_LINE
@@ -391,11 +391,7 @@ CURRENT_STRUCT(String) {
   CURRENT_CONSTRUCTOR(String)(const std::string& value = "") : value(value) {}
 };
 
-// TODO(dkorolev): Parentheses fix.
-using LHS_Integer_String = ripcurrent::LHS<Integer, String>;
-using RHS_Integer_String = ripcurrent::RHS<Integer, String>;
-
-RIPCURRENT_NODE(EmitStringAndInteger, ripcurrent::LHS<>, RHS_Integer_String) {
+RIPCURRENT_NODE(EmitStringAndInteger, (), (Integer, String)) {
   EmitStringAndInteger() {
     emit(String("Answer"));
     emit(Integer(42));
@@ -403,7 +399,7 @@ RIPCURRENT_NODE(EmitStringAndInteger, ripcurrent::LHS<>, RHS_Integer_String) {
 };
 #define EmitStringAndInteger(...) RIPCURRENT_MACRO(EmitStringAndInteger, __VA_ARGS__)
 
-RIPCURRENT_NODE(MultIntegerOrString, LHS_Integer_String, RHS_Integer_String) {
+RIPCURRENT_NODE(MultIntegerOrString, (Integer, String), (Integer, String)) {
   const int k;
   MultIntegerOrString(int k = 101) : k(k) {}
   void f(Integer x) {
@@ -415,7 +411,7 @@ RIPCURRENT_NODE(MultIntegerOrString, LHS_Integer_String, RHS_Integer_String) {
 };
 #define MultIntegerOrString(...) RIPCURRENT_MACRO(MultIntegerOrString, __VA_ARGS__)
 
-RIPCURRENT_NODE(DumpIntegerAndString, LHS_Integer_String, ripcurrent::RHS<>) {
+RIPCURRENT_NODE(DumpIntegerAndString, (Integer, String), ()) {
   std::vector<std::string>* ptr;
   DumpIntegerAndString() : ptr(nullptr) {}  // LCOV_EXCL_LINE
   DumpIntegerAndString(std::vector<std::string>& ref) : ptr(&ref) {}

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -418,7 +418,7 @@ CURRENT_STRUCT(String) {
   CURRENT_CONSTRUCTOR(String)(const std::string& value = "") : value(value) {}
 };
 
-RIPCURRENT_NODE(EmitStringAndInteger, (), (Integer, String)) {
+RIPCURRENT_NODE(EmitStringAndInteger, (), (Integer, String)) {  // Note: `()` is same as `void`.
   EmitStringAndInteger() {
     emit(String("Answer"));
     emit(Integer(42));
@@ -438,7 +438,7 @@ RIPCURRENT_NODE(MultIntegerOrString, (Integer, String), (Integer, String)) {
 };
 #define MultIntegerOrString(...) RIPCURRENT_MACRO(MultIntegerOrString, __VA_ARGS__)
 
-RIPCURRENT_NODE(DumpIntegerAndString, (Integer, String), ()) {
+RIPCURRENT_NODE(DumpIntegerAndString, (Integer, String), ()) {  // Note: `()` is same as `void`.
   std::vector<std::string>* ptr;
   DumpIntegerAndString() : ptr(nullptr) {}  // LCOV_EXCL_LINE
   DumpIntegerAndString(std::vector<std::string>& ref) : ptr(&ref) {}

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -34,7 +34,6 @@ using current::strings::Join;
 // `clang-format` messes up macro-defined class definitions, so disable it temporarily for this section. -- D.K.
 
 // clang-format off
-
 namespace ripcurrent_unittest {
 
 CURRENT_STRUCT(Integer) {
@@ -42,73 +41,79 @@ CURRENT_STRUCT(Integer) {
   CURRENT_CONSTRUCTOR(Integer)(int32_t value = 0) : value(value) {}
 };
 
-// `RCFoo`: The emitter of events. RHS the integers passed to its constructor.
-RIPCURRENT_NODE(RCFoo, ripcurrent::LHS<>, ripcurrent::RHS<Integer>) {
-  static std::string UnitTestClassName() { return "RCFoo"; }
-  RCFoo() {}  // LCOV_EXCL_LINE
-  RCFoo(int a) { emit(Integer(a)); }
-  RCFoo(int a, int b) {
+// `RCEmit`: The emitter of events. RHS the integers passed to its constructor.
+RIPCURRENT_NODE(RCEmit, ripcurrent::LHS<>, ripcurrent::RHS<Integer>) {
+  static std::string UnitTestClassName() { return "RCEmit"; }
+  RCEmit() {}  // LCOV_EXCL_LINE
+  RCEmit(int a) { emit(Integer(a)); }
+  RCEmit(int a, int b) {
     emit(Integer(a));
     emit(Integer(b));
   }
-  RCFoo(int a, int b, int c) {
+  RCEmit(int a, int b, int c) {
     emit(Integer(a));
     emit(Integer(b));
     emit(Integer(c));
   }
 };
-#define RCFoo(...) RIPCURRENT_MACRO(RCFoo, __VA_ARGS__)
+#define RCEmit(...) RIPCURRENT_MACRO(RCEmit, __VA_ARGS__)
 
-// `RCBar`: The processor of events. Multiplies each integer by what was passed to its constructor.
-RIPCURRENT_NODE(RCBar, ripcurrent::LHS<Integer>, ripcurrent::RHS<Integer>) {
-  static std::string UnitTestClassName() { return "RCBar"; }
+// `RCMult`: The processor of events. Multiplies each integer by what was passed to its constructor.
+RIPCURRENT_NODE(RCMult, ripcurrent::LHS<Integer>, ripcurrent::RHS<Integer>) {
+  static std::string UnitTestClassName() { return "RCMult"; }
   int k;
-  RCBar(int k = 1) : k(k) {}
+  RCMult(int k = 1) : k(k) {}
   void f(Integer x) { emit(Integer(x.value * k)); }
 };
-#define RCBar(...) RIPCURRENT_MACRO(RCBar, __VA_ARGS__)
+#define RCMult(...) RIPCURRENT_MACRO(RCMult, __VA_ARGS__)
 
-// `RCBaz`: The destination of events. Collects the output integers.
-RIPCURRENT_NODE(RCBaz, ripcurrent::LHS<Integer>, ripcurrent::RHS<>) {
-  static std::string UnitTestClassName() { return "RCBaz"; }
+// `RCDump`: The destination of events. Collects the output integers.
+RIPCURRENT_NODE(RCDump, ripcurrent::LHS<Integer>, ripcurrent::RHS<>) {
+  static std::string UnitTestClassName() { return "RCDump"; }
   std::vector<int>* ptr;
-  RCBaz() : ptr(nullptr) {}  // LCOV_EXCL_LINE
-  RCBaz(std::vector<int>& ref) : ptr(&ref) {}
+  RCDump() : ptr(nullptr) {}  // LCOV_EXCL_LINE
+  RCDump(std::vector<int>& ref) : ptr(&ref) {}
   void f(Integer x) {
     CURRENT_ASSERT(ptr);
     ptr->push_back(x.value);
   }
 };
-#define RCBaz(...) RIPCURRENT_MACRO(RCBaz, __VA_ARGS__)
+#define RCDump(...) RIPCURRENT_MACRO(RCDump, __VA_ARGS__)
 
 }  // namespace ripcurrent_unittest
-
 // clang-format on
+
+TEST(RipCurrent, TypeStaticAsserts) {
+  using namespace ripcurrent_unittest;
+
+  std::vector<int> result;
+
+  using rcemit_t = RIPCURRENT_UNDERLYING_TYPE(RCEmit());
+  using rcdump_t = RIPCURRENT_UNDERLYING_TYPE(RCDump(std::ref(result)));
+
+  static_assert(sizeof(is_same_or_compile_error<ripcurrent::LHS<>, typename rcemit_t::input_t>), "");
+  static_assert(sizeof(is_same_or_compile_error<ripcurrent::RHS<Integer>, typename rcemit_t::output_t>), "");
+
+  static_assert(sizeof(is_same_or_compile_error<ripcurrent::LHS<Integer>, typename rcdump_t::input_t>), "");
+  static_assert(sizeof(is_same_or_compile_error<ripcurrent::RHS<>, typename rcdump_t::output_t>), "");
+
+  static_assert(sizeof(is_same_or_compile_error<
+                    decltype(RCEmit(1, 2, 3)),
+                    current::ripcurrent::UserClass<ripcurrent::LHS<>, ripcurrent::RHS<Integer>, rcemit_t>>),
+                "");
+
+  static_assert(sizeof(is_same_or_compile_error<
+                    decltype(RCDump(std::ref(result))),
+                    current::ripcurrent::UserClass<ripcurrent::LHS<Integer>, ripcurrent::RHS<>, rcdump_t>>),
+                "");
+}
+
 TEST(RipCurrent, SingleEdgeFlow) {
   using namespace ripcurrent_unittest;
 
   std::vector<int> result;
 
-  using rcfoo_t = RIPCURRENT_UNDERLYING_TYPE(RCFoo());
-  using rcbaz_t = RIPCURRENT_UNDERLYING_TYPE(RCBaz(std::ref(result)));
-
-  static_assert(sizeof(is_same_or_compile_error<ripcurrent::LHS<>, typename rcfoo_t::input_t>), "");
-  static_assert(sizeof(is_same_or_compile_error<ripcurrent::RHS<Integer>, typename rcfoo_t::output_t>), "");
-
-  static_assert(sizeof(is_same_or_compile_error<ripcurrent::LHS<Integer>, typename rcbaz_t::input_t>), "");
-  static_assert(sizeof(is_same_or_compile_error<ripcurrent::RHS<>, typename rcbaz_t::output_t>), "");
-
-  static_assert(sizeof(is_same_or_compile_error<
-                    decltype(RCFoo(1, 2, 3)),
-                    current::ripcurrent::UserClass<ripcurrent::LHS<>, ripcurrent::RHS<Integer>, rcfoo_t>>),
-                "");
-
-  static_assert(sizeof(is_same_or_compile_error<
-                    decltype(RCBaz(std::ref(result))),
-                    current::ripcurrent::UserClass<ripcurrent::LHS<Integer>, ripcurrent::RHS<>, rcbaz_t>>),
-                "");
-
-  (RCFoo(1, 2, 3) | RCBaz(std::ref(result))).RipCurrent().Sync();
+  (RCEmit(1, 2, 3) | RCDump(std::ref(result))).RipCurrent().Sync();
   EXPECT_EQ("1,2,3", Join(result, ','));
 }
 
@@ -116,7 +121,8 @@ TEST(RipCurrent, SingleChainFlow) {
   using namespace ripcurrent_unittest;
 
   std::vector<int> result;
-  (RCFoo(1, 2, 3) | RCBar(10) | RCBar(10) | RCBaz(std::ref(result))).RipCurrent().Sync();
+
+  (RCEmit(1, 2, 3) | RCMult(2) | RCMult(5) | RCMult(10) | RCDump(std::ref(result))).RipCurrent().Sync();
   EXPECT_EQ("100,200,300", Join(result, ','));
 }
 
@@ -125,17 +131,16 @@ TEST(RipCurrent, DeclarationDoesNotRunConstructors) {
 
   std::vector<int> result;
 
-  RipCurrentLHS<ripcurrent::RHS<Integer>> foo = RCFoo(42);
-  EXPECT_EQ("RCFoo(42) | ...", foo.Describe());
+  RipCurrentLHS<ripcurrent::RHS<Integer>> emit = RCEmit(42);
+  RipCurrentRHS<ripcurrent::LHS<Integer>> dump = RCDump(std::ref(result));
+  RipCurrent emit_dump = emit | dump;
 
-  RipCurrentRHS<ripcurrent::LHS<Integer>> baz = RCBaz(std::ref(result));
-  EXPECT_EQ("... | RCBaz(std::ref(result))", baz.Describe());
-
-  RipCurrent foo_baz = foo | baz;
-  EXPECT_EQ("RCFoo(42) | RCBaz(std::ref(result))", foo_baz.Describe());
+  EXPECT_EQ("RCEmit(42) | ...", emit.Describe());
+  EXPECT_EQ("... | RCDump(std::ref(result))", dump.Describe());
+  EXPECT_EQ("RCEmit(42) | RCDump(std::ref(result))", emit_dump.Describe());
 
   EXPECT_EQ("", Join(result, ','));
-  foo_baz.RipCurrent().Sync();
+  emit_dump.RipCurrent().Sync();
   EXPECT_EQ("42", Join(result, ','));
 }
 
@@ -144,13 +149,9 @@ TEST(RipCurrent, OrderDoesNotMatter) {
 
   std::vector<int> result;
 
-  result.clear();
-  (RCFoo(1) | RCBar(10) | RCBaz(std::ref(result))).RipCurrent().Sync();
-  EXPECT_EQ("10", Join(result, ','));
-
-  const auto a = RCFoo(1);
-  const auto b = RCBar(2);
-  const auto c = RCBaz(std::ref(result));
+  const auto a = RCEmit(1);
+  const auto b = RCMult(2);
+  const auto c = RCDump(std::ref(result));
 
   result.clear();
   (a | b | b | c).RipCurrent().Sync();
@@ -169,27 +170,27 @@ TEST(RipCurrent, OrderDoesNotMatter) {
   EXPECT_EQ("4", Join(result, ','));
 }
 
-TEST(RipCurrent, BuildingBlocksCanBeReUsed) {
+TEST(RipCurrent, BuildingBlocksCanBeReused) {
   using namespace ripcurrent_unittest;
 
   std::vector<int> result1;
   std::vector<int> result2;
 
-  RipCurrentLHS<ripcurrent::RHS<Integer>> foo1 = RCFoo(1);
-  RipCurrentLHS<ripcurrent::RHS<Integer>> foo2 = RCFoo(2);
-  RipCurrentVIA<ripcurrent::LHS<Integer>, ripcurrent::RHS<Integer>> bar = RCBar(10);
-  RipCurrentRHS<ripcurrent::LHS<Integer>> baz1 = RCBaz(std::ref(result1));
-  RipCurrentRHS<ripcurrent::LHS<Integer>> baz2 = RCBaz(std::ref(result2));
+  RipCurrentLHS<ripcurrent::RHS<Integer>> emit1 = RCEmit(1);
+  RipCurrentLHS<ripcurrent::RHS<Integer>> emit2 = RCEmit(2);
+  RipCurrentVIA<ripcurrent::LHS<Integer>, ripcurrent::RHS<Integer>> mult10 = RCMult(10);
+  RipCurrentRHS<ripcurrent::LHS<Integer>> dump1 = RCDump(std::ref(result1));
+  RipCurrentRHS<ripcurrent::LHS<Integer>> dump2 = RCDump(std::ref(result2));
 
-  (foo1 | bar | baz1).RipCurrent().Sync();
-  (foo2 | bar | baz2).RipCurrent().Sync();
+  (emit1 | mult10 | dump1).RipCurrent().Sync();
+  (emit2 | mult10 | dump2).RipCurrent().Sync();
   EXPECT_EQ("10", Join(result1, ','));
   EXPECT_EQ("20", Join(result2, ','));
 
   result1.clear();
   result2.clear();
-  ((foo1 | bar) | baz1).RipCurrent().Sync();
-  ((foo2 | bar) | baz2).RipCurrent().Sync();
+  ((emit1 | mult10) | dump1).RipCurrent().Sync();
+  ((emit2 | mult10) | dump2).RipCurrent().Sync();
   EXPECT_EQ("10", Join(result1, ','));
   EXPECT_EQ("20", Join(result2, ','));
 }
@@ -197,118 +198,123 @@ TEST(RipCurrent, BuildingBlocksCanBeReUsed) {
 TEST(RipCurrent, SynopsisAndDecorators) {
   using namespace ripcurrent_unittest;
 
-  EXPECT_EQ("RCFoo() | ...", (RCFoo()).Describe());
-  EXPECT_EQ("... | RCBar() | ...", (RCBar()).Describe());
-  EXPECT_EQ("... | RCBaz()", (RCBaz()).Describe());
+  EXPECT_EQ("RCEmit() | ...", (RCEmit()).Describe());
+  EXPECT_EQ("... | RCMult() | ...", (RCMult()).Describe());
+  EXPECT_EQ("... | RCDump()", (RCDump()).Describe());
 
-  EXPECT_EQ("RCFoo() | RCBaz()", (RCFoo() | RCBaz()).Describe());
-  EXPECT_EQ("RCFoo() | RCBar() | RCBar() | RCBar() | RCBaz()",
-            (RCFoo() | RCBar() | RCBar() | RCBar() | RCBaz()).Describe());
+  EXPECT_EQ("RCEmit() | RCDump()", (RCEmit() | RCDump()).Describe());
+  EXPECT_EQ("RCEmit() | RCMult() | RCMult() | RCMult() | RCDump()",
+            (RCEmit() | RCMult() | RCMult() | RCMult() | RCDump()).Describe());
 
-  EXPECT_EQ("RCFoo() | RCBar() | ...", (RCFoo() | RCBar()).Describe());
-  EXPECT_EQ("RCFoo() | RCBar() | RCBar() | RCBar() | ...", (RCFoo() | RCBar() | RCBar() | RCBar()).Describe());
+  EXPECT_EQ("RCEmit() | RCMult() | ...", (RCEmit() | RCMult()).Describe());
+  EXPECT_EQ("RCEmit() | RCMult() | RCMult() | RCMult() | ...", (RCEmit() | RCMult() | RCMult() | RCMult()).Describe());
 
-  EXPECT_EQ("... | RCBar() | RCBaz()", (RCBar() | RCBaz()).Describe());
-  EXPECT_EQ("... | RCBar() | RCBar() | RCBar() | RCBaz()", (RCBar() | RCBar() | RCBar() | RCBaz()).Describe());
+  EXPECT_EQ("... | RCMult() | RCDump()", (RCMult() | RCDump()).Describe());
+  EXPECT_EQ("... | RCMult() | RCMult() | RCMult() | RCDump()", (RCMult() | RCMult() | RCMult() | RCDump()).Describe());
 
-  EXPECT_EQ("... | RCBar() | RCBar() | RCBar() | ...", (RCBar() | RCBar() | RCBar()).Describe());
+  EXPECT_EQ("... | RCMult() | RCMult() | RCMult() | ...", (RCMult() | RCMult() | RCMult()).Describe());
 
   const int blah = 5;
-  EXPECT_EQ("RCFoo(1) | RCBar(2) | RCBar(3 + 4) | RCBar(blah) | RCBaz()",
-            (RCFoo(1) | RCBar(2) | RCBar(3 + 4) | RCBar(blah) | RCBaz()).Describe());
+  EXPECT_EQ("RCEmit(1) | RCMult(2) | RCMult(3 + 4) | RCMult(blah) | RCDump()",
+            (RCEmit(1) | RCMult(2) | RCMult(3 + 4) | RCMult(blah) | RCDump()).Describe());
 
   const int x = 1;
   const int y = 1;
   const int z = 1;
-  EXPECT_EQ("RCFoo(x, y, z) | RCBaz()", (RCFoo(x, y, z) | RCBaz()).Describe());
+  EXPECT_EQ("RCEmit(x, y, z) | RCDump()", (RCEmit(x, y, z) | RCDump()).Describe());
 }
 
 TEST(RipCurrent, TypeIntrospection) {
   using namespace ripcurrent_unittest;
 
-  EXPECT_EQ("RCFoo() => { Integer } | ...", (RCFoo()).DescribeWithTypes());
-  EXPECT_EQ("... | { Integer } => RCBar() => { Integer } | ...", (RCBar()).DescribeWithTypes());
-  EXPECT_EQ("... | { Integer } => RCBaz()", (RCBaz()).DescribeWithTypes());
+  EXPECT_EQ("RCEmit() => { Integer } | ...", (RCEmit()).DescribeWithTypes());
+  EXPECT_EQ("... | { Integer } => RCMult() => { Integer } | ...", (RCMult()).DescribeWithTypes());
+  EXPECT_EQ("... | { Integer } => RCDump()", (RCDump()).DescribeWithTypes());
 }
 
-TEST(RipCurrent, TypeSystemGuarantees) {
+TEST(RipCurrent, MoreTypeSystemGuarantees) {
   using namespace ripcurrent_unittest;
 
-  EXPECT_EQ("RCFoo", RCFoo::UnitTestClassName());
-  static_assert(std::is_same<RCFoo::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RCFoo::output_t, ripcurrent::RHS<Integer>>::value, "");
+  EXPECT_EQ("RCEmit", RCEmit::UnitTestClassName());
+  static_assert(std::is_same<RCEmit::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RCEmit::output_t, ripcurrent::RHS<Integer>>::value, "");
 
-  EXPECT_EQ("RCFoo", RIPCURRENT_UNDERLYING_TYPE(RCFoo())::UnitTestClassName());
+  EXPECT_EQ("RCEmit", RIPCURRENT_UNDERLYING_TYPE(RCEmit())::UnitTestClassName());
 
-  const auto foo = RCFoo();
-  EXPECT_EQ("RCFoo", RIPCURRENT_UNDERLYING_TYPE(foo)::UnitTestClassName());
+  const auto emit = RCEmit();
+  EXPECT_EQ("RCEmit", RIPCURRENT_UNDERLYING_TYPE(emit)::UnitTestClassName());
 
-  EXPECT_EQ("RCBar", RCBar::UnitTestClassName());
-  static_assert(std::is_same<RCBar::input_t, ripcurrent::LHS<Integer>>::value, "");
-  static_assert(std::is_same<RCBar::output_t, ripcurrent::RHS<Integer>>::value, "");
+  EXPECT_EQ("RCMult", RCMult::UnitTestClassName());
+  static_assert(std::is_same<RCMult::input_t, ripcurrent::LHS<Integer>>::value, "");
+  static_assert(std::is_same<RCMult::output_t, ripcurrent::RHS<Integer>>::value, "");
 
-  EXPECT_EQ("RCBar", RIPCURRENT_UNDERLYING_TYPE(RCBar())::UnitTestClassName());
+  EXPECT_EQ("RCMult", RIPCURRENT_UNDERLYING_TYPE(RCMult())::UnitTestClassName());
 
-  const auto bar = RCBar();
-  EXPECT_EQ("RCBar", RIPCURRENT_UNDERLYING_TYPE(bar)::UnitTestClassName());
+  const auto mult = RCMult();
+  EXPECT_EQ("RCMult", RIPCURRENT_UNDERLYING_TYPE(mult)::UnitTestClassName());
 
-  EXPECT_EQ("RCBaz", RCBaz::UnitTestClassName());
-  static_assert(std::is_same<RCBaz::input_t, ripcurrent::LHS<Integer>>::value, "");
-  static_assert(std::is_same<RCBaz::output_t, ripcurrent::RHS<>>::value, "");
+  EXPECT_EQ("RCDump", RCDump::UnitTestClassName());
+  static_assert(std::is_same<RCDump::input_t, ripcurrent::LHS<Integer>>::value, "");
+  static_assert(std::is_same<RCDump::output_t, ripcurrent::RHS<>>::value, "");
 
-  EXPECT_EQ("RCBaz", RIPCURRENT_UNDERLYING_TYPE(RCBaz())::UnitTestClassName());
+  EXPECT_EQ("RCDump", RIPCURRENT_UNDERLYING_TYPE(RCDump())::UnitTestClassName());
 
-  const auto baz = RCBaz();
-  EXPECT_EQ("RCBaz", RIPCURRENT_UNDERLYING_TYPE(baz)::UnitTestClassName());
+  const auto dump = RCDump();
+  EXPECT_EQ("RCDump", RIPCURRENT_UNDERLYING_TYPE(dump)::UnitTestClassName());
 
-  const auto foo_bar = foo | bar;
-  const auto bar_baz = bar | baz;
-  const auto foo_baz = foo | baz;
-  const auto foo_bar_baz_1 = (foo | bar) | baz;
-  const auto foo_bar_baz_2 = foo | (bar | baz);
-  const auto foo_bar_bar_baz_1 = (foo | bar) | (bar | baz);
-  const auto foo_bar_bar_baz_2 = foo | (bar | bar) | baz;
-  const auto foo_bar_bar_baz_3 = ((foo | bar) | bar) | baz;
-  const auto foo_bar_bar_baz_4 = foo | (bar | (bar | baz));
+  const auto emit_mult = emit | mult;
+  const auto mult_dump = mult | dump;
+  const auto emit_dump = emit | dump;
+  const auto emit_mult_dump_1 = (emit | mult) | dump;
+  const auto emit_mult_dump_2 = emit | (mult | dump);
+  const auto emit_mult_mult_dump_1 = (emit | mult) | (mult | dump);
+  const auto emit_mult_mult_dump_2 = emit | (mult | mult) | dump;
+  const auto emit_mult_mult_dump_3 = ((emit | mult) | mult) | dump;
+  const auto emit_mult_mult_dump_4 = emit | (mult | (mult | dump));
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar)::output_t, ripcurrent::RHS<Integer>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult)::output_t, ripcurrent::RHS<Integer>>::value, "");
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(bar_baz)::input_t, ripcurrent::LHS<Integer>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(bar_baz)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(mult_dump)::input_t, ripcurrent::LHS<Integer>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(mult_dump)::output_t, ripcurrent::RHS<>>::value, "");
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_baz)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_baz)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_dump)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_dump)::output_t, ripcurrent::RHS<>>::value, "");
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_baz_1)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_baz_1)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_dump_1)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_dump_1)::output_t, ripcurrent::RHS<>>::value, "");
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_baz_2)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_baz_2)::output_t, ripcurrent::RHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_1)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_1)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_dump_2)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_dump_2)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_1)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_1)::output_t, ripcurrent::RHS<>>::value,
+                "");
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_2)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_2)::output_t, ripcurrent::RHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_3)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_3)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_2)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_2)::output_t, ripcurrent::RHS<>>::value,
+                "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_3)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_3)::output_t, ripcurrent::RHS<>>::value,
+                "");
 
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_4)::input_t, ripcurrent::LHS<>>::value, "");
-  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(foo_bar_bar_baz_4)::output_t, ripcurrent::RHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_4)::input_t, ripcurrent::LHS<>>::value, "");
+  static_assert(std::is_same<RIPCURRENT_UNDERLYING_TYPE(emit_mult_mult_dump_4)::output_t, ripcurrent::RHS<>>::value,
+                "");
 
-  foo_bar.Dismiss();
-  bar_baz.Dismiss();
-  foo_baz.Dismiss();
-  foo_bar_baz_1.Dismiss();
-  foo_bar_baz_2.Dismiss();
-  foo_bar_bar_baz_1.Dismiss();
-  foo_bar_bar_baz_2.Dismiss();
-  foo_bar_bar_baz_3.Dismiss();
-  foo_bar_bar_baz_4.Dismiss();
+  emit_mult.Dismiss();
+  mult_dump.Dismiss();
+  emit_dump.Dismiss();
+  emit_mult_dump_1.Dismiss();
+  emit_mult_dump_2.Dismiss();
+  emit_mult_mult_dump_1.Dismiss();
+  emit_mult_mult_dump_2.Dismiss();
+  emit_mult_mult_dump_3.Dismiss();
+  emit_mult_mult_dump_4.Dismiss();
 }
 
-static std::string ExpectHasNAndReturnFirstTwoLines(size_t n, const std::string& s) {
-  const std::vector<std::string> lines = current::strings::Split<current::strings::ByLines>(s);
+// A test helper to chop off file name and line numbers from exception messages.
+static std::string ExpectHasNAndReturnFirstTwoLines(size_t n, const std::string& message) {
+  const std::vector<std::string> lines = current::strings::Split<current::strings::ByLines>(message);
   EXPECT_EQ(n, lines.size());
   return current::strings::Join(
       std::vector<std::string>(lines.begin(),
@@ -316,69 +322,68 @@ static std::string ExpectHasNAndReturnFirstTwoLines(size_t n, const std::string&
       '\n');
 }
 
-TEST(RipCurrent, NotLeftHanging) {
+TEST(RipCurrent, UnusedRipCurrentBlockYieldsAnException) {
   using namespace ripcurrent_unittest;
 
   std::string captured_error_message;
-  const auto scope = current::Singleton<current::ripcurrent::RipCurrentMockableErrorHandler>().ScopedInjectHandler(
+  const auto mock_scope = current::Singleton<current::ripcurrent::RipCurrentMockableErrorHandler>().ScopedInjectHandler(
       [&captured_error_message](const std::string& error_message) { captured_error_message = error_message; });
 
   EXPECT_EQ("", captured_error_message);
-  RCFoo();
+  RCEmit();
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "RCFoo() | ...",
+      "RCEmit() | ...",
       ExpectHasNAndReturnFirstTwoLines(4, captured_error_message));
-  RCBar();
+  RCMult();
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "... | RCBar() | ...",
+      "... | RCMult() | ...",
       ExpectHasNAndReturnFirstTwoLines(4, captured_error_message));
-  RCBaz();
+  RCDump();
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "... | RCBaz()",
+      "... | RCDump()",
       ExpectHasNAndReturnFirstTwoLines(4, captured_error_message));
-  RCFoo(1) | RCBar(2);
+  RCEmit(1) | RCMult(2);
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "RCFoo(1) | RCBar(2) | ...",
+      "RCEmit(1) | RCMult(2) | ...",
       ExpectHasNAndReturnFirstTwoLines(5, captured_error_message));
-  RCBar(3) | RCBaz();
+  RCMult(3) | RCDump();
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "... | RCBar(3) | RCBaz()",
+      "... | RCMult(3) | RCDump()",
       ExpectHasNAndReturnFirstTwoLines(5, captured_error_message));
   std::vector<int> result;
-  RCFoo(42) | RCBar(100) | RCBaz(std::ref(result));
+  RCEmit(42) | RCMult(100) | RCDump(std::ref(result));
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "RCFoo(42) | RCBar(100) | RCBaz(std::ref(result))",
+      "RCEmit(42) | RCMult(100) | RCDump(std::ref(result))",
       ExpectHasNAndReturnFirstTwoLines(6, captured_error_message));
 
-  { const auto tmp = RCFoo() | RCBar(1) | RCBaz(std::ref(result)); }
+  { const auto tmp = RCEmit() | RCMult(1) | RCDump(std::ref(result)); }
   EXPECT_EQ(
       "RipCurrent building block leaked.\n"
-      "RCFoo() | RCBar(1) | RCBaz(std::ref(result))",
+      "RCEmit() | RCMult(1) | RCDump(std::ref(result))",
       ExpectHasNAndReturnFirstTwoLines(6, captured_error_message));
 
   captured_error_message = "NO ERROR";
   {
-    const auto tmp = RCFoo() | RCBar(2) | RCBaz(std::ref(result));
+    const auto tmp = RCEmit() | RCMult(2) | RCDump(std::ref(result));
     tmp.Describe();
   }
   EXPECT_EQ("NO ERROR", captured_error_message);
 
   captured_error_message = "NO ERROR ONCE AGAIN";
   {
-    const auto tmp = RCFoo() | RCBar(3) | RCBaz(std::ref(result));
+    const auto tmp = RCEmit() | RCMult(3) | RCDump(std::ref(result));
     tmp.Dismiss();
   }
   EXPECT_EQ("NO ERROR ONCE AGAIN", captured_error_message);
 }
 
 // clang-format off
-
 namespace ripcurrent_unittest {
 
 CURRENT_STRUCT(String) {
@@ -390,17 +395,17 @@ CURRENT_STRUCT(String) {
 using LHS_Integer_String = ripcurrent::LHS<Integer, String>;
 using RHS_Integer_String = ripcurrent::RHS<Integer, String>;
 
-RIPCURRENT_NODE(RCFoo2, ripcurrent::LHS<>, RHS_Integer_String) {
-  RCFoo2() {
+RIPCURRENT_NODE(EmitStringAndInteger, ripcurrent::LHS<>, RHS_Integer_String) {
+  EmitStringAndInteger() {
     emit(String("Answer"));
     emit(Integer(42));
   }
 };
-#define RCFoo2(...) RIPCURRENT_MACRO(RCFoo2, __VA_ARGS__)
+#define EmitStringAndInteger(...) RIPCURRENT_MACRO(EmitStringAndInteger, __VA_ARGS__)
 
-RIPCURRENT_NODE(RCBar2, LHS_Integer_String, RHS_Integer_String) {
+RIPCURRENT_NODE(MultIntegerOrString, LHS_Integer_String, RHS_Integer_String) {
   const int k;
-  RCBar2(int k = 101) : k(k) {}
+  MultIntegerOrString(int k = 101) : k(k) {}
   void f(Integer x) {
     emit(Integer(x.value * k));
   }
@@ -408,12 +413,12 @@ RIPCURRENT_NODE(RCBar2, LHS_Integer_String, RHS_Integer_String) {
     emit(String("Yo? " + x.value + " Yo!"));
   }
 };
-#define RCBar2(...) RIPCURRENT_MACRO(RCBar2, __VA_ARGS__)
+#define MultIntegerOrString(...) RIPCURRENT_MACRO(MultIntegerOrString, __VA_ARGS__)
 
-RIPCURRENT_NODE(RCBaz2, LHS_Integer_String, ripcurrent::RHS<>) {
+RIPCURRENT_NODE(DumpIntegerAndString, LHS_Integer_String, ripcurrent::RHS<>) {
   std::vector<std::string>* ptr;
-  RCBaz2() : ptr(nullptr) {}  // LCOV_EXCL_LINE
-  RCBaz2(std::vector<std::string>& ref) : ptr(&ref) {}
+  DumpIntegerAndString() : ptr(nullptr) {}  // LCOV_EXCL_LINE
+  DumpIntegerAndString(std::vector<std::string>& ref) : ptr(&ref) {}
   void f(Integer x) {
     CURRENT_ASSERT(ptr);
     ptr->push_back(current::ToString(x.value));
@@ -423,17 +428,16 @@ RIPCURRENT_NODE(RCBaz2, LHS_Integer_String, ripcurrent::RHS<>) {
     ptr->push_back("'" + x.value + "'");
   }
 };
-#define RCBaz2(...) RIPCURRENT_MACRO(RCBaz2, __VA_ARGS__)
+#define DumpIntegerAndString(...) RIPCURRENT_MACRO(DumpIntegerAndString, __VA_ARGS__)
 
 }  // namespace ripcurrent_unittest
-
 // clang-format on
 
 TEST(RipCurrent, CustomTypesIntrospection) {
   using namespace ripcurrent_unittest;
 
-  EXPECT_EQ("RCFoo2() => { Integer, String } | ...", (RCFoo2()).DescribeWithTypes());
-  EXPECT_EQ("... | { Integer, String } => RCBaz2()", (RCBaz2()).DescribeWithTypes());
+  EXPECT_EQ("EmitStringAndInteger() => { Integer, String } | ...", (EmitStringAndInteger()).DescribeWithTypes());
+  EXPECT_EQ("... | { Integer, String } => DumpIntegerAndString()", (DumpIntegerAndString()).DescribeWithTypes());
 }
 
 TEST(RipCurrent, CustomTypesFlow) {
@@ -441,19 +445,22 @@ TEST(RipCurrent, CustomTypesFlow) {
 
   {
     std::vector<std::string> result;
-    (RCFoo2() | RCBaz2(std::ref(result))).RipCurrent().Sync();
+    (EmitStringAndInteger() | DumpIntegerAndString(std::ref(result))).RipCurrent().Sync();
     EXPECT_EQ("'Answer', 42", Join(result, ", "));
   }
 
   {
     std::vector<std::string> result;
-    (RCFoo2() | RCBar2() | RCBaz2(std::ref(result))).RipCurrent().Sync();
+    (EmitStringAndInteger() | MultIntegerOrString() | DumpIntegerAndString(std::ref(result))).RipCurrent().Sync();
     EXPECT_EQ("'Yo? Answer Yo!', 4242", Join(result, ", "));
   }
 
   {
     std::vector<std::string> result;
-    (RCFoo2() | RCBar2() | RCBar2(10001) | RCBaz2(std::ref(result))).RipCurrent().Sync();
+    (EmitStringAndInteger() | MultIntegerOrString() | MultIntegerOrString(10001) |
+     DumpIntegerAndString(std::ref(result)))
+        .RipCurrent()
+        .Sync();
     EXPECT_EQ("'Yo? Yo? Answer Yo! Yo!', 42424242", Join(result, ", "));
   }
 }

--- a/TypeSystem/remove_parentheses.h
+++ b/TypeSystem/remove_parentheses.h
@@ -1,0 +1,52 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Maxim Zhurovich <zhurovich@gmail.com>
+          (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_TYPE_SYSTEM_REMOVE_PARENTHESES_H
+#define CURRENT_TYPE_SYSTEM_REMOVE_PARENTHESES_H
+
+#include "../port.h"
+
+#include <tuple>
+
+// A macro to equally treat bare and parenthesized type arguments:
+// REMOVE_PARENTHESES((int)) = REMOVE_PARENTHESES(int) = int
+#define EMPTY_CF_TYPE_EXTRACT
+#define CF_TYPE_PASTE(x, ...) x##__VA_ARGS__
+#define CF_TYPE_PASTE2(x, ...) CF_TYPE_PASTE(x, __VA_ARGS__)
+#define CF_TYPE_EXTRACT(...) CF_TYPE_EXTRACT __VA_ARGS__
+
+// Was. -- D.K. TODO: Test on Windows.
+// #define REMOVE_PARENTHESES(x) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT x)
+
+// Now. -- D.K.
+#define REMOVE_PARENTHESES(...) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT __VA_ARGS__)
+
+// Self-test.
+static int DIMA = 42;
+static_assert(sizeof(is_same_or_compile_error<int, REMOVE_PARENTHESES(int)>), "");
+static_assert(sizeof(is_same_or_compile_error<std::tuple<int>, std::tuple<REMOVE_PARENTHESES(int)>>), "");
+static_assert(sizeof(is_same_or_compile_error<std::tuple<int, double>, std::tuple<REMOVE_PARENTHESES(int, double)>>), "");
+
+#endif  // CURRENT_TYPE_SYSTEM_REMOVE_PARENTHESES_H

--- a/TypeSystem/remove_parentheses.h
+++ b/TypeSystem/remove_parentheses.h
@@ -44,7 +44,6 @@ SOFTWARE.
 #define REMOVE_PARENTHESES(...) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT __VA_ARGS__)
 
 // Self-test.
-static int DIMA = 42;
 static_assert(sizeof(is_same_or_compile_error<int, REMOVE_PARENTHESES(int)>), "");
 static_assert(sizeof(is_same_or_compile_error<std::tuple<int>, std::tuple<REMOVE_PARENTHESES(int)>>), "");
 static_assert(sizeof(is_same_or_compile_error<std::tuple<int, double>, std::tuple<REMOVE_PARENTHESES(int, double)>>), "");

--- a/TypeSystem/remove_parentheses.h
+++ b/TypeSystem/remove_parentheses.h
@@ -31,21 +31,22 @@ SOFTWARE.
 #include <tuple>
 
 // A macro to equally treat bare and parenthesized type arguments:
-// REMOVE_PARENTHESES((int)) = REMOVE_PARENTHESES(int) = int
+// CURRENT_REMOVE_PARENTHESES((int)) = CURRENT_REMOVE_PARENTHESES(int) = int
 #define EMPTY_CF_TYPE_EXTRACT
 #define CF_TYPE_PASTE(x, ...) x##__VA_ARGS__
 #define CF_TYPE_PASTE2(x, ...) CF_TYPE_PASTE(x, __VA_ARGS__)
 #define CF_TYPE_EXTRACT(...) CF_TYPE_EXTRACT __VA_ARGS__
 
 // Was. -- D.K. TODO: Test on Windows.
-// #define REMOVE_PARENTHESES(x) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT x)
+// #define CURRENT_REMOVE_PARENTHESES(x) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT x)
 
 // Now. -- D.K.
-#define REMOVE_PARENTHESES(...) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT __VA_ARGS__)
+#define CURRENT_REMOVE_PARENTHESES(...) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT __VA_ARGS__)
 
 // Self-test.
-static_assert(sizeof(is_same_or_compile_error<int, REMOVE_PARENTHESES(int)>), "");
-static_assert(sizeof(is_same_or_compile_error<std::tuple<int>, std::tuple<REMOVE_PARENTHESES(int)>>), "");
-static_assert(sizeof(is_same_or_compile_error<std::tuple<int, double>, std::tuple<REMOVE_PARENTHESES(int, double)>>), "");
+static_assert(sizeof(is_same_or_compile_error<int, CURRENT_REMOVE_PARENTHESES(int)>), "");
+static_assert(sizeof(is_same_or_compile_error<std::tuple<int>, std::tuple<CURRENT_REMOVE_PARENTHESES(int)>>), "");
+static_assert(
+    sizeof(is_same_or_compile_error<std::tuple<int, double>, std::tuple<CURRENT_REMOVE_PARENTHESES(int, double)>>), "");
 
 #endif  // CURRENT_TYPE_SYSTEM_REMOVE_PARENTHESES_H

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -321,16 +321,17 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CF_SWITCH(x, y) x y
 #define CURRENT_FIELD(...) CF_SWITCH(CF_CHOOSERX(CF_NARGS(__VA_ARGS__)), (__VA_ARGS__))
 
-#define CURRENT_FIELD_WITH_NO_VALUE(name, type)                                           \
-  ::current::reflection::Field<INSTANTIATION_TYPE, REMOVE_PARENTHESES(type)> name;        \
-  constexpr static size_t CURRENT_FIELD_INDEX_##name =                                    \
-      CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1; \
+#define CURRENT_FIELD_WITH_NO_VALUE(name, type)                                            \
+  ::current::reflection::Field<INSTANTIATION_TYPE, CURRENT_REMOVE_PARENTHESES(type)> name; \
+  constexpr static size_t CURRENT_FIELD_INDEX_##name =                                     \
+      CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1;  \
   CURRENT_FIELD_REFLECTION(CURRENT_FIELD_INDEX_##name, type, name)
 
-#define CURRENT_FIELD_WITH_VALUE(name, type, value)                                                           \
-  ::current::reflection::Field<INSTANTIATION_TYPE, REMOVE_PARENTHESES(type)> name{REMOVE_PARENTHESES(value)}; \
-  constexpr static size_t CURRENT_FIELD_INDEX_##name =                                                        \
-      CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1;                     \
+#define CURRENT_FIELD_WITH_VALUE(name, type, value)                                        \
+  ::current::reflection::Field<INSTANTIATION_TYPE, CURRENT_REMOVE_PARENTHESES(type)> name{ \
+      CURRENT_REMOVE_PARENTHESES(value)};                                                  \
+  constexpr static size_t CURRENT_FIELD_INDEX_##name =                                     \
+      CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1;  \
   CURRENT_FIELD_REFLECTION(CURRENT_FIELD_INDEX_##name, type, name)
 
 #define CURRENT_FIELD_DESCRIPTION(name, description)                    \
@@ -371,12 +372,12 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   template <class F>                                                                                                   \
   static void CURRENT_REFLECTION(F&& CURRENT_CALL_F,                                                                   \
                                  ::current::reflection::Index<::current::reflection::FieldTypeAndName, idx>) {         \
-    CURRENT_CALL_F(::current::reflection::TypeSelector<REMOVE_PARENTHESES(type)>(), #name);                            \
+    CURRENT_CALL_F(::current::reflection::TypeSelector<CURRENT_REMOVE_PARENTHESES(type)>(), #name);                    \
   }                                                                                                                    \
   template <class F>                                                                                                   \
   static void CURRENT_REFLECTION(F&& CURRENT_CALL_F,                                                                   \
                                  ::current::reflection::Index<::current::reflection::FieldTypeAndNameAndIndex, idx>) { \
-    CURRENT_CALL_F(::current::reflection::TypeSelector<REMOVE_PARENTHESES(type)>(),                                    \
+    CURRENT_CALL_F(::current::reflection::TypeSelector<CURRENT_REMOVE_PARENTHESES(type)>(),                            \
                    #name,                                                                                              \
                    ::current::reflection::SimpleIndex<idx>());                                                         \
   }                                                                                                                    \

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -28,6 +28,8 @@ SOFTWARE.
 
 #include "../port.h"
 
+#include "remove_parentheses.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -303,14 +305,6 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 
 #endif  // CURRENT_WINDOWS
 
-// Macro to equally treat bare and parenthesized type arguments:
-// CF_TYPE((int)) = CF_TYPE(int) = int
-#define EMPTY_CF_TYPE_EXTRACT
-#define CF_TYPE_PASTE(x, ...) x##__VA_ARGS__
-#define CF_TYPE_PASTE2(x, ...) CF_TYPE_PASTE(x, __VA_ARGS__)
-#define CF_TYPE_EXTRACT(...) CF_TYPE_EXTRACT __VA_ARGS__
-#define CF_TYPE(x) CF_TYPE_PASTE2(EMPTY_, CF_TYPE_EXTRACT x)
-
 // `CURRENT_FIELD` related macros and implementation.
 #define CF_IMPL2(a, b) CURRENT_FIELD_WITH_NO_VALUE(a, b)
 #define CF_IMPL3(a, b, c) CURRENT_FIELD_WITH_VALUE(a, b, c)
@@ -328,15 +322,15 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CURRENT_FIELD(...) CF_SWITCH(CF_CHOOSERX(CF_NARGS(__VA_ARGS__)), (__VA_ARGS__))
 
 #define CURRENT_FIELD_WITH_NO_VALUE(name, type)                                           \
-  ::current::reflection::Field<INSTANTIATION_TYPE, CF_TYPE(type)> name;                   \
+  ::current::reflection::Field<INSTANTIATION_TYPE, REMOVE_PARENTHESES(type)> name;        \
   constexpr static size_t CURRENT_FIELD_INDEX_##name =                                    \
       CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1; \
   CURRENT_FIELD_REFLECTION(CURRENT_FIELD_INDEX_##name, type, name)
 
-#define CURRENT_FIELD_WITH_VALUE(name, type, value)                                       \
-  ::current::reflection::Field<INSTANTIATION_TYPE, CF_TYPE(type)> name{CF_TYPE(value)};   \
-  constexpr static size_t CURRENT_FIELD_INDEX_##name =                                    \
-      CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1; \
+#define CURRENT_FIELD_WITH_VALUE(name, type, value)                                                           \
+  ::current::reflection::Field<INSTANTIATION_TYPE, REMOVE_PARENTHESES(type)> name{REMOVE_PARENTHESES(value)}; \
+  constexpr static size_t CURRENT_FIELD_INDEX_##name =                                                        \
+      CURRENT_EXPAND_MACRO(__COUNTER__) - FIELD_INDEX_BASE::CURRENT_FIELD_INDEX_BASE - 1;                     \
   CURRENT_FIELD_REFLECTION(CURRENT_FIELD_INDEX_##name, type, name)
 
 #define CURRENT_FIELD_DESCRIPTION(name, description)                    \
@@ -377,13 +371,14 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   template <class F>                                                                                                   \
   static void CURRENT_REFLECTION(F&& CURRENT_CALL_F,                                                                   \
                                  ::current::reflection::Index<::current::reflection::FieldTypeAndName, idx>) {         \
-    CURRENT_CALL_F(::current::reflection::TypeSelector<CF_TYPE(type)>(), #name);                                       \
+    CURRENT_CALL_F(::current::reflection::TypeSelector<REMOVE_PARENTHESES(type)>(), #name);                            \
   }                                                                                                                    \
   template <class F>                                                                                                   \
   static void CURRENT_REFLECTION(F&& CURRENT_CALL_F,                                                                   \
                                  ::current::reflection::Index<::current::reflection::FieldTypeAndNameAndIndex, idx>) { \
-    CURRENT_CALL_F(                                                                                                    \
-        ::current::reflection::TypeSelector<CF_TYPE(type)>(), #name, ::current::reflection::SimpleIndex<idx>());       \
+    CURRENT_CALL_F(::current::reflection::TypeSelector<REMOVE_PARENTHESES(type)>(),                                    \
+                   #name,                                                                                              \
+                   ::current::reflection::SimpleIndex<idx>());                                                         \
   }                                                                                                                    \
   template <class F, class SELF>                                                                                       \
   static void CURRENT_REFLECTION(F&& CURRENT_CALL_F,                                                                   \


### PR DESCRIPTION
Hi Max!

A few tweaks from the airplane. Cleaner syntax, and, looks like, I've fixed the global `using namespace current;` top-level `make test` issue in the meantime.

Worth testing on Windows as I factored out the `REMOVE_PARENTHESES` macro into a dedicated header, and extended it with `__VA_ARGS__`.

Thanks,
Dima