### PR TITLE
The "priority MMQ" to allow `PublishIntoTheFuture` and `UpdateHead`.

### DIFF
--- a/Blocks/MMQ/mmpq.h
+++ b/Blocks/MMQ/mmpq.h
@@ -132,7 +132,7 @@ class MMPQ {
       }
 
       auto it = queue_.begin();
-      consumer_(std::move(it->message_body), it->index_timestamp, last_idx_ts_);
+      consumer_(std::move(const_cast<Entry&>(*it).message_body), it->index_timestamp, last_idx_ts_);
       queue_.erase(it);
     }
   }

--- a/Blocks/MMQ/mmpq.h
+++ b/Blocks/MMQ/mmpq.h
@@ -70,12 +70,10 @@ class MMPQ {
   }
 
   // Adds a message to the buffer. Supports both copy and move semantics. THREAD SAFE.
-  using MutexLockStatus = current::locks::MutexLockStatus;
 
   // NOTE(dkorolev): `std::enable_if_t<std::is_same<message_t, current::decay<T>>::value, idxts_t>` can't convert
   // `const char*` into an `std::string`, which is essential, as, unlike MMQ, MMPQ is not an `ss::EntryPublisher<>`.
-
-  template <MutexLockStatus MLS = MutexLockStatus::NeedToLock, class T>
+  template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock, class T>
   idxts_t Publish(T&& message, std::chrono::microseconds timestamp = current::time::Now()) {
     locks::SmartMutexLockGuard<MLS> lock(mutex_);
     if (!(timestamp > last_idx_ts_.us)) {
@@ -88,7 +86,7 @@ class MMPQ {
     return last_idx_ts_;
   }
 
-  template <MutexLockStatus MLS = MutexLockStatus::NeedToLock, class T>
+  template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock, class T>
   idxts_t PublishIntoTheFuture(T&& message, std::chrono::microseconds timestamp = current::time::Now()) {
     locks::SmartMutexLockGuard<MLS> lock(mutex_);
     if (!(timestamp > last_idx_ts_.us)) {
@@ -101,7 +99,7 @@ class MMPQ {
     return last_idx_ts_;
   }
 
-  template <MutexLockStatus MLS = MutexLockStatus::NeedToLock>
+  template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
   void UpdateHead(std::chrono::microseconds timestamp = current::time::Now()) {
     locks::SmartMutexLockGuard<MLS> lock(mutex_);
     if (!(timestamp > last_idx_ts_.us)) {

--- a/Blocks/MMQ/mmpq.h
+++ b/Blocks/MMQ/mmpq.h
@@ -140,7 +140,7 @@ class MMPQ {
   // The instance of the consuming side of the FIFO buffer.
   consumer_t& consumer_;
 
-  // The `Entry` struct keeps the entries along with their completion status.
+  // The `Entry` struct keeps the entries along with their timestamps.
   struct Entry {
     idxts_t index_timestamp;
     message_t message_body;

--- a/Blocks/MMQ/mmpq.h
+++ b/Blocks/MMQ/mmpq.h
@@ -1,0 +1,145 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef BLOCKS_MMQ_MMPQ_H
+#define BLOCKS_MMQ_MMPQ_H
+
+// MMPQ is an in-memory priority queue, with the external interface loosely resembling the one of the original MMQ.
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <queue>
+
+#include "../SS/ss.h"
+
+#include "../../Bricks/time/chrono.h"
+
+namespace current {
+namespace mmq {
+
+template <typename MESSAGE, typename CONSUMER, size_t DEFAULT_BUFFER_SIZE = 1024, bool DROP_ON_OVERFLOW = false>
+class MMPQ {
+  static_assert(current::ss::IsEntrySubscriber<CONSUMER, MESSAGE>::value, "");
+
+ public:
+  // The type of messages to store and dispatch.
+  using message_t = MESSAGE;
+
+  // Consumer's `operator()` will be called from a dedicated thread, which is spawned and owned
+  // by the instance of MMPQ. See "Blocks/SS/ss.h" and its test for possible callee signatures.
+  using consumer_t = CONSUMER;
+
+  MMPQ(consumer_t& consumer) : consumer_(consumer), consumer_thread_(&MMPQ::ConsumerThread, this) {
+    consumer_thread_created_ = true;
+  }
+
+  // The destructor waits for the consumer thread to terminate, which implies committing all the queued messages.
+  ~MMPQ() {
+    if (consumer_thread_created_) {
+      CURRENT_ASSERT(consumer_thread_.joinable());
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        destructing_ = true;
+        condition_variable_.notify_all();
+      }
+      consumer_thread_.join();
+    }
+  }
+
+  // Adds a message to the buffer. Supports both copy and move semantics. THREAD SAFE.
+  using MutexLockStatus = current::locks::MutexLockStatus;
+
+  // NOTE(dkorolev): `std::enable_if_t<std::is_same<message_t, current::decay<T>>::value, idxts_t>` can't convert
+  // `const char*` into an `std::string`, which is essential, as, unlike MMQ, MMPQ is not an `ss::EntryPublisher<>`.
+
+  template <MutexLockStatus MLS = MutexLockStatus::NeedToLock, class T>
+  idxts_t Publish(T&& message, std::chrono::microseconds timestamp = current::time::Now()) {
+    locks::SmartMutexLockGuard<MLS> lock(mutex_);
+    if (!(timestamp > last_idx_ts_.us)) {
+      CURRENT_THROW(ss::InconsistentTimestampException(last_idx_ts_.us + std::chrono::microseconds(1), timestamp));
+    }
+    ++last_idx_ts_.index;
+    last_idx_ts_.us = timestamp;
+    queue_.emplace(std::move(message), last_idx_ts_);
+    condition_variable_.notify_all();
+    return last_idx_ts_;
+  }
+
+ private:
+  MMPQ(const MMPQ&) = delete;
+  MMPQ(MMPQ&&) = delete;
+  void operator=(const MMPQ&) = delete;
+  void operator=(MMPQ&&) = delete;
+
+  void ConsumerThread() {
+    while (true) {
+      std::unique_lock<std::mutex> lock(mutex_);
+
+      condition_variable_.wait(lock, [this] { return !queue_.empty() || destructing_; });
+
+      if (destructing_) {
+        return;  // LCOV_EXCL_LINE
+      }
+
+      Entry e = std::move(queue_.front());
+      queue_.pop();
+
+      lock.unlock();
+      consumer_(std::move(e.message_body), e.index_timestamp, last_idx_ts_);
+    }
+  }
+
+  bool consumer_thread_created_ = false;
+
+  // The instance of the consuming side of the FIFO buffer.
+  consumer_t& consumer_;
+
+  // The `Entry` struct keeps the entries along with their completion status.
+  struct Entry {
+    idxts_t index_timestamp;
+    message_t message_body;
+    Entry() = default;
+    Entry(Entry&&) = default;
+    Entry(message_t&& message_body, idxts_t index_timestamp)
+        : index_timestamp(index_timestamp), message_body(std::move(message_body)) {}
+  };
+
+  std::queue<Entry> queue_;
+  idxts_t last_idx_ts_ = idxts_t(0, std::chrono::microseconds(-1));
+  std::mutex mutex_;
+  std::condition_variable condition_variable_;
+
+  // For safe thread destruction.
+  bool destructing_ = false;
+
+  // The thread in which the consuming process is running.
+  std::thread consumer_thread_;
+};
+
+}  // namespace mmq
+}  // namespace current
+
+#endif  // BLOCKS_MMQ_MMPQ_H

--- a/Blocks/MMQ/mmq.h
+++ b/Blocks/MMQ/mmq.h
@@ -101,9 +101,7 @@ class MMQImpl {
   // Adds a message to the buffer.
   // Supports both copy and move semantics.
   // THREAD SAFE. Blocks the calling thread for as short period of time as possible.
-  using MutexLockStatus = current::locks::MutexLockStatus;
-
-  template <MutexLockStatus MLS>
+  template <current::locks::MutexLockStatus MLS>
   idxts_t DoPublish(const message_t& message, std::chrono::microseconds timestamp) {
     if (CHECK_TIMESTAMP_MONOTONICITY) {
       if (!(timestamp > last_idx_ts_.us)) {
@@ -120,7 +118,7 @@ class MMQImpl {
     }
   }
 
-  template <MutexLockStatus MLS>
+  template <current::locks::MutexLockStatus MLS>
   idxts_t DoPublish(message_t&& message, std::chrono::microseconds timestamp) {
     if (CHECK_TIMESTAMP_MONOTONICITY) {
       if (!(timestamp > last_idx_ts_.us)) {

--- a/Blocks/MMQ/mmq.h
+++ b/Blocks/MMQ/mmq.h
@@ -266,7 +266,7 @@ class MMQImpl {
   // Messages beyond it will be dropped.
   const size_t circular_buffer_size_;
 
-  // The `Entry` struct keeps the entries along with their completion status.
+  // The `Entry` struct keeps the entries along with their timestamps and completion status.
   struct Entry {
     idxts_t index_timestamp;
     message_t message_body;

--- a/Blocks/MMQ/test.cc
+++ b/Blocks/MMQ/test.cc
@@ -31,6 +31,7 @@ SOFTWARE.
 #include <thread>
 
 #include "../../Bricks/strings/printf.h"
+#include "../../Bricks/strings/join.h"
 
 #include "../../3rdparty/gtest/gtest-main.h"
 
@@ -238,4 +239,140 @@ TEST(InMemoryMQ, TimeShouldNotGoBack) {
     }
     EXPECT_EQ("one\nthree\n", c.messages_);
   }
+}
+
+TEST(InMemoryMQ, MMPQAllowsTimeExplicitlyGoingBack) {
+  struct ConsumerImpl {
+    std::vector<std::string> messages_by_indexes_;
+    std::vector<std::string> messages_by_timestamps_;
+    std::atomic_size_t processed_messages_;
+    ConsumerImpl() : processed_messages_(0u) {}
+    EntryResponse operator()(const std::string& s, idxts_t idxts, idxts_t) {
+      messages_by_indexes_.push_back("[" + current::ToString(idxts.index) + "] = " + s);
+      messages_by_timestamps_.push_back(s + " @ " + current::ToString(idxts.us));
+      ++processed_messages_;
+      return EntryResponse::More;
+    }
+  };
+
+  using Consumer = current::ss::EntrySubscriber<ConsumerImpl, std::string>;
+
+  Consumer c;
+  MMPQ<std::string, Consumer> mmpq(c);
+
+  // Publish "one". It gets to the consumer immediately.
+  mmpq.Publish("one", std::chrono::microseconds(1));
+  while (c.processed_messages_ != 1) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = one", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("one @ 1", current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Publish "two", "three", and "four". The first one to get published is "three", but, as it's published
+  // into the future, it won't get processed until "four" is. Note the index of "two" is `3`, not `2`.
+  mmpq.PublishIntoTheFuture("three", std::chrono::microseconds(3));
+  mmpq.Publish("two", std::chrono::microseconds(2));
+  while (c.processed_messages_ != 2) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = one, [3] = two", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("one @ 1, two @ 2", current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Finally, publish "four". As it's past "three", the consumer will get both "three" and "four".
+  mmpq.Publish("four", std::chrono::microseconds(4));
+  while (c.processed_messages_ != 4) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = one, [3] = two, [2] = three, [4] = four", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("one @ 1, two @ 2, three @ 3, four @ 4", current::strings::Join(c.messages_by_timestamps_, ", "));
+}
+
+TEST(InMemoryMQ, MMPQSupportsUpdateHead) {
+  struct ConsumerImpl {
+    std::vector<std::string> messages_by_indexes_;
+    std::vector<std::string> messages_by_timestamps_;
+    std::atomic_size_t processed_messages_;
+    ConsumerImpl() : processed_messages_(0u) {}
+    EntryResponse operator()(const std::string& s, idxts_t idxts, idxts_t) {
+      messages_by_indexes_.push_back("[" + current::ToString(idxts.index) + "] = " + s);
+      messages_by_timestamps_.push_back(s + " @ " + current::ToString(idxts.us));
+      ++processed_messages_;
+      return EntryResponse::More;
+    }
+  };
+
+  using Consumer = current::ss::EntrySubscriber<ConsumerImpl, std::string>;
+
+  Consumer c;
+  MMPQ<std::string, Consumer> mmpq(c);
+
+  // Start with "three": publish and confirm it goes through.
+  mmpq.Publish("three", std::chrono::microseconds(3));
+  while (c.processed_messages_ != 1) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = three", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("three @ 3", current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Follow up with "seven". Without `UpdateHead()` it won't get to the consumer. With `UpdateHead()` it does.
+  mmpq.PublishIntoTheFuture("seven", std::chrono::microseconds(7));
+  mmpq.UpdateHead(std::chrono::microseconds(7));
+  while (c.processed_messages_ != 2) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = three, [2] = seven", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("three @ 3, seven @ 7", current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Can't publish anything prior to "seven", as HEAD is already at `7`.
+  ASSERT_THROW(mmpq.Publish("five", std::chrono::microseconds(5)), current::ss::InconsistentTimestampException);
+  ASSERT_THROW(mmpq.Publish("another seven", std::chrono::microseconds(7)),
+               current::ss::InconsistentTimestampException);
+
+  // Confirm `UpdateHead()` prevents publishing into the past compared to itself as well.
+  // Here, as HEAD is bumped to `21`, publishing "eleven", as well as "blackjack" should correctly fail.
+  mmpq.UpdateHead(std::chrono::microseconds(25));
+  ASSERT_THROW(mmpq.Publish("eleven", std::chrono::microseconds(11)), current::ss::InconsistentTimestampException);
+  ASSERT_THROW(mmpq.Publish("blackjack", std::chrono::microseconds(21)), current::ss::InconsistentTimestampException);
+
+  // Publish an "ace" at 100.
+  mmpq.Publish("ace", std::chrono::microseconds(100));
+  while (c.processed_messages_ != 3) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = three, [2] = seven, [3] = ace", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("three @ 3, seven @ 7, ace @ 100", current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Now, at `t=100`, publish three more messages at {101,102,103}, all into the future, in a mixed up order.
+  mmpq.PublishIntoTheFuture("queen", std::chrono::microseconds(102));
+  mmpq.PublishIntoTheFuture("king", std::chrono::microseconds(101));
+  mmpq.PublishIntoTheFuture("jack", std::chrono::microseconds(103));
+
+  // Update HEAD to capture just one of the three, to `t=101`, and confirm "king" does get to the consumer.
+  mmpq.UpdateHead(std::chrono::microseconds(101));
+  while (c.processed_messages_ != 4) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = three, [2] = seven, [3] = ace, [5] = king", current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("three @ 3, seven @ 7, ace @ 100, king @ 101", current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Update HEAD to capture the second one of three, to `t=102`, and confirm "queen" does get to the consumer.
+  mmpq.UpdateHead(std::chrono::microseconds(102));
+  while (c.processed_messages_ != 5) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = three, [2] = seven, [3] = ace, [5] = king, [4] = queen",
+            current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("three @ 3, seven @ 7, ace @ 100, king @ 101, queen @ 102",
+            current::strings::Join(c.messages_by_timestamps_, ", "));
+
+  // Finally, publish "joker", in the "present" which is way ahead in time compared to the third one left, the "jack".
+  // This publish into "present" would force the consumer to process both the outstanding "jack" and the "joker" itself.
+  mmpq.Publish("joker", std::chrono::microseconds(1000));
+  while (c.processed_messages_ != 7) {
+    ;  // Spin lock;
+  }
+  EXPECT_EQ("[1] = three, [2] = seven, [3] = ace, [5] = king, [4] = queen, [6] = jack, [7] = joker",
+            current::strings::Join(c.messages_by_indexes_, ", "));
+  EXPECT_EQ("three @ 3, seven @ 7, ace @ 100, king @ 101, queen @ 102, jack @ 103, joker @ 1000",
+            current::strings::Join(c.messages_by_timestamps_, ", "));
 }

--- a/Blocks/Persistence/exceptions.h
+++ b/Blocks/Persistence/exceptions.h
@@ -42,26 +42,6 @@ struct MalformedEntryException : PersistenceException {
   using PersistenceException::PersistenceException;
 };
 
-struct InconsistentIndexOrTimestampException : PersistenceException {
-  using PersistenceException::PersistenceException;
-};
-
-struct InconsistentIndexException : InconsistentIndexOrTimestampException {
-  using InconsistentIndexOrTimestampException::InconsistentIndexOrTimestampException;
-  InconsistentIndexException(uint64_t expected, uint64_t found) {
-    using current::strings::Printf;
-    SetWhat(Printf("Expecting index %llu, seeing %llu.", expected, found));
-  }
-};
-
-struct InconsistentTimestampException : InconsistentIndexOrTimestampException {
-  using InconsistentIndexOrTimestampException::InconsistentIndexOrTimestampException;
-  InconsistentTimestampException(std::chrono::microseconds expected, std::chrono::microseconds found) {
-    using current::strings::Printf;
-    SetWhat(Printf("Expecting timestamp >= %llu, seeing %llu.", expected.count(), found.count()));
-  }
-};
-
 struct InvalidIterableRangeException : PersistenceException {
   using PersistenceException::PersistenceException;
 };

--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -72,11 +72,11 @@ class IteratorOverFileOfPersistedEntries {
       const auto current = ParseJSON<idxts_t>(line_.substr(0, tab_pos));
       if (current.index != next_.index) {
         // Indexes must be strictly continuous.
-        CURRENT_THROW(InconsistentIndexException(next_.index, current.index));
+        CURRENT_THROW(ss::InconsistentIndexException(next_.index, current.index));
       }
       if (current.us < next_.us) {
         // Timestamps must monotonically increase.
-        CURRENT_THROW(InconsistentTimestampException(next_.us, current.us));
+        CURRENT_THROW(ss::InconsistentTimestampException(next_.us, current.us));
       }
       f(current, line_.c_str() + tab_pos + 1);
       next_ = current;
@@ -235,8 +235,8 @@ class FilePersister {
                   found = true;
                   result.idx_ts = cursor;
                   result.entry = ParseJSON<ENTRY>(json);
-                } else if (cursor.index > i_) {                                 // LCOV_EXCL_LINE
-                  CURRENT_THROW(InconsistentIndexException(i_, cursor.index));  // LCOV_EXCL_LINE
+                } else if (cursor.index > i_) {                                     // LCOV_EXCL_LINE
+                  CURRENT_THROW(ss::InconsistentIndexException(i_, cursor.index));  // LCOV_EXCL_LINE
                 }
               }))) {
             // End of file. Should never happen as long as the user only iterates over valid ranges.
@@ -303,7 +303,7 @@ class FilePersister {
   idxts_t DoPublish(E&& entry, const std::chrono::microseconds timestamp) {
     end_t iterator = file_persister_impl_->end.load();
     if (timestamp < iterator.us) {
-      CURRENT_THROW(InconsistentTimestampException(iterator.us, timestamp));
+      CURRENT_THROW(ss::InconsistentTimestampException(iterator.us, timestamp));
     }
     iterator.us = timestamp;
     const auto current = idxts_t(iterator.index, iterator.us);

--- a/Blocks/Persistence/memory.h
+++ b/Blocks/Persistence/memory.h
@@ -128,7 +128,7 @@ class MemoryPersister {
     if (!container_->entries.empty()) {
       const std::chrono::microseconds expected = container_->entries.back().first;
       if (!(timestamp > expected)) {
-        CURRENT_THROW(InconsistentTimestampException(expected + std::chrono::microseconds(1), timestamp));
+        CURRENT_THROW(ss::InconsistentTimestampException(expected + std::chrono::microseconds(1), timestamp));
       }
     }
     const auto index = static_cast<uint64_t>(container_->entries.size());

--- a/Blocks/Persistence/test.cc
+++ b/Blocks/Persistence/test.cc
@@ -203,6 +203,7 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
         if (!iterator) {
           break;
         }
+        std::this_thread::yield();
       }
     }
 
@@ -217,6 +218,7 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
         if (!iterable) {
           break;
         }
+        std::this_thread::yield();
       }
     }
 
@@ -497,6 +499,7 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
         if (!iterator) {
           break;
         }
+        std::this_thread::yield();
       }
     }
 
@@ -511,6 +514,7 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
         if (!iterable) {
           break;
         }
+        std::this_thread::yield();
       }
     }
 

--- a/Blocks/Persistence/test.cc
+++ b/Blocks/Persistence/test.cc
@@ -143,7 +143,7 @@ TEST(PersistenceLayer, MemoryExceptions) {
     impl.Publish("2", std::chrono::microseconds(2));
     current::time::ResetToZero();
     current::time::SetNow(std::chrono::microseconds(1));
-    ASSERT_THROW(impl.Publish("1"), current::persistence::InconsistentTimestampException);
+    ASSERT_THROW(impl.Publish("1"), current::ss::InconsistentTimestampException);
   }
 
   {
@@ -152,7 +152,7 @@ TEST(PersistenceLayer, MemoryExceptions) {
     current::time::SetNow(std::chrono::microseconds(3));
     IMPL impl;
     impl.Publish("2");
-    ASSERT_THROW(impl.Publish("1"), current::persistence::InconsistentTimestampException);
+    ASSERT_THROW(impl.Publish("1"), current::ss::InconsistentTimestampException);
   }
 
   {
@@ -342,7 +342,7 @@ TEST(PersistenceLayer, FileExceptions) {
     impl.Publish("2");
     current::time::ResetToZero();
     current::time::SetNow(std::chrono::microseconds(1));
-    ASSERT_THROW(impl.Publish("1"), current::persistence::InconsistentTimestampException);
+    ASSERT_THROW(impl.Publish("1"), current::ss::InconsistentTimestampException);
   }
 
   {
@@ -352,7 +352,7 @@ TEST(PersistenceLayer, FileExceptions) {
     current::time::SetNow(std::chrono::microseconds(3));
     IMPL impl(persistence_file_name);
     impl.Publish("2");
-    ASSERT_THROW(impl.Publish("1"), current::persistence::InconsistentTimestampException);
+    ASSERT_THROW(impl.Publish("1"), current::ss::InconsistentTimestampException);
   }
 
   {
@@ -525,9 +525,9 @@ TEST(PersistenceLayer, Exceptions) {
   using namespace persistence_test;
   using IMPL = current::persistence::File<StorableString>;
   using current::ss::IndexAndTimestamp;
+  using current::ss::InconsistentTimestampException;
+  using current::ss::InconsistentIndexException;
   using current::persistence::MalformedEntryException;
-  using current::persistence::InconsistentIndexException;
-  using current::persistence::InconsistentTimestampException;
 
   const std::string persistence_file_name = current::FileSystem::JoinPath(FLAGS_persistence_test_tmpdir, "data");
 

--- a/Blocks/SS/idx_ts.h
+++ b/Blocks/SS/idx_ts.h
@@ -44,6 +44,26 @@ CURRENT_STRUCT(IndexAndTimestamp) {
   CURRENT_CONSTRUCTOR(IndexAndTimestamp)(uint64_t index, std::chrono::microseconds us) : index(index), us(us) {}
 };
 
+struct InconsistentIndexOrTimestampException : Exception {
+  using Exception::Exception;
+};
+
+struct InconsistentIndexException : InconsistentIndexOrTimestampException {
+  using InconsistentIndexOrTimestampException::InconsistentIndexOrTimestampException;
+  InconsistentIndexException(uint64_t expected, uint64_t found) {
+    using current::strings::Printf;
+    SetWhat(Printf("Expecting index %llu, seeing %llu.", expected, found));
+  }
+};
+
+struct InconsistentTimestampException : InconsistentIndexOrTimestampException {
+  using InconsistentIndexOrTimestampException::InconsistentIndexOrTimestampException;
+  InconsistentTimestampException(std::chrono::microseconds expected, std::chrono::microseconds found) {
+    using current::strings::Printf;
+    SetWhat(Printf("Expecting timestamp >= %llu, seeing %llu.", expected.count(), found.count()));
+  }
+};
+
 }  // namespace current::ss
 }  // namespace current
 

--- a/EventCollector/test.cc
+++ b/EventCollector/test.cc
@@ -74,7 +74,7 @@ TEST(EventCollector, Smoke) {
 
   current::time::SetNow(std::chrono::microseconds(112000));
   while (collector.EventsPushed() < 2u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
 
   current::time::SetNow(std::chrono::microseconds(178000));
@@ -84,7 +84,7 @@ TEST(EventCollector, Smoke) {
 
   current::time::SetNow(std::chrono::microseconds(278000));
   while (collector.EventsPushed() < 4u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
 
   // Strip headers from test output since they are platform dependent.

--- a/Karl/test.cc
+++ b/Karl/test.cc
@@ -472,10 +472,10 @@ TEST(Karl, DeregisterWithNginx) {
   {
     // Must wait for Nginx config reload to take effect.
     while (HTTP(GET(is_prime_proxied_status_url)).code != HTTPResponseCode.NotFound) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));  // Spin lock.
+      std::this_thread::yield();
     }
     while (HTTP(GET(generator_proxied_status_url)).code != HTTPResponseCode.NotFound) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));  // Spin lock.
+      std::this_thread::yield();
     }
   }
 }
@@ -498,7 +498,7 @@ TEST(Karl, DisconnectedByTimout) {
     const auto response = HTTP(POST(keepalive_url, claire));
     EXPECT_EQ(200, static_cast<int>(response.code));
     while (karl.ActiveServicesCount() == 0u) {
-      std::this_thread::yield();  // Spin lock.
+      std::this_thread::yield();
     }
     const auto result =
         karl.InternalExposeStorage().ReadOnlyTransaction([&](ImmutableFields<unittest_karl_t::storage_t> fields) {
@@ -553,7 +553,7 @@ TEST(Karl, DisconnectedByTimoutWithNginx) {
     const auto response = HTTP(POST(keepalive_url, claire));
     EXPECT_EQ(200, static_cast<int>(response.code));
     while (karl.ActiveServicesCount() == 0u) {
-      std::this_thread::yield();  // Spin lock.
+      std::this_thread::yield();
     }
     const auto result =
         karl.InternalExposeStorage().ReadOnlyTransaction([&](ImmutableFields<unittest_karl_t::storage_t> fields) {
@@ -688,7 +688,7 @@ TEST(Karl, ChangeKarlWhichClaireReportsTo) {
   }
 
   while (secondary_karl.ActiveServicesCount() == 0u) {
-    std::this_thread::yield();  // Spin lock.
+    std::this_thread::yield();
   }
   // The `generator` service is registered in the secondary `Karl`.
   {
@@ -726,7 +726,7 @@ TEST(Karl, ChangeKarlWhichClaireReportsTo) {
   }
 
   while (primary_karl.ActiveServicesCount() == 0u) {
-    std::this_thread::yield();  // Spin lock.
+    std::this_thread::yield();
   }
   // The `generator` service is again registered as active in the primary `Karl`.
   {
@@ -978,7 +978,7 @@ TEST(Karl, KarlNotifiesUserObject) {
   EXPECT_EQ(current::strings::Join(expected, ", "), current::strings::Join(karl_notifications_receiver.events, ", "));
 
   while (karl.ActiveServicesCount()) {
-    std::this_thread::yield();  // Spin lock.
+    std::this_thread::yield();
   }
 
   // Now, the timeout test with respect to callbacks.
@@ -996,7 +996,7 @@ TEST(Karl, KarlNotifiesUserObject) {
       const auto response = HTTP(POST(keepalive_url, claire));
       EXPECT_EQ(200, static_cast<int>(response.code));
       while (karl.ActiveServicesCount() != 1u) {
-        std::this_thread::yield();  // Spin lock.
+        std::this_thread::yield();
       }
     }
     expected.push_back("Keepalive: ABCDEF");

--- a/Karl/test.cc
+++ b/Karl/test.cc
@@ -472,10 +472,12 @@ TEST(Karl, DeregisterWithNginx) {
   {
     // Must wait for Nginx config reload to take effect.
     while (HTTP(GET(is_prime_proxied_status_url)).code != HTTPResponseCode.NotFound) {
-      std::this_thread::yield();
+      // Spin lock, exprerimentally confirmed to be better than `std::this_thread::yield()` here.
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     while (HTTP(GET(generator_proxied_status_url)).code != HTTPResponseCode.NotFound) {
-      std::this_thread::yield();
+      // Spin lock, exprerimentally confirmed to be better than `std::this_thread::yield()` here.
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
 }

--- a/Midichlorians/Client/test.cc
+++ b/Midichlorians/Client/test.cc
@@ -141,7 +141,7 @@ TEST(MidichloriansClient, iOSSmokeTest) {
   [Midichlorians focusEvent:NO source:@"applicationDidEnterBackground"];
 
   while (server.MessagesProcessed() < 5u) {
-    ;  // spin lock.
+    std::this_thread::yield();
   }
 
   EXPECT_EQ(5u, server.Messages().size());

--- a/Midichlorians/Server/test.cc
+++ b/Midichlorians/Server/test.cc
@@ -204,7 +204,7 @@ TEST(MidichloriansServer, iOSEventsFromCPPSmokeTest) {
   current::time::SetNow(std::chrono::microseconds(112000));
   // Waiting for 3 entries: 1 valid, 1 unparsable and 1 tick.
   while (consumer.EventsAndErrorsTotalCount() < 3u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
   EXPECT_EQ(2u, consumer.EventsCount());
   EXPECT_EQ(1u, consumer.ErrorsCount());
@@ -225,7 +225,7 @@ TEST(MidichloriansServer, iOSEventsFromCPPSmokeTest) {
   current::time::SetNow(std::chrono::microseconds(450000));
   // Waiting for 4 more entries: 2 valid, 1 unparsable and 1 tick.
   while (consumer.EventsAndErrorsTotalCount() < 7u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
 
   EXPECT_EQ(5u, consumer.EventsCount());
@@ -270,7 +270,7 @@ TEST(MidichloriansServer, iOSEventsFromNativeClientSmokeTest) {
   [Midichlorians focusEvent:NO source:@"applicationDidEnterBackground"];
 
   while (consumer.EventsAndErrorsTotalCount() < 5u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
 
   EXPECT_EQ(
@@ -340,7 +340,7 @@ TEST(MidichloriansServer, WebEventsFromCPPSmokeTest) {
   HTTP(MockGETRequest(server_url, 10, "action", "category"));
 
   while (consumer.EventsAndErrorsTotalCount() < 5u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
 
   EXPECT_EQ(

--- a/Storage/transaction_policy.h
+++ b/Storage/transaction_policy.h
@@ -291,7 +291,7 @@ class Synchronous final {
   void PersistJournal() {
     try {
       persister_.PersistJournal(journal_);
-    } catch (const persistence::InconsistentTimestampException& e) {
+    } catch (const ss::InconsistentTimestampException& e) {
       std::cerr << "PersistJournal() failed with InconsistentTimestampException: " << e.what() << std::endl;
 #ifdef CURRENT_MOCK_TIME
       std::cerr << "Binary is compiled with `CURRENT_MOCK_TIME`. Probably `SetNow()` wasn't properly called."

--- a/examples/EventStore/test.cc
+++ b/examples/EventStore/test.cc
@@ -77,7 +77,7 @@ TEST(EventStore, SmokeWithInMemoryEventStore) {
   }
 
   while (event_store.readonly_nonstorage_event_log_persister.Size() < 1u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
   EXPECT_EQ(1u, event_store.readonly_nonstorage_event_log_persister.Size());
   EXPECT_EQ("haha",
@@ -126,7 +126,7 @@ TEST(EventStore, SmokeWithDiskPersistedEventStore) {
     }
 
     while (event_store.readonly_nonstorage_event_log_persister.Size() < 1u) {
-      ;  // Spin lock.
+      std::this_thread::yield();
     }
     EXPECT_EQ(1u, event_store.readonly_nonstorage_event_log_persister.Size());
     EXPECT_EQ("haha",
@@ -195,7 +195,7 @@ TEST(EventStore, SmokeWithHTTP) {
   }
 
   while (event_store.readonly_nonstorage_event_log_persister.Size() < 1u) {
-    ;  // Spin lock.
+    std::this_thread::yield();
   }
   EXPECT_EQ(1u, event_store.readonly_nonstorage_event_log_persister.Size());
   EXPECT_EQ("1\n",


### PR DESCRIPTION
Hi @mzhurovich and CC @grixa.

I've put together a piece of logic to allow joining events from the future with events from the present using timestamps as sort keys.

The last two tests should be self-explanatory. Requires comments are:

* I've kept MMQ (and MMPQ) indexes 1-based, as historically zero return code from MMQ's `Publish()` is used to indicate the message has been dropped.
* Obviously, `std::priority_queue<>` would outperform `std::set<>`, but sadly it doesn't allow extracting the top element by rvalue reference. This change is just to prove the semantics though; the production code would use `std::make_heap()` etc.
* @grixa, don't be quick to use this piece, as a) (although I generally like it) it's just an architectural suggestion which may evolve, and b) more cool stuff is coming soon.

Thanks,
Dima