### PR TITLE
`X-Current*` headers for microsecond timestamps in Storage REST.

### DIFF
--- a/Storage/docu/docu_3_code.cc
+++ b/Storage/docu/docu_3_code.cc
@@ -472,15 +472,16 @@ TEST(StorageDocumentation, IfUnmodifiedSince) {
   const auto base_url = current::strings::Printf("http://localhost:%d", FLAGS_client_storage_test_port);
 
   // POST one record.
-  auto publish_time = std::chrono::microseconds(1467363600000000);  // `Fri, 01 Jul 2016 09:00:00 GMT`.
-  current::time::SetNow(publish_time);
+  const auto publish_time_1 = current::IMFFixDateTimeStringToTimestamp("Fri, 01 Jul 2016 09:00:00 GMT");
+  EXPECT_EQ(1467363600000000, publish_time_1.count());
+  current::time::SetNow(publish_time_1);
   const auto post_response = HTTP(POST(base_url + "/api_basic/data/client", Client(ClientID(42))));
-  const std::string client1_key_str = post_response.body;
-  const ClientID client1_key = static_cast<ClientID>(current::FromString<uint64_t>(client1_key_str));
+  const std::string client_key_str = post_response.body;
+  const ClientID client_key = static_cast<ClientID>(current::FromString<uint64_t>(client_key_str));
   EXPECT_EQ(201, static_cast<int>(post_response.code));
 
   {
-    const auto response = HTTP(GET(base_url + "/api/data/client/" + client1_key_str));
+    const auto response = HTTP(GET(base_url + "/api/data/client/" + client_key_str));
     EXPECT_EQ(200, static_cast<int>(response.code));
     ASSERT_TRUE(response.headers.Has("Last-Modified"));
     EXPECT_EQ("Fri, 01 Jul 2016 09:00:00 GMT", response.headers.Get("Last-Modified"));
@@ -488,71 +489,176 @@ TEST(StorageDocumentation, IfUnmodifiedSince) {
     EXPECT_EQ("1467363600000000", response.headers.Get("X-Current-Last-Modified"));
   }
 
-  Client updated_client1((ClientID(client1_key)));
-  updated_client1.name = "Jane Doe";
+  Client updated_client((ClientID(client_key)));
+  updated_client.name = "Jane Doe";
 
-  // Try to modify the record with the incorrect header `X-Current-If-Unmodified-Since`.
+  // Attempt to modify the record passing in the wrong value of the `X-Current-If-Unmodified-Since` header.
   {
-    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client1_key_str, updated_client1)
+    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client_key_str, updated_client)
                                    .SetHeader("X-Current-If-Unmodified-Since", "-1"));
     EXPECT_EQ(400, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"InvalidHeader\","
+                  "\"message\":\"Invalid microsecond timestamp value.\","
+                  "\"details\":{"
+                    "\"header\":\"X-Current-If-Unmodified-Since\","
+                    "\"header_value\":\"-1\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
-  // Try to modify the record with the incorrect header `If-Unmodified-Since`.
+  // Attempt to modify the record passing in the wrong value of the `If-Unmodified-Since` header.
   {
-    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client1_key_str, updated_client1)
+    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client_key_str, updated_client)
                                    .SetHeader("If-Unmodified-Since", "Bad string"));
     EXPECT_EQ(400, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"InvalidHeader\","
+                  "\"message\":\"Unparsable datetime value.\","
+                  "\"details\":{"
+                    "\"header\":\"If-Unmodified-Since\","
+                    "\"header_value\":\"Bad string\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
 
-  // Try to modify the record with the header `X-Current-If-Unmodified-Since` set 1 us in the past.
+  // Attempt to modify the record with the value of the `X-Current-If-Unmodified-Since` header set to 1 us in the past.
   {
-    const auto header_value = current::ToString(publish_time - std::chrono::microseconds(1));
-    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client1_key_str, updated_client1)
+    const auto header_value = current::ToString(publish_time_1 - std::chrono::microseconds(1));
+    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client_key_str, updated_client)
                                    .SetHeader("X-Current-If-Unmodified-Since", header_value));
     EXPECT_EQ(412, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"ResourceWasModifiedError\","
+                  "\"message\":\"Resource can not be updated as it has been modified in the meantime.\","
+                  "\"details\":{"
+                    "\"requested_date\":\"Fri, 01 Jul 2016 08:59:59 GMT\","
+                    "\"requested_us\":\"1467363599999999\","
+                    "\"resource_last_modified_date\":\"Fri, 01 Jul 2016 09:00:00 GMT\","
+                    "\"resource_last_modified_us\":\"1467363600000000\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
-  // Try to modify the record with the header `If-Unmodified-Since` set slightly in the past.
+  // Attempt to modify the record with the value of the `If-Unmodified-Since` header set to 1 second in the past.
   {
-    const auto header_value = current::FormatDateTimeAsIMFFix(publish_time - std::chrono::microseconds(1000000));
-    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client1_key_str, updated_client1)
+    const auto header_value = current::FormatDateTimeAsIMFFix(publish_time_1 - std::chrono::microseconds(1000000));
+    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client_key_str, updated_client)
                                    .SetHeader("If-Unmodified-Since", header_value));
     EXPECT_EQ(412, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"ResourceWasModifiedError\","
+                  "\"message\":\"Resource can not be updated as it has been modified in the meantime.\","
+                  "\"details\":{"
+                    "\"requested_date\":\"Fri, 01 Jul 2016 08:59:59 GMT\","
+                    "\"requested_us\":\"1467363599999999\","
+                    "\"resource_last_modified_date\":\"Fri, 01 Jul 2016 09:00:00 GMT\","
+                    "\"resource_last_modified_us\":\"1467363600000000\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
 
-  // Try to DELETE the record with the incorrect header `X-Current-If-Unmodified-Since`.
+  // Attempt to delete the record passing in the wrong value of the `X-Current-If-Unmodified-Since` header.
   {
-    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client1_key_str)
+    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client_key_str)
                                    .SetHeader("X-Current-If-Unmodified-Since", "Bad string"));
     EXPECT_EQ(400, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"InvalidHeader\","
+                  "\"message\":\"Invalid microsecond timestamp value.\","
+                  "\"details\":{"
+                    "\"header\":\"X-Current-If-Unmodified-Since\","
+                    "\"header_value\":\"Bad string\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
-  // Try to DELETE the record with the incorrect header `If-Unmodified-Since`.
+  // Attempt to delete the record passing in the wrong value of the `If-Unmodified-Since` header.
   {
-    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client1_key_str)
+    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client_key_str)
                                    .SetHeader("If-Unmodified-Since", "Bad string"));
     EXPECT_EQ(400, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"InvalidHeader\","
+                  "\"message\":\"Unparsable datetime value.\","
+                  "\"details\":{"
+                    "\"header\":\"If-Unmodified-Since\","
+                    "\"header_value\":\"Bad string\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
 
-  // Try to DELETE the record with the header `X-Current-If-Unmodified-Since` set 1 us in the past.
+  // Attempt to delete the record with the value of the `X-Current-If-Unmodified-Since` header set to 1 us in the past.
   {
-    const auto header_value = current::ToString(publish_time - std::chrono::microseconds(1));
-    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client1_key_str)
+    const auto header_value = current::ToString(publish_time_1 - std::chrono::microseconds(1));
+    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client_key_str)
                                    .SetHeader("X-Current-If-Unmodified-Since", header_value));
     EXPECT_EQ(412, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"ResourceWasModifiedError\","
+                  "\"message\":\"Resource can not be deleted as it has been modified in the meantime.\","
+                  "\"details\":{"
+                    "\"requested_date\":\"Fri, 01 Jul 2016 08:59:59 GMT\","
+                    "\"requested_us\":\"1467363599999999\","
+                    "\"resource_last_modified_date\":\"Fri, 01 Jul 2016 09:00:00 GMT\","
+                    "\"resource_last_modified_us\":\"1467363600000000\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
-  // Try to DELETE the record with the header `If-Unmodified-Since` set slightly in the past.
+  // Attempt to delete the record with the value of the `If-Unmodified-Since` header set to 1 second in the past.
   {
-    const auto header_value = current::FormatDateTimeAsIMFFix(publish_time - std::chrono::microseconds(1000000));
-    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client1_key_str)
+    const auto header_value = current::FormatDateTimeAsIMFFix(publish_time_1 - std::chrono::microseconds(1000000));
+    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client_key_str)
                                    .SetHeader("If-Unmodified-Since", header_value));
     EXPECT_EQ(412, static_cast<int>(response.code));
+    EXPECT_EQ("{"
+                "\"success\":false,"
+                "\"message\":null,"
+                "\"error\":{"
+                  "\"name\":\"ResourceWasModifiedError\","
+                  "\"message\":\"Resource can not be deleted as it has been modified in the meantime.\","
+                  "\"details\":{"
+                    "\"requested_date\":\"Fri, 01 Jul 2016 08:59:59 GMT\","
+                    "\"requested_us\":\"1467363599999999\","
+                    "\"resource_last_modified_date\":\"Fri, 01 Jul 2016 09:00:00 GMT\","
+                    "\"resource_last_modified_us\":\"1467363600000000\""
+                  "}"
+                "}"
+              "}\n", response.body);
   }
 
-  auto update_time = std::chrono::microseconds(1467374400000000);  // `Fri, 01 Jul 2016 12:00:00 GMT`.
-  current::time::SetNow(update_time);
+  const auto update_time_1 = current::IMFFixDateTimeStringToTimestamp("Fri, 01 Jul 2016 12:00:00 GMT");
+  EXPECT_EQ(1467374400000000, update_time_1.count());
+  current::time::SetNow(update_time_1);
   // `PUT` with the real modification timestamp in `X-Current-If-Unmodified-Since` should pass.
   {
-    const auto header_value = current::ToString(publish_time);
-    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client1_key_str, updated_client1)
+    const auto header_value = current::ToString(publish_time_1);
+    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client_key_str, updated_client)
                                    .SetHeader("X-Current-If-Unmodified-Since", header_value));
     EXPECT_EQ(200, static_cast<int>(response.code));
     ASSERT_TRUE(response.headers.Has("Last-Modified"));
@@ -562,14 +668,14 @@ TEST(StorageDocumentation, IfUnmodifiedSince) {
   }
 
   // Test microsecond resolution of `X-Current-If-Unmodified-Since`.
-  auto delete_time = update_time + std::chrono::microseconds(1);
-  current::time::SetNow(delete_time);
+  const auto delete_time_1 = update_time_1 + std::chrono::microseconds(1);
+  current::time::SetNow(delete_time_1);
   // `DELETE` with the real modification timestamp in `X-Current-If-Unmodified-Since` should pass.
   // `X-Current-If-Unmodified-Since` has precedence over `If-Unmodified-Since`.
   {
-    const auto rfc_header_value = current::FormatDateTimeAsIMFFix(publish_time);
-    const auto current_header_value = current::ToString(update_time);
-    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client1_key_str)
+    const auto rfc_header_value = current::FormatDateTimeAsIMFFix(publish_time_1);
+    const auto current_header_value = current::ToString(update_time_1);
+    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client_key_str)
                                    .SetHeader("X-Current-If-Unmodified-Since", current_header_value)
                                    .SetHeader("If-Unmodified-Since", rfc_header_value));
     EXPECT_EQ(200, static_cast<int>(response.code));
@@ -580,19 +686,31 @@ TEST(StorageDocumentation, IfUnmodifiedSince) {
   }
 
   // Restore the original client entry.
-  publish_time = delete_time + std::chrono::microseconds(1000);
-  current::time::SetNow(publish_time);
+  const auto publish_time_2 = delete_time_1 + std::chrono::microseconds(1000);
+  current::time::SetNow(publish_time_2);
+  EXPECT_EQ(1467374400001001, publish_time_2.count());
   {
-    const auto post_response = HTTP(POST(base_url + "/api_basic/data/client", Client(ClientID(42))));
+    const auto post_response = HTTP(POST(base_url + "/api/data/client", Client(ClientID(42))));
     EXPECT_EQ(201, static_cast<int>(post_response.code));
+    // Check `Last-Modified`.
+    ASSERT_TRUE(post_response.headers.Has("Last-Modified"));
+    const auto expected_date = current::FormatDateTimeAsIMFFix(publish_time_2);
+    ASSERT_EQ("Fri, 01 Jul 2016 12:00:00 GMT", expected_date);
+    EXPECT_EQ(expected_date, post_response.headers.Get("Last-Modified"));
+    // Check `X-Current-Last-Modified`.
+    ASSERT_TRUE(post_response.headers.Has("X-Current-Last-Modified"));
+    const auto expected_us_string = current::ToString(publish_time_2);
+    ASSERT_EQ("1467374400001001", expected_us_string);
+    EXPECT_EQ(expected_us_string, post_response.headers.Get("X-Current-Last-Modified"));
   }
 
-  update_time = std::chrono::microseconds(1467381600000000);  // `Fri, 01 Jul 2016 14:00:00 GMT`.
-  current::time::SetNow(update_time);
+  const auto update_time_2 = current::IMFFixDateTimeStringToTimestamp("Fri, 01 Jul 2016 14:00:00 GMT");
+  EXPECT_EQ(1467381600000000, update_time_2.count());
+  current::time::SetNow(update_time_2);
   // `PUT` with the real modification timestamp in `If-Unmodified-Since` should pass.
   {
-    const auto header_value = current::FormatDateTimeAsIMFFix(publish_time);
-    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client1_key_str, updated_client1)
+    const auto header_value = current::FormatDateTimeAsIMFFix(publish_time_2);
+    const auto response = HTTP(PUT(base_url + "/api/data/client/" + client_key_str, updated_client)
                                    .SetHeader("If-Unmodified-Since", header_value));
     EXPECT_EQ(200, static_cast<int>(response.code));
     ASSERT_TRUE(response.headers.Has("Last-Modified"));
@@ -601,12 +719,13 @@ TEST(StorageDocumentation, IfUnmodifiedSince) {
     EXPECT_EQ("1467381600000000", response.headers.Get("X-Current-Last-Modified"));
   }
 
-  delete_time = std::chrono::microseconds(1467385200000000);  // `Fri, 01 Jul 2016 15:00:00 GMT`.
-  current::time::SetNow(delete_time);
+  const auto delete_time_2 = current::IMFFixDateTimeStringToTimestamp("Fri, 01 Jul 2016 15:00:00 GMT");
+  EXPECT_EQ(1467385200000000, delete_time_2.count());
+  current::time::SetNow(delete_time_2);
   // `DELETE` with the real modification timestamp in `If-Unmodified-Since` should pass.
   {
-    const auto header_value = current::FormatDateTimeAsIMFFix(update_time);
-    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client1_key_str)
+    const auto header_value = current::FormatDateTimeAsIMFFix(update_time_2);
+    const auto response = HTTP(DELETE(base_url + "/api/data/client/" + client_key_str)
                                    .SetHeader("If-Unmodified-Since", header_value));
     EXPECT_EQ(200, static_cast<int>(response.code));
     ASSERT_TRUE(response.headers.Has("Last-Modified"));
@@ -614,7 +733,6 @@ TEST(StorageDocumentation, IfUnmodifiedSince) {
     ASSERT_TRUE(response.headers.Has("X-Current-Last-Modified"));
     EXPECT_EQ("1467385200000000", response.headers.Get("X-Current-Last-Modified"));
   }
-
 }
 
 namespace storage_docu {

--- a/Storage/rest/structured.h
+++ b/Storage/rest/structured.h
@@ -41,6 +41,11 @@ namespace storage {
 namespace rest {
 namespace generic {
 
+const std::string kLastModifiedHeader = "Last-Modified";
+const std::string kCurrentLastModifiedHeader = "X-Current-Last-Modified";
+const std::string kIfUnmodifiedSinceHeader = "If-Unmodified-Since";
+const std::string kCurrentIfUnmodifiedSinceHeader = "X-Current-If-Unmodified-Since";
+
 template <typename RESPONSE_FORMATTER>
 struct Structured {
   template <class HTTP_VERB, typename OPERATION, typename PARTICULAR_FIELD, typename ENTRY, typename KEY>
@@ -73,14 +78,26 @@ struct Structured {
   // Returns `false` on error.
   static bool ExtractIfUnmodifiedSinceOrRespondWithError(Request& request,
                                                          Optional<std::chrono::microseconds>& destination) {
-    if (request.headers.Has("If-Unmodified-Since")) {
-      const auto& header_value = request.headers.Get("If-Unmodified-Since");
+    // If `X-Current-If-Unmodified-Since` header is set, traditional `If-Unmodified-Since` is ignored.
+    if (request.headers.Has(kCurrentIfUnmodifiedSinceHeader)) {
+      const auto& header_value = request.headers.Get(kCurrentIfUnmodifiedSinceHeader);
+      const auto parsed_us = current::FromString<std::chrono::microseconds>(header_value);
+      if (parsed_us.count() > 0) {
+        destination = parsed_us;
+      } else {
+        request(ErrorResponseObject(InvalidHeaderError(
+                    "Invalid microsecond timestamp value.", kCurrentIfUnmodifiedSinceHeader, header_value)),
+                HTTPResponseCode.BadRequest);
+        return false;
+      }
+    } else if (request.headers.Has(kIfUnmodifiedSinceHeader)) {
+      const auto& header_value = request.headers.Get(kIfUnmodifiedSinceHeader);
       try {
         destination = net::http::ParseHTTPDate(header_value);
       } catch (const current::net::http::InvalidHTTPDateException&) {
-        request(
-            ErrorResponseObject(InvalidHeaderError("Unparsable datetime value.", "If-Unmodified-Since", header_value)),
-            HTTPResponseCode.BadRequest);
+        request(ErrorResponseObject(
+                    InvalidHeaderError("Unparsable datetime value.", kIfUnmodifiedSinceHeader, header_value)),
+                HTTPResponseCode.BadRequest);
         return false;
       }
     } else {
@@ -140,7 +157,8 @@ struct Structured {
                 url_collection + '/' + field_type_dependent_t<PARTICULAR_FIELD>::FormatURLKey(url_key_value);
             Response response = RESPONSE_FORMATTER::BuildResponseForResource(context, url, url_collection, value);
             if (Exists(last_modified)) {
-              response.SetHeader("Last-Modified", FormatDateTimeAsIMFFix(Value(last_modified)));
+              response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
+              response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
             }
             return response;
           } else {
@@ -289,7 +307,8 @@ struct Structured {
         auto response = Response(RESTResourceUpdateResponse(true, "Resource created.", url), HTTPResponseCode.Created);
         const auto last_modified = input.field.LastModified(entry_key);
         if (Exists(last_modified)) {
-          response.SetHeader("Last-Modified", FormatDateTimeAsIMFFix(Value(last_modified)));
+          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
+          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
         }
         return response;
       } else {
@@ -347,7 +366,8 @@ struct Structured {
         }
         const auto last_modified = input.field.LastModified(input.entry_key);
         if (Exists(last_modified)) {
-          response.SetHeader("Last-Modified", FormatDateTimeAsIMFFix(Value(last_modified)));
+          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
+          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
         }
         return response;
       } else {
@@ -413,7 +433,8 @@ struct Structured {
             Response response(hypermedia_response, HTTPResponseCode.OK);
             const auto last_modified = input.field.LastModified(input.patch_key);
             if (Exists(last_modified)) {
-              response.SetHeader("Last-Modified", FormatDateTimeAsIMFFix(Value(last_modified)));
+              response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
+              response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
             }
             return response;
           }
@@ -467,7 +488,8 @@ struct Structured {
       if (existed) {
         const auto last_modified = input.field.LastModified(input.delete_key);
         if (Exists(last_modified)) {
-          response.SetHeader("Last-Modified", FormatDateTimeAsIMFFix(Value(last_modified)));
+          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
+          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
         }
       }
       return response;

--- a/Storage/rest/structured.h
+++ b/Storage/rest/structured.h
@@ -78,7 +78,7 @@ struct Structured {
   // Returns `false` on error.
   static bool ExtractIfUnmodifiedSinceOrRespondWithError(Request& request,
                                                          Optional<std::chrono::microseconds>& destination) {
-    // If `X-Current-If-Unmodified-Since` header is set, traditional `If-Unmodified-Since` is ignored.
+    // If the `X-Current-If-Unmodified-Since` header is set, the traditional `If-Unmodified-Since` is ignored.
     if (request.headers.Has(kCurrentIfUnmodifiedSinceHeader)) {
       const auto& header_value = request.headers.Get(kCurrentIfUnmodifiedSinceHeader);
       const auto parsed_us = current::FromString<std::chrono::microseconds>(header_value);

--- a/Storage/rest/structured.h
+++ b/Storage/rest/structured.h
@@ -157,8 +157,9 @@ struct Structured {
                 url_collection + '/' + field_type_dependent_t<PARTICULAR_FIELD>::FormatURLKey(url_key_value);
             Response response = RESPONSE_FORMATTER::BuildResponseForResource(context, url, url_collection, value);
             if (Exists(last_modified)) {
-              response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
-              response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
+              const auto last_modified_value = Value(last_modified);
+              response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(last_modified_value));
+              response.SetHeader(kCurrentLastModifiedHeader, current::ToString(last_modified_value));
             }
             return response;
           } else {
@@ -307,8 +308,9 @@ struct Structured {
         auto response = Response(RESTResourceUpdateResponse(true, "Resource created.", url), HTTPResponseCode.Created);
         const auto last_modified = input.field.LastModified(entry_key);
         if (Exists(last_modified)) {
-          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
-          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
+          const auto last_modified_value = Value(last_modified);
+          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(last_modified_value));
+          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(last_modified_value));
         }
         return response;
       } else {
@@ -366,8 +368,9 @@ struct Structured {
         }
         const auto last_modified = input.field.LastModified(input.entry_key);
         if (Exists(last_modified)) {
-          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
-          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
+          const auto last_modified_value = Value(last_modified);
+          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(last_modified_value));
+          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(last_modified_value));
         }
         return response;
       } else {
@@ -433,8 +436,9 @@ struct Structured {
             Response response(hypermedia_response, HTTPResponseCode.OK);
             const auto last_modified = input.field.LastModified(input.patch_key);
             if (Exists(last_modified)) {
-              response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
-              response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
+              const auto last_modified_value = Value(last_modified);
+              response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(last_modified_value));
+              response.SetHeader(kCurrentLastModifiedHeader, current::ToString(last_modified_value));
             }
             return response;
           }
@@ -488,8 +492,9 @@ struct Structured {
       if (existed) {
         const auto last_modified = input.field.LastModified(input.delete_key);
         if (Exists(last_modified)) {
-          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(Value(last_modified)));
-          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(Value(last_modified)));
+          const auto last_modified_value = Value(last_modified);
+          response.SetHeader(kLastModifiedHeader, FormatDateTimeAsIMFFix(last_modified_value));
+          response.SetHeader(kCurrentLastModifiedHeader, current::ToString(last_modified_value));
         }
       }
       return response;

--- a/Storage/rest/types.h
+++ b/Storage/rest/types.h
@@ -155,7 +155,9 @@ inline generic::RESTError ResourceWasModifiedError(const std::string& message,
   return generic::RESTError("ResourceWasModifiedError",
                             message,
                             {{"requested_date", FormatDateTimeAsIMFFix(requested)},
-                             {"resource_last_modified_date", FormatDateTimeAsIMFFix(last_modified)}});
+                             {"requested_us", ToString(requested)},
+                             {"resource_last_modified_date", FormatDateTimeAsIMFFix(last_modified)},
+                             {"resource_last_modified_us", ToString(last_modified)}});
 }
 
 }  // namespace current::storage::rest::helpers


### PR DESCRIPTION
- `X-Current-Last-Modified` header containing microsecond modification timestamp is always set along with `Last-Modified`.
- `X-Current-If-Unmodified-Since` with the microsecond timestamp can be used for more precise updates. If this header is set, traditional `If-Unmodified-Since` is ignored.