### PR TITLE
Do not throw the `InconsistentTimestampException` in case of publishing with zero timestamp into a fresh and empty MMQ.

### DIFF
--- a/Blocks/MMQ/mmpq.h
+++ b/Blocks/MMQ/mmpq.h
@@ -76,7 +76,7 @@ class MMPQ {
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock, class T>
   idxts_t Publish(T&& message, std::chrono::microseconds timestamp = current::time::Now()) {
     locks::SmartMutexLockGuard<MLS> lock(mutex_);
-    if (!(timestamp > last_idx_ts_.us)) {
+    if (last_idx_ts_.us.count() && !(timestamp > last_idx_ts_.us)) {
       CURRENT_THROW(ss::InconsistentTimestampException(last_idx_ts_.us + std::chrono::microseconds(1), timestamp));
     }
     ++last_idx_ts_.index;
@@ -89,7 +89,7 @@ class MMPQ {
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock, class T>
   idxts_t PublishIntoTheFuture(T&& message, std::chrono::microseconds timestamp = current::time::Now()) {
     locks::SmartMutexLockGuard<MLS> lock(mutex_);
-    if (!(timestamp > last_idx_ts_.us)) {
+    if (last_idx_ts_.us.count() && !(timestamp > last_idx_ts_.us)) {
       CURRENT_THROW(ss::InconsistentTimestampException(last_idx_ts_.us + std::chrono::microseconds(1), timestamp));
     }
     ++last_idx_ts_.index;
@@ -102,7 +102,7 @@ class MMPQ {
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
   void UpdateHead(std::chrono::microseconds timestamp = current::time::Now()) {
     locks::SmartMutexLockGuard<MLS> lock(mutex_);
-    if (!(timestamp > last_idx_ts_.us)) {
+    if (last_idx_ts_.us.count() && !(timestamp > last_idx_ts_.us)) {
       CURRENT_THROW(ss::InconsistentTimestampException(last_idx_ts_.us + std::chrono::microseconds(1), timestamp));
     }
     last_idx_ts_.us = timestamp;

--- a/Blocks/MMQ/mmq.h
+++ b/Blocks/MMQ/mmq.h
@@ -104,7 +104,7 @@ class MMQImpl {
   template <current::locks::MutexLockStatus MLS>
   idxts_t DoPublish(const message_t& message, std::chrono::microseconds timestamp) {
     if (CHECK_TIMESTAMP_MONOTONICITY) {
-      if (!(timestamp > last_idx_ts_.us)) {
+      if (last_idx_ts_.us.count() && !(timestamp > last_idx_ts_.us)) {
         CURRENT_THROW(ss::InconsistentTimestampException(last_idx_ts_.us + std::chrono::microseconds(1), timestamp));
       }
     }
@@ -121,7 +121,7 @@ class MMQImpl {
   template <current::locks::MutexLockStatus MLS>
   idxts_t DoPublish(message_t&& message, std::chrono::microseconds timestamp) {
     if (CHECK_TIMESTAMP_MONOTONICITY) {
-      if (!(timestamp > last_idx_ts_.us)) {
+      if (last_idx_ts_.us.count() && !(timestamp > last_idx_ts_.us)) {
         CURRENT_THROW(ss::InconsistentTimestampException(last_idx_ts_.us + std::chrono::microseconds(1), timestamp));
       }
     }


### PR DESCRIPTION
CC @dkorolev @mzhurovich 