### PR TITLE
Storage REST: detailed export format + sharding.

### DIFF
--- a/Storage/api_types.h
+++ b/Storage/api_types.h
@@ -39,8 +39,8 @@ const std::string kRESTfulSchemaURLComponent = "schema";
 const std::string kRESTfulExportURLQueryParameter = "export";
 
 enum class FieldExportFormat {
-  Simple,   // Single entry JSON/one JSON per line, no timestamps.
-  Detailed  // Single JSON/array of `DetailedExportEntry<>`-s.
+  Simple,   // Single entry object JSON or one JSON per line for collections, no timestamps.
+  Detailed  // Entries wrapped in `DetailedExportEntry<>`, single JSON object or JSON array for collections.
 };
 
 // TODO(dkorolev): The whole `FieldTypeDependentImpl` section below to be moved to `semantics.h`.

--- a/Storage/api_types.h
+++ b/Storage/api_types.h
@@ -37,10 +37,19 @@ namespace rest {
 const std::string kRESTfulDataURLComponent = "data";
 const std::string kRESTfulSchemaURLComponent = "schema";
 const std::string kRESTfulExportURLQueryParameter = "export";
+// Additional URL query parameters for `export` mode.
+const std::string kRESTfulExportNShardsURLQueryParameter = "nshards";  // Number of shards.
+const std::string kRESTfulExportShardURLQueryParameter = "shard";      // Shard to export.
 
 enum class FieldExportFormat {
   Simple,   // Single entry object JSON or one JSON per line for collections, no timestamps.
   Detailed  // Entries wrapped in `DetailedExportEntry<>`, single JSON object or JSON array for collections.
+};
+
+struct FieldExportParams {
+  FieldExportFormat format = FieldExportFormat::Simple;
+  uint32_t nshards = 0u;
+  uint32_t shard = 0u;
 };
 
 // TODO(dkorolev): The whole `FieldTypeDependentImpl` section below to be moved to `semantics.h`.
@@ -228,7 +237,7 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
   const std::string field_name;
   Optional<url_key_t> get_url_key;
   const StorageRole role;
-  Optional<FieldExportFormat> requested_export_fmt;
+  Optional<FieldExportParams> requested_export_params;
 
   RESTfulGETInput(const RESTfulGenericInput<STORAGE>& input,
                   immutable_fields_t fields,
@@ -236,28 +245,28 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
                   const std::string& field_name,
                   const Optional<url_key_t>& get_url_key,
                   const StorageRole role,
-                  const Optional<FieldExportFormat>& requested_export_fmt)
+                  const Optional<FieldExportParams>& requested_export_params)
       : RESTfulGenericInput<STORAGE>(input),
         fields(fields),
         field(field),
         field_name(field_name),
         get_url_key(get_url_key),
         role(role),
-        requested_export_fmt(requested_export_fmt) {}
+        requested_export_params(requested_export_params) {}
   RESTfulGETInput(RESTfulGenericInput<STORAGE>&& input,
                   immutable_fields_t fields,
                   const field_t& field,
                   const std::string& field_name,
                   const Optional<url_key_t>& get_url_key,
                   const StorageRole role,
-                  const Optional<FieldExportFormat>& requested_export_fmt)
+                  const Optional<FieldExportParams>& requested_export_params)
       : RESTfulGenericInput<STORAGE>(std::move(input)),
         fields(fields),
         field(field),
         field_name(field_name),
         get_url_key(get_url_key),
         role(role),
-        requested_export_fmt(requested_export_fmt) {}
+        requested_export_params(requested_export_params) {}
 };
 
 // A dedicated "GETInput" for the GETs over row or col of a matrix container.

--- a/Storage/api_types.h
+++ b/Storage/api_types.h
@@ -37,7 +37,7 @@ namespace rest {
 const std::string kRESTfulDataURLComponent = "data";
 const std::string kRESTfulSchemaURLComponent = "schema";
 const std::string kRESTfulExportURLQueryParameter = "export";
-// Additional URL query parameters for `export` mode.
+// Additional URL query parameters for the `export` mode.
 const std::string kRESTfulExportNShardsURLQueryParameter = "nshards";  // Number of shards.
 const std::string kRESTfulExportShardURLQueryParameter = "shard";      // Shard to export.
 

--- a/Storage/api_types.h
+++ b/Storage/api_types.h
@@ -36,6 +36,12 @@ namespace rest {
 
 const std::string kRESTfulDataURLComponent = "data";
 const std::string kRESTfulSchemaURLComponent = "schema";
+const std::string kRESTfulExportURLQueryParameter = "export";
+
+enum class FieldExportFormat {
+  Simple,   // Single entry JSON/one JSON per line, no timestamps.
+  Detailed  // Single JSON/array of `DetailedExportEntry<>`-s.
+};
 
 // TODO(dkorolev): The whole `FieldTypeDependentImpl` section below to be moved to `semantics.h`.
 template <typename>
@@ -222,7 +228,7 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
   const std::string field_name;
   Optional<url_key_t> get_url_key;
   const StorageRole role;
-  const bool export_requested;
+  Optional<FieldExportFormat> requested_export_fmt;
 
   RESTfulGETInput(const RESTfulGenericInput<STORAGE>& input,
                   immutable_fields_t fields,
@@ -230,28 +236,28 @@ struct RESTfulGETInput : RESTfulGenericInput<STORAGE> {
                   const std::string& field_name,
                   const Optional<url_key_t>& get_url_key,
                   const StorageRole role,
-                  const bool export_requested)
+                  const Optional<FieldExportFormat>& requested_export_fmt)
       : RESTfulGenericInput<STORAGE>(input),
         fields(fields),
         field(field),
         field_name(field_name),
         get_url_key(get_url_key),
         role(role),
-        export_requested(export_requested) {}
+        requested_export_fmt(requested_export_fmt) {}
   RESTfulGETInput(RESTfulGenericInput<STORAGE>&& input,
                   immutable_fields_t fields,
                   const field_t& field,
                   const std::string& field_name,
                   const Optional<url_key_t>& get_url_key,
                   const StorageRole role,
-                  const bool export_requested)
+                  const Optional<FieldExportFormat>& requested_export_fmt)
       : RESTfulGenericInput<STORAGE>(std::move(input)),
         fields(fields),
         field(field),
         field_name(field_name),
         get_url_key(get_url_key),
         role(role),
-        export_requested(export_requested) {}
+        requested_export_fmt(requested_export_fmt) {}
 };
 
 // A dedicated "GETInput" for the GETs over row or col of a matrix container.

--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -138,6 +138,7 @@ class GenericDictionary {
     bool operator==(const Iterator& rhs) const { return iterator == rhs.iterator; }
     bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
     key_t OuterKeyForPartialHypermediaCollectionView() const { return iterator->first; }
+    key_t key() const { return iterator->first; }
     const T& operator*() const { return iterator->second; }
     const T* operator->() const { return &iterator->second; }
   };

--- a/Storage/container/dictionary.h
+++ b/Storage/container/dictionary.h
@@ -137,8 +137,9 @@ class GenericDictionary {
     void operator++() { ++iterator; }
     bool operator==(const Iterator& rhs) const { return iterator == rhs.iterator; }
     bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
-    key_t OuterKeyForPartialHypermediaCollectionView() const { return iterator->first; }
-    key_t key() const { return iterator->first; }
+    // TODO(dkorolev): Replace `OuterKeyForPartialHypermediaCollectionView()` with `key()`?
+    copy_free<key_t> OuterKeyForPartialHypermediaCollectionView() const { return iterator->first; }
+    copy_free<key_t> key() const { return iterator->first; }
     const T& operator*() const { return iterator->second; }
     const T* operator->() const { return &iterator->second; }
   };

--- a/Storage/rest/structured.h
+++ b/Storage/rest/structured.h
@@ -144,7 +144,7 @@ struct Structured {
             }
             return response;
           } else {
-            // Export requested via `?export`, dump the record using appropriate format.
+            // Export requested via `?export`, dump the record using the appropriate format.
             if (Value(input.requested_export_params).format == FieldExportFormat::Detailed) {
               return detailed_export_entry_t(Value(last_modified), detailed_export_helper_t(key, value));
             } else {

--- a/Storage/rest/types.h
+++ b/Storage/rest/types.h
@@ -252,7 +252,7 @@ struct DetailedExportEntryHelperWrapper {
 };
 
 template <>
-struct DetailedExportEntryHelperWrapper<int> {
+struct DetailedExportEntryHelperWrapper<current::reflection::DummyTemplateType> {
   using key_t = int;
   using entry_t = int;
 };

--- a/Storage/rest/types.h
+++ b/Storage/rest/types.h
@@ -234,7 +234,7 @@ CURRENT_STRUCT_T(HypermediaRESTCollectionResponse) {
   CURRENT_FIELD(data, std::vector<T>);
 };
 
-// The most simple way to pass universal dictionary/matrix key and entry to the templated Current struct.
+// The simplest way to pass universal dictionary/matrix key and entry to the templated Current struct.
 template <typename KEY, typename ENTRY>
 struct DetailedExportEntryHelper {
   using key_t = KEY;

--- a/Storage/rest/types.h
+++ b/Storage/rest/types.h
@@ -238,23 +238,23 @@ CURRENT_STRUCT_T(HypermediaRESTCollectionResponse) {
 template <typename KEY, typename ENTRY>
 struct DetailedExportEntryHelper {
   using key_t = KEY;
-  using entry_t = const ENTRY&;
+  using entry_cref_t = const ENTRY&;
   key_t key;
-  entry_t entry;
-  DetailedExportEntryHelper(key_t key, entry_t entry) : key(key), entry(entry) {}
+  entry_cref_t entry_cref;
+  DetailedExportEntryHelper(key_t key, entry_cref_t entry_cref) : key(key), entry_cref(entry_cref) {}
 };
 
 // Required for templated Current structs using `T::something` :(
 template <typename T>
 struct DetailedExportEntryHelperWrapper {
   using key_t = typename T::key_t;
-  using entry_t = typename T::entry_t;
+  using entry_cref_t = typename T::entry_cref_t;
 };
 
 template <>
 struct DetailedExportEntryHelperWrapper<current::reflection::DummyTemplateType> {
   using key_t = int;
-  using entry_t = int;
+  using entry_cref_t = int;
 };
 
 // `T` = `DetailedExportEntryHelper<KEY, ENTRY>`.
@@ -264,12 +264,12 @@ CURRENT_STRUCT_T(HypermediaRESTDetailedExportEntry) {
   CURRENT_FIELD(key, typename DetailedExportEntryHelperWrapper<T>::key_t);
   CURRENT_FIELD(timestamp_us, std::chrono::microseconds, std::chrono::microseconds(0));
   CURRENT_FIELD(timestamp_http, std::string);
-  CURRENT_FIELD(data, typename DetailedExportEntryHelperWrapper<T>::entry_t);
+  CURRENT_FIELD(data, typename DetailedExportEntryHelperWrapper<T>::entry_cref_t);
   CURRENT_CONSTRUCTOR_T(HypermediaRESTDetailedExportEntry)(std::chrono::microseconds timestamp, const T& helper)
       : key(helper.key),
         timestamp_us(timestamp),
         timestamp_http(FormatDateTimeAsIMFFix(timestamp)),
-        data(helper.entry) {}
+        data(helper.entry_cref) {}
 };
 
 using HypermediaRESTGenericResponse = generic::RESTGenericResponse;

--- a/TypeSystem/base.h
+++ b/TypeSystem/base.h
@@ -33,6 +33,9 @@ namespace r {
 struct DF {};
 struct FC {};
 
+// Special type used as `T` in templated Current structs instantiation along with `FC`.
+struct DummyT {};
+
 // Dummy type for `FC` instantiation type.
 struct CountFieldsImplementationType {
   template <typename... T>
@@ -69,6 +72,7 @@ namespace current {
 namespace reflection {
 using DeclareFields = ::crnt::r::DF;
 using CountFields = ::crnt::r::FC;
+using DummyTemplateType = ::crnt::r::DummyT;
 using ::crnt::r::CountFieldsImplementationType;
 using ::crnt::r::FieldTypeAndName;
 using ::crnt::r::FieldTypeAndNameAndIndex;

--- a/TypeSystem/struct.h
+++ b/TypeSystem/struct.h
@@ -198,7 +198,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   struct CRTH<s> {                                                                 \
     constexpr static size_t CURRENT_FIELD_INDEX_BASE_IMPL = __COUNTER__;           \
     constexpr static const char* CURRENT_STRUCT_NAME() { return #s "_Z"; }         \
-    typedef CSTI_##s<int, ::crnt::r::FC> CURRENT_FIELD_COUNT_STRUCT;               \
+    typedef CSTI_##s<::crnt::r::DummyT, ::crnt::r::FC> CURRENT_FIELD_COUNT_STRUCT; \
     using FIELD_INDEX_BASE = ::crnt::r::FIELD_INDEX_BASE_IMPL<CRTH<s>>;            \
   };                                                                               \
   struct CURRENT_STRUCT_T_SUPER_HELPER_##s {                                       \
@@ -226,19 +226,19 @@ struct CurrentStructFieldsConsistency<T, 0u> {
     using FIELD_INDEX_BASE = ::crnt::r::FIELD_INDEX_BASE_IMPL<CRH<s>>;   \
   }
 
-#define CURRENT_STRUCT_T_HELPERS(s, super)                                 \
-  template <typename T, typename INSTANTIATION_TYPE>                       \
-  struct CSTI_##s;                                                         \
-  template <typename T>                                                    \
-  using s = CSTI_##s<T, ::crnt::r::DF>;                                    \
-  template <template <typename> class>                                     \
-  struct CRTH;                                                             \
-  template <>                                                              \
-  struct CRTH<s> {                                                         \
-    constexpr static size_t CURRENT_FIELD_INDEX_BASE_IMPL = __COUNTER__;   \
-    constexpr static const char* CURRENT_STRUCT_NAME() { return #s "_Z"; } \
-    typedef CSTI_##s<int, ::crnt::r::FC> CURRENT_FIELD_COUNT_STRUCT;       \
-    using FIELD_INDEX_BASE = ::crnt::r::FIELD_INDEX_BASE_IMPL<CRTH<s>>;    \
+#define CURRENT_STRUCT_T_HELPERS(s, super)                                         \
+  template <typename T, typename INSTANTIATION_TYPE>                               \
+  struct CSTI_##s;                                                                 \
+  template <typename T>                                                            \
+  using s = CSTI_##s<T, ::crnt::r::DF>;                                            \
+  template <template <typename> class>                                             \
+  struct CRTH;                                                                     \
+  template <>                                                                      \
+  struct CRTH<s> {                                                                 \
+    constexpr static size_t CURRENT_FIELD_INDEX_BASE_IMPL = __COUNTER__;           \
+    constexpr static const char* CURRENT_STRUCT_NAME() { return #s "_Z"; }         \
+    typedef CSTI_##s<::crnt::r::DummyT, ::crnt::r::FC> CURRENT_FIELD_COUNT_STRUCT; \
+    using FIELD_INDEX_BASE = ::crnt::r::FIELD_INDEX_BASE_IMPL<CRTH<s>>;            \
   }
 
 #endif  // CURRENT_WINDOWS


### PR DESCRIPTION
- Added dedicated dummy type (`crnt::r::DummyT` aka `current::reflection::DummyTemplateType`) for the templated Current structs instantiation during counting the fields.
- Storage RESTful API `?export[=detailed]` URL query parameter extension to export JSON arrays containing `HypermediaRESTDetailedExportEntry<>` objects:
```
CURRENT_STRUCT_T(HypermediaRESTDetailedExportEntry) {
  CURRENT_FIELD(key, typename DetailedExportEntryHelperWrapper<T>::key_t);
  CURRENT_FIELD(timestamp_us, std::chrono::microseconds, std::chrono::microseconds(0));
  CURRENT_FIELD(timestamp_http, std::string);
  CURRENT_FIELD(data, typename DetailedExportEntryHelperWrapper<T>::entry_t);
};
```
- Additional query parameters to support sharding the `export` response by the value of the object key hash (calculated via `CurrentHashFunction<>`):
  + `nshards={x}`, `x` is expected to be >1 to actually perform sharding
  + `shard={i}`, `0 <= i < x`