### PR TITLE
More robust locking in Stream => SS => Persister.

### DIFF
--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -41,8 +41,9 @@ SOFTWARE.
 
 #include "../../TypeSystem/Serialization/json.h"
 
-#include "../../Bricks/time/chrono.h"
+#include "../../Bricks/sync/locks.h"
 #include "../../Bricks/sync/scope_owned.h"
+#include "../../Bricks/time/chrono.h"
 #include "../../Bricks/util/atomic_that_works.h"
 
 namespace current {
@@ -131,7 +132,7 @@ class FilePersister {
     std::fstream head_rewriter;
 
     // `offset.size() == end.next_index`, and `offset[i]` is the offset in bytes where the line for index `i` begins.
-    std::mutex mutex;
+    std::mutex mutex;  // Guards `offset`, `head_offset` and `timestamp`.
     std::vector<std::streampos> offset;
     std::streamoff head_offset;
     std::vector<std::chrono::microseconds> timestamp;
@@ -343,29 +344,34 @@ class FilePersister {
     const std::streampos begin_offset_;
   };
 
-  template <typename E>
+  template <current::locks::MutexLockStatus MLS, typename E>
   idxts_t DoPublish(E&& entry, const std::chrono::microseconds timestamp) {
+    current::locks::SmartMutexLockGuard<MLS> lock(file_persister_impl_->mutex);
+
     end_t iterator = file_persister_impl_->end.load();
     if (!(timestamp > iterator.head)) {
       CURRENT_THROW(ss::InconsistentTimestampException(iterator.head + std::chrono::microseconds(1), timestamp));
     }
+
     iterator.last_entry_us = iterator.head = timestamp;
     const auto current = idxts_t(iterator.next_index, iterator.last_entry_us);
-    {
-      std::lock_guard<std::mutex> lock(file_persister_impl_->mutex);
-      CURRENT_ASSERT(file_persister_impl_->offset.size() == iterator.next_index);
-      CURRENT_ASSERT(file_persister_impl_->timestamp.size() == iterator.next_index);
-      file_persister_impl_->offset.push_back(file_persister_impl_->appender.tellp());
-      file_persister_impl_->timestamp.push_back(timestamp);
-    }
+    CURRENT_ASSERT(file_persister_impl_->offset.size() == iterator.next_index);
+    CURRENT_ASSERT(file_persister_impl_->timestamp.size() == iterator.next_index);
+    file_persister_impl_->offset.push_back(file_persister_impl_->appender.tellp());
+    file_persister_impl_->timestamp.push_back(timestamp);
+
     file_persister_impl_->appender << JSON(current) << '\t' << JSON(std::forward<E>(entry)) << std::endl;
     ++iterator.next_index;
     file_persister_impl_->head_offset = 0;
     file_persister_impl_->end.store(iterator);
+
     return current;
   }
 
+  template <current::locks::MutexLockStatus MLS>
   void DoUpdateHead(const std::chrono::microseconds timestamp) {
+    current::locks::SmartMutexLockGuard<MLS> lock(file_persister_impl_->mutex);
+
     end_t iterator = file_persister_impl_->end.load();
     if (!(timestamp > iterator.head)) {
       CURRENT_THROW(ss::InconsistentTimestampException(iterator.head + std::chrono::microseconds(1), timestamp));

--- a/Blocks/SS/persister.h
+++ b/Blocks/SS/persister.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 #include "idx_ts.h"
 
+#include "../../Bricks/sync/locks.h"
 #include "../../Bricks/time/chrono.h"
 
 namespace current {
@@ -46,13 +47,18 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
       : IMPL(std::forward<ARGS>(args)...) {}
   virtual ~EntryPersister() {}
 
+  template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
   IndexAndTimestamp Publish(const ENTRY& e, std::chrono::microseconds us = current::time::Now()) {
-    return IMPL::DoPublish(e, us);
+    return IMPL::template DoPublish<MLS>(e, us);
   }
+  template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
   IndexAndTimestamp Publish(ENTRY&& e, std::chrono::microseconds us = current::time::Now()) {
-    return IMPL::DoPublish(std::move(e), us);
+    return IMPL::template DoPublish<MLS>(std::move(e), us);
   }
-  void UpdateHead(std::chrono::microseconds us = current::time::Now()) { return IMPL::DoUpdateHead(us); }
+  template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
+  void UpdateHead(std::chrono::microseconds us = current::time::Now()) {
+    return IMPL::template DoUpdateHead<MLS>(us);
+  }
 
   // template <typename... ARGS>
   // IndexAndTimestamp Emplace(ARGS&&... args) {


### PR DESCRIPTION
Hi guys,

A follow up after @grixa's excellent elaboration. I've tried to make it clean that:
- `Publish/UpdateHead` and `DoPublish/DoUpdateHead` all have the template `MutexLockStatus` parameter.
- The `Do*` methods have this parameter required, the non-`Do` ones have it defaulting to `MLS::NeedToLock`.
- In `Sherlock`, where the mutex locked in the stream level and then, deeper down, another mutex is locked on the persistence level, I took the liberty to make the inner call unchecked.

Making the inner call unchecked is generally unsafe if the user is calling methods such as `CurrentHead()` from `InternalExposePersister()`, and I've added a note that whoever does use `InternalExposePersister()` is playing with fire. Maybe we should revisit this decision.

Also, I've made head rewrite in `Blocks/Persistence/file.h` a bit stronger-locked. Open for a conversation re. whether it's how it should be -- perhaps another look specifically for file rewrites could be a better idea.

Thanks!
Dima
