### PR TITLE
Incorporated MMPQ into RipCurrent.

### DIFF
--- a/Bricks/sync/test.cc
+++ b/Bricks/sync/test.cc
@@ -267,6 +267,20 @@ TEST(WaitableAtomic, Smoke) {
   EXPECT_EQ(copy_of_object.y + 1u, object.MutableUse([](Object& object) { return ++object.y; }));
 }
 
+TEST(WaitableAtomic, ProxyConstructor) {
+  using current::WaitableAtomic;
+
+  struct NonDefaultConstructibleObject {
+    int a;
+    int b;
+    NonDefaultConstructibleObject(int a, int b) : a(a), b(b) {}
+    int APlusB() const { return a + b; }
+  };
+
+  WaitableAtomic<NonDefaultConstructibleObject> object(1, 1);
+  EXPECT_EQ(2, object.GetValue().APlusB());
+}
+
 TEST(WaitableAtomic, IntrusiveClientsCanBeTransferred) {
   using current::WaitableAtomic;
   using current::IntrusiveClient;

--- a/Bricks/sync/waitable_atomic.h
+++ b/Bricks/sync/waitable_atomic.h
@@ -110,8 +110,9 @@ class WaitableAtomicImpl {
     using data_t = DATA;
     enum { IS_INTRUSIVE = false };
 
-    template<typename... ARGS>
-    BasicImpl(ARGS&&... args) : data_(std::forward<ARGS>(args)...) {}
+    template <typename... ARGS>
+    BasicImpl(ARGS&&... args)
+        : data_(std::forward<ARGS>(args)...) {}
 
     BasicImpl(const DATA& data) : data_(data) {}
 

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -651,7 +651,7 @@ class UserCodeInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_
    private:
     class ThreadMessageCounters {
      public:
-      ThreadMessageCounters(int a, int b) : published_(a), processed_(b) {}
+      ThreadMessageCounters(int published, int processed) : published_(published), processed_(processed) {}
       void ReportMessagePublished() { ++published_; }
       void ReportMessageNotQuitePublished() { --published_; }
       void ReportMessageProcessed() { ++processed_; }

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -506,16 +506,16 @@ class HasEmit<LHSTypes<NEXT_TYPES...>> : public AbstractHasEmit {
   template <typename T, typename... ARGS>
   std::enable_if_t<TypeListContains<TypeListImpl<NEXT_TYPES...>, T>::value> emit(ARGS&&... args) const {
     // A seemingly unnecessary `release()` is due to `std::make_unique()` not supporting a custom deleter. -- D.K
-    next_handler_->OnThreadUnsafeEmitted(
-        std::move(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release())), time::Now());
+    next_handler_->OnThreadUnsafeEmitted(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release()),
+                                         time::Now());
   }
 
   template <typename T, typename... ARGS>
   std::enable_if_t<TypeListContains<TypeListImpl<NEXT_TYPES...>, T>::value> post(std::chrono::microseconds t,
                                                                                  ARGS&&... args) const {
     // A seemingly unnecessary `release()` is due to `std::make_unique()` not supporting a custom deleter. -- D.K
-    next_handler_->OnThreadUnsafeEmitted(
-        std::move(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release())), t);
+    next_handler_->OnThreadUnsafeEmitted(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release()),
+                                         t);
   }
 
   template <typename T, typename... ARGS>
@@ -523,7 +523,7 @@ class HasEmit<LHSTypes<NEXT_TYPES...>> : public AbstractHasEmit {
                                                                                      ARGS&&... args) const {
     // A seemingly unnecessary `release()` is due to `std::make_unique()` not supporting a custom deleter. -- D.K
     next_handler_->OnThreadUnsafeScheduled(
-        std::move(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release())), t);
+        movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release()), t);
   }
 
   void head(std::chrono::microseconds t) const { next_handler_->OnThreadUnsafeHeadUpdated(t); }

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -340,7 +340,7 @@ class RipCurrentScope final {
   RipCurrentScope(RipCurrentScope&& rhs)
       : scope_(std::move(rhs.scope_)),
         legitimately_terminated_(rhs.legitimately_terminated_),
-        description_as_text_(rhs.description_as_text_) {
+        description_as_text_(std::move(rhs.description_as_text_)) {
     rhs.legitimately_terminated_ = true;
   }
   void Join() {

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -424,7 +424,7 @@ class SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
     std::ostringstream os;
     super_t::GetDefinition().FullDescription(os);
 
-    return RipCurrentScope(std::move(SpawnAndRun(std::make_shared<EmitDestination<LHSTypes<>>>())), os.str());
+    return RipCurrentScope(SpawnAndRun(std::make_shared<EmitDestination<LHSTypes<>>>()), os.str());
   }
 
  private:

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -424,8 +424,7 @@ class SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
     std::ostringstream os;
     super_t::GetDefinition().FullDescription(os);
 
-    return std::move(
-        RipCurrentScope(std::move(SpawnAndRun(std::make_shared<EmitDestination<LHSTypes<>>>())), os.str()));
+    return RipCurrentScope(std::move(SpawnAndRun(std::make_shared<EmitDestination<LHSTypes<>>>())), os.str());
   }
 
  private:

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -28,16 +28,17 @@ SOFTWARE.
 // Building blocks can be output-only ("LHS"), input-only ("RHS"), in/out ("VIA"), or end-to-end ("E2E").
 // No buliding block, simple or composite, can be left hanging. Each one should be used, run, described,
 // or dismissed.
-// End-to-end blocks can be run with `(...).RipCurrent().Sync()`. TODO(dkorolev): Not only `.Sync()`.
+//
+// End-to-end blocks can be run with `(...).RipCurrent().Join()`. Another option is to save the return value
+// of `(...).RipCurrent()` into some `scope` variable, which must be `.Join()`-ed at a later time. Finally,
+// the `scope` variable can be called `.Async()` on, which would eliminate the need to explicitly call `.Join()`
+// at the end of its lifetime; and the syntax of `auto scope = (...).RipCurrent().Async();` is supported as well.
 //
 // HI-PRI:
 // TODO(dkorolev): ParseFileByLines() and/or TailFileForever() as possible LHS.
 // TODO(dkorolev): Sherlock listener as possible LHS.
-// TODO(dkorolev): MMQ.
-// TODO(dkorolev): Threads and joins, run forever.
 // TODO(dkorolev): The `+`-combiner.
 // TODO(dkorolev): Syntax for no-MMQ and no-multithreading message passing (`| !foo`, `| ~foo`).
-// TODO(dkorolev): Run scoping strategies others than `.Sync()`.
 //
 // LO-PRI:
 // TODO(dkorolev): Add debug output counters / HTTP endpoint for # of messages per typeid.
@@ -60,14 +61,19 @@ SOFTWARE.
 #include "../TypeSystem/struct.h"
 #include "../TypeSystem/remove_parentheses.h"
 
+#include "../Blocks/MMQ/mmpq.h"
+
 #include "../Bricks/strings/join.h"
-#include "../Bricks/template/typelist.h"
+#include "../Bricks/sync/waitable_atomic.h"
 #include "../Bricks/template/rtti_dynamic_call.h"
+#include "../Bricks/template/typelist.h"
 #include "../Bricks/util/lazy_instantiation.h"
 #include "../Bricks/util/singleton.h"
 
 namespace current {
 namespace ripcurrent {
+
+using movable_message_t = std::unique_ptr<CurrentSuper, CurrentSuperDeleter>;
 
 template <typename... TS>
 class LHSTypes;
@@ -286,7 +292,9 @@ class SharedDefinition<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> {
 class GenericEmitDestination {
  public:
   virtual ~GenericEmitDestination() = default;
-  virtual void OnEmitted(CurrentSuper&&) = 0;
+  virtual void OnThreadUnsafeEmitted(movable_message_t&&, std::chrono::microseconds) = 0;
+  virtual void OnThreadUnsafeScheduled(movable_message_t&&, std::chrono::microseconds) = 0;
+  virtual void OnThreadUnsafeHeadUpdated(std::chrono::microseconds) = 0;
 };
 
 template <class LHS_TYPELIST>
@@ -298,34 +306,18 @@ class EmitDestination<LHSTypes<LHS_XS...>> : public GenericEmitDestination {};
 template <>
 class EmitDestination<LHSTypes<>> : public GenericEmitDestination {
  public:
-  void OnEmitted(CurrentSuper&&) override {
+  void OnThreadUnsafeEmitted(movable_message_t&&, std::chrono::microseconds) override {
     std::cerr << "Not expecting any entries to be sent to a non-consuming \"consumer\".\n";
     CURRENT_ASSERT(false);
   }
-};
-
-// Run context for RipCurrent allows to run it in background, foreground, or scoped.
-// TODO(dkorolev): Only supports `.Sync()` now. Implement everything else.
-class RipCurrentScope final {
- public:
-  explicit RipCurrentScope(const std::string& error_message) : sync_called_(false), error_message_(error_message) {}
-  RipCurrentScope(RipCurrentScope&& rhs) : error_message_(rhs.error_message_) {
-    CURRENT_ASSERT(!rhs.sync_called_);
-    rhs.sync_called_ = true;
+  void OnThreadUnsafeScheduled(movable_message_t&&, std::chrono::microseconds) override {
+    std::cerr << "Not expecting any entries to be sent to a non-consuming \"consumer\".\n";
+    CURRENT_ASSERT(false);
   }
-  void Sync() {
-    CURRENT_ASSERT(!sync_called_);
-    sync_called_ = true;
+  virtual void OnThreadUnsafeHeadUpdated(std::chrono::microseconds) override {
+    std::cerr << "Not expecting HEAD to be updated for a non-consuming \"consumer\".\n";
+    CURRENT_ASSERT(false);
   }
-  ~RipCurrentScope() {
-    if (!sync_called_) {
-      current::Singleton<RipCurrentMockableErrorHandler>().HandleError(error_message_);  // LCOV_EXCL_LINE
-    }
-  }
-
- private:
-  bool sync_called_ = false;
-  std::string error_message_;
 };
 
 template <class LHS_TYPELIST, class RHS_TYPELIST>
@@ -335,6 +327,52 @@ template <class... LHS_TYPES, class... RHS_TYPES>
 class SubCurrentScope<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>> : public EmitDestination<LHSTypes<LHS_TYPES...>> {
  public:
   virtual ~SubCurrentScope() = default;
+};
+
+// The run context for RipCurrent to allow running it synchronously (via `.RipCurrent().Join()`), or
+// asyncronously (via `auto scope = (...).RipCurrent(); ... scope.Join()`).
+class RipCurrentScope final {
+ public:
+  using scope_t = SubCurrentScope<LHSTypes<>, RHSTypes<>>;
+
+  RipCurrentScope(std::shared_ptr<scope_t> scope, const std::string& description_as_text)
+      : scope_(scope), legitimately_terminated_(false), description_as_text_(description_as_text) {}
+  RipCurrentScope(RipCurrentScope&& rhs)
+      : scope_(std::move(rhs.scope_)),
+        legitimately_terminated_(rhs.legitimately_terminated_),
+        description_as_text_(rhs.description_as_text_) {
+    rhs.legitimately_terminated_ = true;
+  }
+  void Join() {
+    if (legitimately_terminated_) {
+      current::Singleton<RipCurrentMockableErrorHandler>().HandleError(
+          "Attempted to call `RipCurrent::Join()` on a scope that has already been legitimately taken care of.\n" +
+          description_as_text_);  // LCOV_EXCL_LINE
+    }
+    legitimately_terminated_ = true;
+    scope_ = nullptr;
+  }
+  RipCurrentScope& Async() {
+    if (legitimately_terminated_) {
+      current::Singleton<RipCurrentMockableErrorHandler>().HandleError(
+          "Attempted to call `RipCurrent::Async()` on a scope that has already been legitimately taken care of.\n" +
+          description_as_text_);  // LCOV_EXCL_LINE
+    }
+    legitimately_terminated_ = true;
+    return *this;
+  }
+  ~RipCurrentScope() {
+    if (!legitimately_terminated_) {
+      current::Singleton<RipCurrentMockableErrorHandler>().HandleError(
+          "RipCurrent run context was left hanging. Call `.Join()` or `.Async()` on it.\n" +
+          description_as_text_);  // LCOV_EXCL_LINE
+    }
+  }
+
+ private:
+  std::shared_ptr<scope_t> scope_;
+  bool legitimately_terminated_ = false;
+  std::string description_as_text_;
 };
 
 // Template logic to wrap the above implementations into abstract classes of proper templated types.
@@ -382,14 +420,12 @@ class SharedCurrent<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>>
 
   // User-facing `RipCurrent()` method.
   template <int IN_N = sizeof...(LHS_TYPES), int OUT_N = sizeof...(RHS_TYPES)>
-  std::enable_if_t<IN_N == 0 && OUT_N == 0, RipCurrentScope> RipCurrent() {
-    SpawnAndRun(std::make_shared<EmitDestination<LHSTypes<>>>());
-
-    // TODO(dkorolev): Return proper run context. So far, just require `.Sync()` to be called on it.
+  std::enable_if_t<IN_N == 0 && OUT_N == 0, RipCurrentScope> RipCurrent() const {
     std::ostringstream os;
-    os << "RipCurrent run context was left hanging. Call `.Sync()`, or, well, something else. -- D.K.\n";
     super_t::GetDefinition().FullDescription(os);
-    return std::move(RipCurrentScope(os.str()));
+
+    return std::move(
+        RipCurrentScope(std::move(SpawnAndRun(std::make_shared<EmitDestination<LHSTypes<>>>())), os.str()));
   }
 
  private:
@@ -468,13 +504,33 @@ class HasEmit<LHSTypes<NEXT_TYPES...>> : public AbstractHasEmit {
   virtual ~HasEmit() = default;
 
  protected:
-  template <typename T>
-  std::enable_if_t<TypeListContains<TypeListImpl<NEXT_TYPES...>, current::decay<T>>::value> emit(T&& x) const {
-    next_handler_->OnEmitted(std::forward<T>(x));
+  template <typename T, typename... ARGS>
+  std::enable_if_t<TypeListContains<TypeListImpl<NEXT_TYPES...>, T>::value> emit(ARGS&&... args) const {
+    // A seemingly unnecessary `release()` is due to `std::make_unique()` not supporting a custom deleter. -- D.K
+    next_handler_->OnThreadUnsafeEmitted(
+        std::move(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release())), time::Now());
   }
 
+  template <typename T, typename... ARGS>
+  std::enable_if_t<TypeListContains<TypeListImpl<NEXT_TYPES...>, T>::value> post(std::chrono::microseconds t,
+                                                                                 ARGS&&... args) const {
+    // A seemingly unnecessary `release()` is due to `std::make_unique()` not supporting a custom deleter. -- D.K
+    next_handler_->OnThreadUnsafeEmitted(
+        std::move(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release())), t);
+  }
+
+  template <typename T, typename... ARGS>
+  std::enable_if_t<TypeListContains<TypeListImpl<NEXT_TYPES...>, T>::value> schedule(std::chrono::microseconds t,
+                                                                                     ARGS&&... args) const {
+    // A seemingly unnecessary `release()` is due to `std::make_unique()` not supporting a custom deleter. -- D.K
+    next_handler_->OnThreadUnsafeScheduled(
+        std::move(movable_message_t(std::make_unique<T>(std::forward<ARGS>(args)...).release())), t);
+  }
+
+  void head(std::chrono::microseconds t) const { next_handler_->OnThreadUnsafeHeadUpdated(t); }
+
  private:
-  EmitDestination<LHSTypes<NEXT_TYPES...>>* const next_handler_;
+  emit_destination_t* next_handler_;
 };
 
 template <typename LHS_TYPELIST, typename RHS_TYPELIST, typename USER_CLASS>
@@ -488,8 +544,8 @@ class EventConsumerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, U
   EventConsumerInitializer(std::shared_ptr<EmitDestination<LHSTypes<RHS_TYPES...>>> next, ARGS&&... args)
       : scope_(&impl_, next.get()), impl_(std::forward<ARGS>(args)...) {}
 
-  void Accept(CurrentSuper&& x) {
-    RTTIDynamicCall<TypeListImpl<LHS_TYPES...>>(std::move(x), *this);
+  void OnThreadSafeEmitted(movable_message_t&& x) {
+    RTTIDynamicCall<TypeListImpl<LHS_TYPES...>, CurrentSuper>(std::move(*x), *this);
   }
 
   template <typename X>
@@ -550,20 +606,83 @@ class UserCodeInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_
 
   class Scope final : public SubCurrentScope<instantiator_input_t, instantiator_output_t> {
    public:
-    virtual ~Scope() = default;
-
     explicit Scope(const current::LazilyInstantiated<
                        EventConsumerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>,
                        std::shared_ptr<EmitDestination<LHSTypes<RHS_TYPES...>>>>& lazy_instance,
                    std::shared_ptr<EmitDestination<LHSTypes<RHS_TYPES...>>> next)
-        : next_(next), spawned_user_class_instance_(lazy_instance.InstantiateAsUniquePtrWithExtraParameter(next_)) {}
+        : next_(next),
+          spawned_user_class_instance_(lazy_instance.InstantiateAsUniquePtrWithExtraParameter(next_)),
+          waitable_counters_(0u, 0u),
+          single_threaded_processor_(waitable_counters_, *spawned_user_class_instance_),
+          mmq_(single_threaded_processor_) {}
 
-    void OnEmitted(CurrentSuper&& x) override { spawned_user_class_instance_->Accept(std::move(x)); }
+    virtual ~Scope() {
+      // TODO(dkorolev): Consider other termination strategies, not just the plain "process everything" one.
+      waitable_counters_.Wait([](const ThreadMessageCounters& p) { return p.ProcessedEverything(); });
+    }
+
+    void OnThreadUnsafeEmitted(movable_message_t&& x, std::chrono::microseconds t) override {
+      waitable_counters_.MutableUse([](ThreadMessageCounters& p) { p.ReportMessagePublished(); });
+      try {
+        mmq_.Publish(std::move(x), t);
+      } catch (const ss::InconsistentTimestampException& e) {
+        current::Singleton<RipCurrentMockableErrorHandler>().HandleError(e.What());
+        waitable_counters_.MutableUse([](ThreadMessageCounters& p) { p.ReportMessageNotQuitePublished(); });
+      }
+    }
+
+    void OnThreadUnsafeScheduled(movable_message_t&& x, std::chrono::microseconds t) override {
+      waitable_counters_.MutableUse([](ThreadMessageCounters& p) { p.ReportMessagePublished(); });
+      try {
+        mmq_.PublishIntoTheFuture(std::move(x), t);
+      } catch (const ss::InconsistentTimestampException& e) {
+        current::Singleton<RipCurrentMockableErrorHandler>().HandleError(e.What());
+        waitable_counters_.MutableUse([](ThreadMessageCounters& p) { p.ReportMessageNotQuitePublished(); });
+      }
+    }
+
+    virtual void OnThreadUnsafeHeadUpdated(std::chrono::microseconds t) override {
+      try {
+        mmq_.UpdateHead(t);
+      } catch (const ss::InconsistentTimestampException& e) {
+        current::Singleton<RipCurrentMockableErrorHandler>().HandleError(e.What());
+      }
+    }
 
    private:
+    class ThreadMessageCounters {
+     public:
+      ThreadMessageCounters(int a, int b) : published_(a), processed_(b) {}
+      void ReportMessagePublished() { ++published_; }
+      void ReportMessageNotQuitePublished() { --published_; }
+      void ReportMessageProcessed() { ++processed_; }
+      bool ProcessedEverything() const { return published_ == processed_; }
+
+     private:
+      int published_;
+      int processed_;
+    };
+    using instance_t = EventConsumerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>;
+    using waitable_counters_t = WaitableAtomic<ThreadMessageCounters>;
+
+    struct SingleThreadedProcessorImpl {
+      SingleThreadedProcessorImpl(waitable_counters_t& waitable_counters, instance_t& instance)
+          : waitable_counters_(waitable_counters), instance_(instance) {}
+      ss::EntryResponse operator()(movable_message_t&& e, idxts_t, idxts_t) {
+        instance_.OnThreadSafeEmitted(std::move(e));
+        waitable_counters_.MutableUse([](ThreadMessageCounters& p) { p.ReportMessageProcessed(); });
+        return ss::EntryResponse::More;
+      }
+      waitable_counters_t& waitable_counters_;
+      instance_t& instance_;
+    };
+    using single_threaded_processor_t = current::ss::EntrySubscriber<SingleThreadedProcessorImpl, movable_message_t>;
+
     std::shared_ptr<EmitDestination<LHSTypes<RHS_TYPES...>>> next_;
-    std::unique_ptr<EventConsumerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>>
-        spawned_user_class_instance_;
+    std::unique_ptr<instance_t> spawned_user_class_instance_;
+    waitable_counters_t waitable_counters_;
+    single_threaded_processor_t single_threaded_processor_;
+    mmq::MMPQ<movable_message_t, single_threaded_processor_t> mmq_;
   };
 
   std::shared_ptr<SubCurrentScope<instantiator_input_t, instantiator_output_t>> SpawnAndRun(
@@ -643,7 +762,17 @@ class SharedSequenceImpl<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, VIAType
       self->MarkAs(BlockUsageBit::Run);
     }
 
-    void OnEmitted(CurrentSuper&& x) override { from_->OnEmitted(std::move(x)); }
+    void OnThreadUnsafeEmitted(movable_message_t&& x, std::chrono::microseconds t) override {
+      from_->OnThreadUnsafeEmitted(std::move(x), t);
+    }
+
+    void OnThreadUnsafeScheduled(movable_message_t&& x, std::chrono::microseconds t) override {
+      from_->OnThreadUnsafeScheduled(std::move(x), t);
+    }
+
+    virtual void OnThreadUnsafeHeadUpdated(std::chrono::microseconds t) override {
+      from_->OnThreadUnsafeHeadUpdated(t);
+    }
 
    private:
     // Construction / destruction order matters: { next, into, from }.
@@ -701,6 +830,29 @@ using RHS = SharedCurrent<LHS_TYPELIST, RHSTypes<>>;
 
 using E2E = SharedCurrent<LHSTypes<>, RHSTypes<>>;
 
+// The `RIPCURRENT_PASS` built-in building block.
+template <typename T, typename... TS>
+struct PassImplClassName {
+  static const char* RIPCURRENT_CLASS_NAME() { return "PassImpl"; }
+};
+
+template <typename T, typename... TS>
+struct PassImpl final : UserCode<LHSTypes<T, TS...>, RHSTypes<T, TS...>, PassImplClassName<T, TS...>> {
+  using super_t = UserCode<LHSTypes<T, TS...>, RHSTypes<T, TS...>, PassImplClassName<T, TS...>>;
+  template <typename X>
+  void f(X&& x) {
+    super_t::template emit<current::decay<X>>(std::forward<X>(x));
+  }
+};
+
+// Note: `struct Pass` will only be used if the uses chooses it over the `RIPCURRENT_PASS` one. The latter option
+// includes the names of the types in the type list into the description, which is better for practical purposes.
+template <typename T, typename... TS>
+struct Pass : UserCodeImpl<LHSTypes<T, TS...>, RHSTypes<T, TS...>, PassImpl<T, TS...>> {
+  using super_t = UserCodeImpl<LHSTypes<T, TS...>, RHSTypes<T, TS...>, PassImpl<T, TS...>>;
+  Pass() : super_t(Definition("PASS", __FILE__, __LINE__), std::make_tuple()) {}
+};
+
 }  // namespace current::ripcurrent
 }  // namespace current
 
@@ -719,6 +871,13 @@ using E2E = SharedCurrent<LHSTypes<>, RHSTypes<>>;
   ::current::ripcurrent::UserCodeImpl<typename USER_CLASS::input_t, typename USER_CLASS::output_t, USER_CLASS>( \
       ::current::ripcurrent::Definition(#USER_CLASS "(" #__VA_ARGS__ ")", __FILE__, __LINE__),                  \
       std::make_tuple(__VA_ARGS__))
+
+// A shortcut for `current::ripcurrent::Pass<...>()`, with the benefit of listing types as RipCurrent node name.
+#define RIPCURRENT_PASS(...)                                                                                     \
+  ::current::ripcurrent::UserCodeImpl<::current::ripcurrent::LHSTypes<CURRENT_REMOVE_PARENTHESES(__VA_ARGS__)>,  \
+                                      ::current::ripcurrent::RHSTypes<CURRENT_REMOVE_PARENTHESES(__VA_ARGS__)>,  \
+                                      ::current::ripcurrent::PassImpl<CURRENT_REMOVE_PARENTHESES(__VA_ARGS__)>>( \
+      ::current::ripcurrent::Definition("Pass(" #__VA_ARGS__ ")", __FILE__, __LINE__), std::make_tuple())
 
 // A helper macro to extract the underlying type of the user class, now registered as a RipCurrent block type.
 #define RIPCURRENT_UNDERLYING_TYPE(USER_CLASS) decltype(USER_CLASS.UnderlyingType())

--- a/RipCurrent/ripcurrent.h
+++ b/RipCurrent/ripcurrent.h
@@ -651,15 +651,15 @@ class UserCodeInstantiator<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_
    private:
     class ThreadMessageCounters {
      public:
-      ThreadMessageCounters(int published, int processed) : published_(published), processed_(processed) {}
+      ThreadMessageCounters(size_t published, size_t processed) : published_(published), processed_(processed) {}
       void ReportMessagePublished() { ++published_; }
       void ReportMessageNotQuitePublished() { --published_; }
       void ReportMessageProcessed() { ++processed_; }
       bool ProcessedEverything() const { return published_ == processed_; }
 
      private:
-      int published_;
-      int processed_;
+      size_t published_;
+      size_t processed_;
     };
     using instance_t = EventConsumerInitializer<LHSTypes<LHS_TYPES...>, RHSTypes<RHS_TYPES...>, USER_CLASS>;
     using waitable_counters_t = WaitableAtomic<ThreadMessageCounters>;
@@ -844,7 +844,7 @@ struct PassImpl final : UserCode<LHSTypes<T, TS...>, RHSTypes<T, TS...>, PassImp
   }
 };
 
-// Note: `struct Pass` will only be used if the uses chooses it over the `RIPCURRENT_PASS` one. The latter option
+// Note: `struct Pass` will only be used if the user chooses it over the `RIPCURRENT_PASS` one. The latter option
 // includes the names of the types in the type list into the description, which is better for practical purposes.
 template <typename T, typename... TS>
 struct Pass : UserCodeImpl<LHSTypes<T, TS...>, RHSTypes<T, TS...>, PassImpl<T, TS...>> {

--- a/RipCurrent/test.cc
+++ b/RipCurrent/test.cc
@@ -22,6 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#define CURRENT_MOCK_TIME
+
+#include "../port.h"
+
+#include <atomic>
+
 #include "ripcurrent.h"
 
 #include "../Bricks/dflags/dflags.h"
@@ -49,15 +55,15 @@ CURRENT_STRUCT(Integer) {
 RIPCURRENT_NODE(RCEmit, void, Integer) {
   static std::string UnitTestClassName() { return "RCEmit"; }
   RCEmit() {}  // LCOV_EXCL_LINE
-  RCEmit(int a) { emit(Integer(a)); }
+  RCEmit(int a) { emit<Integer>(a); }
   RCEmit(int a, int b) {
-    emit(Integer(a));
-    emit(Integer(b));
+    emit<Integer>(a);
+    emit<Integer>(b);
   }
   RCEmit(int a, int b, int c) {
-    emit(Integer(a));
-    emit(Integer(b));
-    emit(Integer(c));
+    emit<Integer>(a);
+    emit<Integer>(b);
+    emit<Integer>(c);
   }
 };
 #define RCEmit(...) RIPCURRENT_MACRO(RCEmit, __VA_ARGS__)
@@ -67,7 +73,7 @@ RIPCURRENT_NODE(RCMult, Integer, Integer) {
   static std::string UnitTestClassName() { return "RCMult"; }
   int k;
   RCMult(int k = 1) : k(k) {}
-  void f(Integer x) { emit(Integer(x.value * k)); }
+  void f(Integer x) { emit<Integer>(x.value * k); }
 };
 #define RCMult(...) RIPCURRENT_MACRO(RCMult, __VA_ARGS__)
 
@@ -75,11 +81,16 @@ RIPCURRENT_NODE(RCMult, Integer, Integer) {
 RIPCURRENT_NODE(RCDump, Integer, void) {
   static std::string UnitTestClassName() { return "RCDump"; }
   std::vector<int>* ptr;
+  std::atomic_size_t* cnt = nullptr;
   RCDump() : ptr(nullptr) {}  // LCOV_EXCL_LINE
   RCDump(std::vector<int>& ref) : ptr(&ref) {}
+  RCDump(std::vector<int>& ref, std::atomic_size_t& cnt) : ptr(&ref), cnt(&cnt) {}
   void f(Integer x) {
     CURRENT_ASSERT(ptr);
     ptr->push_back(x.value);
+    if (cnt) {
+      ++(*cnt);
+    }
   }
 };
 #define RCDump(...) RIPCURRENT_MACRO(RCDump, __VA_ARGS__)
@@ -119,20 +130,24 @@ TEST(RipCurrent, TypeStaticAsserts) {
 }
 
 TEST(RipCurrent, SingleEdgeFlow) {
+  current::time::ResetToZero();
+
   using namespace ripcurrent_unittest;
 
   std::vector<int> result;
 
-  (RCEmit(1, 2, 3) | RCDump(std::ref(result))).RipCurrent().Sync();
+  (RCEmit(1, 2, 3) | RCDump(std::ref(result))).RipCurrent().Join();
   EXPECT_EQ("1,2,3", current::strings::Join(result, ','));
 }
 
 TEST(RipCurrent, SingleChainFlow) {
+  current::time::ResetToZero();
+
   using namespace ripcurrent_unittest;
 
   std::vector<int> result;
 
-  (RCEmit(1, 2, 3) | RCMult(2) | RCMult(5) | RCMult(10) | RCDump(std::ref(result))).RipCurrent().Sync();
+  (RCEmit(1, 2, 3) | RCMult(2) | RCMult(5) | RCMult(10) | RCDump(std::ref(result))).RipCurrent().Join();
   EXPECT_EQ("100,200,300", current::strings::Join(result, ','));
 }
 
@@ -150,7 +165,7 @@ TEST(RipCurrent, DeclarationDoesNotRunConstructors) {
   EXPECT_EQ("RCEmit(42) | RCDump(std::ref(result))", emit_dump.Describe());
 
   EXPECT_EQ("", current::strings::Join(result, ','));
-  emit_dump.RipCurrent().Sync();
+  emit_dump.RipCurrent().Join();
   EXPECT_EQ("42", current::strings::Join(result, ','));
 }
 
@@ -164,19 +179,19 @@ TEST(RipCurrent, OrderDoesNotMatter) {
   const auto c = RCDump(std::ref(result));
 
   result.clear();
-  (a | b | b | c).RipCurrent().Sync();
+  (a | b | b | c).RipCurrent().Join();
   EXPECT_EQ("4", current::strings::Join(result, ','));
 
   result.clear();
-  ((a | b) | (b | c)).RipCurrent().Sync();
+  ((a | b) | (b | c)).RipCurrent().Join();
   EXPECT_EQ("4", current::strings::Join(result, ','));
 
   result.clear();
-  ((a | (b | b)) | c).RipCurrent().Sync();
+  ((a | (b | b)) | c).RipCurrent().Join();
   EXPECT_EQ("4", current::strings::Join(result, ','));
 
   result.clear();
-  (a | ((b | b) | c)).RipCurrent().Sync();
+  (a | ((b | b) | c)).RipCurrent().Join();
   EXPECT_EQ("4", current::strings::Join(result, ','));
 }
 
@@ -193,15 +208,15 @@ TEST(RipCurrent, BuildingBlocksCanBeReused) {
   current::ripcurrent::RHS<current::ripcurrent::LHSTypes<Integer>> dump1 = RCDump(std::ref(result1));
   current::ripcurrent::RHS<current::ripcurrent::LHSTypes<Integer>> dump2 = RCDump(std::ref(result2));
 
-  (emit1 | mult10 | dump1).RipCurrent().Sync();
-  (emit2 | mult10 | dump2).RipCurrent().Sync();
+  (emit1 | mult10 | dump1).RipCurrent().Join();
+  (emit2 | mult10 | dump2).RipCurrent().Join();
   EXPECT_EQ("10", current::strings::Join(result1, ','));
   EXPECT_EQ("20", current::strings::Join(result2, ','));
 
   result1.clear();
   result2.clear();
-  ((emit1 | mult10) | dump1).RipCurrent().Sync();
-  ((emit2 | mult10) | dump2).RipCurrent().Sync();
+  ((emit1 | mult10) | dump1).RipCurrent().Join();
+  ((emit2 | mult10) | dump2).RipCurrent().Join();
   EXPECT_EQ("10", current::strings::Join(result1, ','));
   EXPECT_EQ("20", current::strings::Join(result2, ','));
 }
@@ -426,8 +441,8 @@ CURRENT_STRUCT(String) {
 
 RIPCURRENT_NODE(EmitStringAndInteger, (), (Integer, String)) {  // Note: `()` is same as `void`.
   EmitStringAndInteger() {
-    emit(String("Answer"));
-    emit(Integer(42));
+    emit<String>("Answer");
+    emit<Integer>(42);
   }
 };
 #define EmitStringAndInteger(...) RIPCURRENT_MACRO(EmitStringAndInteger, __VA_ARGS__)
@@ -436,10 +451,10 @@ RIPCURRENT_NODE(MultIntegerOrString, (Integer, String), (Integer, String)) {
   const int k;
   MultIntegerOrString(int k = 101) : k(k) {}
   void f(Integer x) {
-    emit(Integer(x.value * k));
+    emit<Integer>(x.value * k);
   }
-  void f(String x) {
-    emit(String("Yo? " + x.value + " Yo!"));
+  void f(String s) {
+    emit<String>("Yo? " + s.value + " Yo!");
   }
 };
 #define MultIntegerOrString(...) RIPCURRENT_MACRO(MultIntegerOrString, __VA_ARGS__)
@@ -452,9 +467,9 @@ RIPCURRENT_NODE(DumpIntegerAndString, (Integer, String), ()) {  // Note: `()` is
     CURRENT_ASSERT(ptr);
     ptr->push_back(current::ToString(x.value));
   }
-  void f(String x) {
+  void f(String s) {
     CURRENT_ASSERT(ptr);
-    ptr->push_back("'" + x.value + "'");
+    ptr->push_back("'" + s.value + "'");
   }
 };
 #define DumpIntegerAndString(...) RIPCURRENT_MACRO(DumpIntegerAndString, __VA_ARGS__)
@@ -470,17 +485,19 @@ TEST(RipCurrent, CustomTypesIntrospection) {
 }
 
 TEST(RipCurrent, CustomTypesFlow) {
+  current::time::ResetToZero();
+
   using namespace ripcurrent_unittest;
 
   {
     std::vector<std::string> result;
-    (EmitStringAndInteger() | DumpIntegerAndString(std::ref(result))).RipCurrent().Sync();
+    (EmitStringAndInteger() | DumpIntegerAndString(std::ref(result))).RipCurrent().Join();
     EXPECT_EQ("'Answer', 42", current::strings::Join(result, ", "));
   }
 
   {
     std::vector<std::string> result;
-    (EmitStringAndInteger() | MultIntegerOrString() | DumpIntegerAndString(std::ref(result))).RipCurrent().Sync();
+    (EmitStringAndInteger() | MultIntegerOrString() | DumpIntegerAndString(std::ref(result))).RipCurrent().Join();
     EXPECT_EQ("'Yo? Answer Yo!', 4242", current::strings::Join(result, ", "));
   }
 
@@ -489,52 +506,295 @@ TEST(RipCurrent, CustomTypesFlow) {
     (EmitStringAndInteger() | MultIntegerOrString() | MultIntegerOrString(10001) |
      DumpIntegerAndString(std::ref(result)))
         .RipCurrent()
-        .Sync();
+        .Join();
     EXPECT_EQ("'Yo? Yo? Answer Yo! Yo!', 42424242", current::strings::Join(result, ", "));
   }
 }
 
 namespace ripcurrent_unittest {
 
-struct RequestContainer : crnt::CurrentSuper {
-  Request request;
-  RequestContainer(Request&& r) : request(std::move(r)) {}
+// clang-format off
+
+RIPCURRENT_NODE(ManuallyImplementedGenericPassThrough1, (Integer, String), (Integer, String)) {
+  void f(Integer x) {
+    emit<Integer>(x);
+  }
+  void f(String s) {
+    emit<String>(s);
+  }
+};
+#define ManuallyImplementedGenericPassThrough1(...) \
+  RIPCURRENT_MACRO(ManuallyImplementedGenericPassThrough1, __VA_ARGS__)
+
+RIPCURRENT_NODE(ManuallyImplementedGenericPassThrough2, (Integer, String), (Integer, String)) {
+ template <typename X>
+ void f(X && x) {
+   emit<current::decay<X>>(std::forward<X>(x));
+  }
+};
+#define ManuallyImplementedGenericPassThrough2(...) \
+  RIPCURRENT_MACRO(ManuallyImplementedGenericPassThrough2, __VA_ARGS__)
+
+// clang-format on
+
+}  // namespace ripcurrent_unittest
+
+TEST(RipCurrent, Passthrough) {
+  current::time::ResetToZero();
+
+  using namespace ripcurrent_unittest;
+
+  {
+    std::vector<std::string> result;
+    (EmitStringAndInteger() | ManuallyImplementedGenericPassThrough1() | DumpIntegerAndString(std::ref(result)))
+        .RipCurrent()
+        .Join();
+    EXPECT_EQ("'Answer', 42", current::strings::Join(result, ", "));
+  }
+
+  {
+    std::vector<std::string> result;
+    (EmitStringAndInteger() | ManuallyImplementedGenericPassThrough2() | DumpIntegerAndString(std::ref(result)))
+        .RipCurrent()
+        .Join();
+    EXPECT_EQ("'Answer', 42", current::strings::Join(result, ", "));
+  }
+
+  {
+    std::vector<std::string> result;
+    (EmitStringAndInteger() | current::ripcurrent::Pass<Integer, String>() | DumpIntegerAndString(std::ref(result)))
+        .RipCurrent()
+        .Join();
+    EXPECT_EQ("'Answer', 42", current::strings::Join(result, ", "));
+  }
+
+  {
+    std::vector<std::string> result;
+    (EmitStringAndInteger() | ManuallyImplementedGenericPassThrough1() | ManuallyImplementedGenericPassThrough2() |
+     DumpIntegerAndString(std::ref(result)))
+        .RipCurrent()
+        .Join();
+    EXPECT_EQ("'Answer', 42", current::strings::Join(result, ", "));
+  }
+
+  {
+    std::vector<std::string> result;
+    (EmitStringAndInteger() | current::ripcurrent::Pass<Integer, String>() | ManuallyImplementedGenericPassThrough1() |
+     ManuallyImplementedGenericPassThrough2() | RIPCURRENT_PASS(Integer, String) |
+     current::ripcurrent::Pass<Integer, String>() | DumpIntegerAndString(std::ref(result)))
+        .RipCurrent()
+        .Join();
+    EXPECT_EQ("'Answer', 42", current::strings::Join(result, ", "));
+  }
+
+  EXPECT_EQ("... | ManuallyImplementedGenericPassThrough1() | ...",
+            (ManuallyImplementedGenericPassThrough1()).Describe());
+  EXPECT_EQ("... | { Integer, String } => ManuallyImplementedGenericPassThrough1() => { Integer, String } | ...",
+            (ManuallyImplementedGenericPassThrough1()).DescribeWithTypes());
+  EXPECT_EQ("... | ManuallyImplementedGenericPassThrough2() | ...",
+            (ManuallyImplementedGenericPassThrough2()).Describe());
+  EXPECT_EQ("... | { Integer, String } => ManuallyImplementedGenericPassThrough2() => { Integer, String } | ...",
+            (ManuallyImplementedGenericPassThrough2()).DescribeWithTypes());
+
+  EXPECT_EQ("... | PASS | ...", (current::ripcurrent::Pass<Integer, String>()).Describe());
+  EXPECT_EQ("... | { Integer, String } => PASS => { Integer, String } | ...",
+            (current::ripcurrent::Pass<Integer, String>()).DescribeWithTypes());
+
+  EXPECT_EQ("... | Pass(Integer, String) | ...", (RIPCURRENT_PASS(Integer, String)).Describe());
+  EXPECT_EQ("... | { Integer, String } => Pass(Integer, String) => { Integer, String } | ...",
+            (RIPCURRENT_PASS(Integer, String)).DescribeWithTypes());
+}
+
+namespace ripcurrent_unittest {
+
+CURRENT_STRUCT(RequestContainer) {
+  CURRENT_FIELD(request, Request);  // Obviously, move-only, no copy allowed.
+  // clang-format off
+  CURRENT_CONSTRUCTOR(RequestContainer)(Request&& request) : request(std::move(request)) {}
+  // clang-format on
 };
 
 RIPCURRENT_NODE(RCHTTPAcceptor, void, RequestContainer) {
   RCHTTPAcceptor(uint16_t port)
-      : scope(HTTP(port).Register("/ripcurrent", [this](Request r) { emit(RequestContainer(std::move(r))); })) {
+      : scope(HTTP(port)
+                  .Register("/ripcurrent", [this](Request request) { emit<RequestContainer>(std::move(request)); })) {
     const std::string base_url = Printf("http://localhost:%d/ripcurrent", static_cast<int>(port));
-    EXPECT_EQ("OK\n", HTTP(GET(base_url)).body);
-    EXPECT_EQ("OK\n", HTTP(HEAD(base_url)).body);
-    EXPECT_EQ("OK\n", HTTP(POST(base_url, "OK")).body);
+    EXPECT_EQ("1\n", HTTP(GET(base_url)).body);
+    EXPECT_EQ("2\n", HTTP(HEAD(base_url)).body);
+    EXPECT_EQ("3\n", HTTP(POST(base_url, "OK")).body);
   }
   HTTPRoutesScope scope;
 };
 #define RCHTTPAcceptor(...) RIPCURRENT_MACRO(RCHTTPAcceptor, __VA_ARGS__)
 
 RIPCURRENT_NODE(RCHTTPResponder, RequestContainer, void) {
-  std::vector<std::string>& requests;
+  int index = 0;
+  std::vector<std::string>& calls;
   // clang-format off
-  RCHTTPResponder(std::vector<std::string>& requests) : requests(requests) {}
-  void f(RequestContainer&& e) {
-    if (e.request.method == "POST") {
-      requests.push_back("POST " + e.request.body);
-    } else {
-      requests.push_back(e.request.method);
-    }
-    e.request("OK\n");
-  }
+  // Messes with " & " -- D.K.
+  RCHTTPResponder(std::vector<std::string>& calls) : calls(calls) {}
   // clang-format on
+  void f(RequestContainer container) {
+    if (container.request.method == "POST") {
+      calls.push_back("POST " + container.request.body);
+    } else {
+      calls.push_back(container.request.method);
+    }
+    container.request(current::ToString(++index) + '\n');
+  }
 };
 #define RCHTTPResponder(...) RIPCURRENT_MACRO(RCHTTPResponder, __VA_ARGS__)
 
 }  // namespace ripcurrent_unittest
 
-TEST(RipCurrent, CanHandleHTTPRequest) {
+TEST(RipCurrent, CanHandleHTTPRequests) {
+  current::time::ResetToZero();
+
+  using namespace ripcurrent_unittest;
+  const uint16_t port = FLAGS_ripcurrent_http_test_port;
+
+  std::vector<std::string> calls;
+
+  const auto job = RCHTTPAcceptor(port) | RCHTTPResponder(std::ref(calls));
+  ASSERT_TRUE(calls.empty());
+
+  // Begin running the job.
+  const auto scope = std::move(job.RipCurrent().Async());
+
+  // The first three calls are performed from the constructor of `RCHTTPAcceptor`, and thus synchronously.
+  EXPECT_EQ("GET,HEAD,POST OK", current::strings::Join(calls, ','));
+
+  // Now make another call and confirm it goes through all the way.
+  EXPECT_EQ("4\n", HTTP(POST(Printf("http://localhost:%d/ripcurrent", static_cast<int>(port)), "ONE MORE")).body);
+  EXPECT_EQ("GET,HEAD,POST OK,POST ONE MORE", current::strings::Join(calls, ','));
+}
+
+namespace ripcurrent_unittest {
+
+// clang-format off
+RIPCURRENT_NODE(RCEmitterWithTimestamps, void, Integer) {
+  RCEmitterWithTimestamps(std::function<void(int, std::chrono::microseconds)>& post_callback,
+                          std::function<void(int, std::chrono::microseconds)>& schedule_callback,
+                          std::function<void(std::chrono::microseconds)>& head_callback) {
+    post_callback = [this](int v, std::chrono::microseconds t) { post<Integer>(t, v); };
+    schedule_callback = [this](int v, std::chrono::microseconds t) { schedule<Integer>(t, v); };
+    head_callback = [this](std::chrono::microseconds t) { head(t); };
+  }
+};
+// clang-format on
+#define RCEmitterWithTimestamps(...) RIPCURRENT_MACRO(RCEmitterWithTimestamps, __VA_ARGS__)
+
+}  // namespace ripcurrent_unittest
+
+TEST(RipCurrent, TimestampsShouldBeStrictlyIncreasing) {
   using namespace ripcurrent_unittest;
 
-  std::vector<std::string> results;
-  (RCHTTPAcceptor(FLAGS_ripcurrent_http_test_port) | RCHTTPResponder(std::ref(results))).RipCurrent().Sync();
-  EXPECT_EQ("GET,HEAD,POST OK", current::strings::Join(results, ','));
+  std::function<void(int, std::chrono::microseconds)> post;
+  std::function<void(int, std::chrono::microseconds)> schedule;
+  std::function<void(std::chrono::microseconds)> head;
+  std::atomic_size_t counter(0u);
+  std::vector<int> result;
+
+  current::WaitableAtomic<std::string> captured_error_message;
+  const auto mock_scope = current::Singleton<current::ripcurrent::RipCurrentMockableErrorHandler>().ScopedInjectHandler(
+      [&captured_error_message](const std::string& error_message) { captured_error_message.SetValue(error_message); });
+
+  EXPECT_EQ("", captured_error_message.GetValue());
+
+  const auto scope = std::move((RCEmitterWithTimestamps(std::ref(post), std::ref(schedule), std::ref(head)) |
+                                RCDump(std::ref(result), std::ref(counter)))
+                                   .RipCurrent()
+                                   .Async());
+
+  EXPECT_EQ("", current::strings::Join(result, ','));
+  post(1, std::chrono::microseconds(1));
+  post(3, std::chrono::microseconds(3));
+
+  EXPECT_EQ("", captured_error_message.GetValue());
+
+  post(2, std::chrono::microseconds(2));
+
+  captured_error_message.Wait([](const std::string& s) { return !s.empty(); });
+  EXPECT_EQ("Expecting timestamp >= 4, seeing 2.",
+            current::strings::Split(captured_error_message.GetValue(), '\t').back());
+
+  while (counter != 2u) {
+    std::this_thread::yield();
+  }
+
+  EXPECT_EQ("1,3", current::strings::Join(result, ','));
+}
+
+TEST(RipCurrent, SchedulingEventsIntoTheFuture) {
+  using namespace ripcurrent_unittest;
+
+  std::function<void(int, std::chrono::microseconds)> post;
+  std::function<void(int, std::chrono::microseconds)> schedule;
+  std::function<void(std::chrono::microseconds)> head;
+  std::atomic_size_t counter(0u);
+  std::vector<int> result;
+
+  const auto scope = std::move((RCEmitterWithTimestamps(std::ref(post), std::ref(schedule), std::ref(head)) |
+                                RCDump(std::ref(result), std::ref(counter)))
+                                   .RipCurrent()
+                                   .Async());
+
+  post(4, std::chrono::microseconds(4));
+  schedule(6, std::chrono::microseconds(6));
+  post(5, std::chrono::microseconds(5));
+  post(7, std::chrono::microseconds(7));
+
+  while (counter != 4u) {
+    std::this_thread::yield();
+  }
+
+  EXPECT_EQ("4,5,6,7", current::strings::Join(result, ','));
+}
+
+TEST(RipCurrent, SchedulingEventsIntoTheFutureAndUpdatingHead) {
+  using namespace ripcurrent_unittest;
+
+  std::function<void(int, std::chrono::microseconds)> post;
+  std::function<void(int, std::chrono::microseconds)> schedule;
+  std::function<void(std::chrono::microseconds)> head;
+  std::atomic_size_t counter(0u);
+  std::vector<int> result;
+
+  const auto scope = std::move((RCEmitterWithTimestamps(std::ref(post), std::ref(schedule), std::ref(head)) |
+                                RCDump(std::ref(result), std::ref(counter)))
+                                   .RipCurrent()
+                                   .Async());
+
+  schedule(11, std::chrono::microseconds(11));
+  schedule(19, std::chrono::microseconds(19));
+  schedule(12, std::chrono::microseconds(12));
+  schedule(17, std::chrono::microseconds(17));
+
+  head(std::chrono::microseconds(11));
+
+  while (counter != 1u) {
+    std::this_thread::yield();
+  }
+  EXPECT_EQ("11", current::strings::Join(result, ','));
+
+  head(std::chrono::microseconds(12));
+
+  while (counter != 2u) {
+    std::this_thread::yield();
+  }
+  EXPECT_EQ("11,12", current::strings::Join(result, ','));
+
+  head(std::chrono::microseconds(18));
+
+  while (counter != 3u) {
+    std::this_thread::yield();
+  }
+  EXPECT_EQ("11,12,17", current::strings::Join(result, ','));
+
+  head(std::chrono::microseconds(20));
+
+  while (counter != 4u) {
+    std::this_thread::yield();
+  }
+  EXPECT_EQ("11,12,17,19", current::strings::Join(result, ','));
 }


### PR DESCRIPTION
* Every `|` in RipCurrent is an MMPQ now. (Which made RipCurrent multithreaded).
* Extending the RipCurrent publishing interface:
  * `emit` is now `emit<MessageType>(constructor, parameters, if, needed, ...)`.
  * `post`, which is `emit` at certain timestamp, for non-`Now()` timestamps.
  * `schedule`, which  is `PublishIntoTheFuture` in MMPQ terminology.
  * `head`, which is `UpdateHead` in MMPQ terminology.
* Added the `RIPCURRENT_PASS` building block.
* Forwarding constructor (`"emplace"`/`"forward"`-style) for `WaitableAtomic<>`.