### PR TITLE
FnCAS refactoring to support gradient compilation.

### DIFF
--- a/FnCAS/TODO.txt
+++ b/FnCAS/TODO.txt
@@ -1,0 +1,9 @@
+"Good to have"-s and "didn't-have-time-to-add"-s, in no particular order.
+
+* Hash of function. Use it in source / library file name. Don't regenerate / recompile same function.
+* Variable policies during optimization (ex. this var should always be positive).
+* Variable adjustment policies (ex. normalize this exp-normal simples to average of zero).
+* Return `PointAndValue` from a compiled function-plus-gradient (now returns only the gradient)?
+* Consider `as` (`gcc X.s`) instead of `nasm`. Or LLVM.
+* Consider self-modifying code too.
+* Tests for unary plus/minus.

--- a/FnCAS/deprecated_test/eval.cc
+++ b/FnCAS/deprecated_test/eval.cc
@@ -168,7 +168,9 @@ struct action_test_gradient : generic_action {
   fncas::g_approximate ga;
   std::unique_ptr<fncas::g_intermediate> gi;
   std::vector<double> errors;
-  static double error_between(double a, double b) { return fabs(b - a) / std::max(1.0, std::max(fabs(a), fabs(b))); }
+  static double error_between(double a, double b) {
+    return std::abs(b - a) / std::max(1.0, std::max(std::abs(a), std::abs(b)));
+  }
   static bool approximate_compare(double a, double b, double eps = 0.03) { return error_between(a, b) < eps; }
   void start() override {
     x = std::vector<double>(f->dim());

--- a/FnCAS/fncas/base.h
+++ b/FnCAS/fncas/base.h
@@ -60,7 +60,7 @@ T& growing_vector_access(std::vector<T>& vector, node_index_type index, V fill) 
 
 enum class type_t : uint8_t { variable, value, operation, function };
 enum class operation_t : uint8_t { add, subtract, multiply, divide, end };
-enum class function_t : uint8_t { sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, zero_or_one, zero_or_x, end };
+enum class function_t : uint8_t { sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, unit_step, ramp, end };
 
 }  // namespace fncas
 

--- a/FnCAS/fncas/base.h
+++ b/FnCAS/fncas/base.h
@@ -34,8 +34,13 @@
 
 namespace fncas {
 
-typedef int64_t node_index_type;  // Allow 4B+ nodes, keep the type signed for evaluation algorithms.
-typedef double fncas_value_type;
+typedef int64_t node_index_type;  // Allow 4B+ nodes on 64-bit arch, keep signed for (~i) vs. (i) index magic.
+
+#ifndef FNCAS_USE_LONG_DOUBLE
+typedef double double_t;  // Make it simple to switch to `long double` or a custom type.
+#else
+typedef long double double_t;
+#endif
 
 struct noncopyable {
   noncopyable() = default;
@@ -45,8 +50,8 @@ struct noncopyable {
   void operator=(noncopyable&&) = delete;
 };
 
-template <typename T>
-T& growing_vector_access(std::vector<T>& vector, node_index_type index, const T& fill) {
+template <typename T, typename V>
+T& growing_vector_access(std::vector<T>& vector, node_index_type index, V fill) {
   if (static_cast<node_index_type>(vector.size()) <= index) {
     vector.resize(static_cast<size_t>(index + 1), fill);
   }

--- a/FnCAS/fncas/base.h
+++ b/FnCAS/fncas/base.h
@@ -60,7 +60,7 @@ T& growing_vector_access(std::vector<T>& vector, node_index_type index, V fill) 
 
 enum class type_t : uint8_t { variable, value, operation, function };
 enum class operation_t : uint8_t { add, subtract, multiply, divide, end };
-enum class function_t : uint8_t { sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, end };
+enum class function_t : uint8_t { sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, zero_or_one, zero_or_x, end };
 
 }  // namespace fncas
 

--- a/FnCAS/fncas/differentiate.h
+++ b/FnCAS/fncas/differentiate.h
@@ -36,10 +36,10 @@ namespace fncas {
 static const double_t APPROXIMATE_DERIVATIVE_EPS = 1e-4;
 
 template <typename F>
-inline double_t approximate_derivative(F f,
-                                       const std::vector<double_t>& x,
-                                       node_index_type i,
-                                       const double_t EPS = APPROXIMATE_DERIVATIVE_EPS) {
+double_t approximate_derivative(F f,
+                                const std::vector<double_t>& x,
+                                node_index_type i,
+                                const double_t EPS = APPROXIMATE_DERIVATIVE_EPS) {
   std::vector<double_t> x1(x);
   std::vector<double_t> x2(x);
   x1[i] -= EPS;
@@ -48,9 +48,9 @@ inline double_t approximate_derivative(F f,
 }
 
 template <typename F>
-inline std::vector<double_t> approximate_gradient(F f,
-                                                  const std::vector<double_t>& x,
-                                                  const double_t EPS = APPROXIMATE_DERIVATIVE_EPS) {
+std::vector<double_t> approximate_gradient(F f,
+                                           const std::vector<double_t>& x,
+                                           const double_t EPS = APPROXIMATE_DERIVATIVE_EPS) {
   std::vector<double_t> g(x.size());
   std::vector<double_t> xx(x);
   for (size_t i = 0; i < xx.size(); ++i) {

--- a/FnCAS/fncas/differentiate.h
+++ b/FnCAS/fncas/differentiate.h
@@ -102,7 +102,13 @@ inline node_index_type d_f(function_t function, const V& original, const V& x, c
       [](const V&, const V& x, const V& dx) { return V(-1.0) * dx / sqrt(V(1.0) - x * x); },
       // atan().
       [](const V&, const V& x, const V& dx) { return dx / (x * x + 1); },
-  };
+      // zero_or_one().
+      [](const V& o, const V&, const V&) {
+        CURRENT_THROW(FnCASZeroOrOneIsNonDifferentiable());
+        return o;
+      },
+      // zero_or_x().
+      [](const V&, const V& x, const V& dx) { return zero_or_one(x) * dx; }};
   return function < function_t::end ? differentiator[static_cast<size_t>(function)](original, x, dx).index() : 0;
 }
 

--- a/FnCAS/fncas/differentiate.h
+++ b/FnCAS/fncas/differentiate.h
@@ -102,13 +102,13 @@ inline node_index_type d_f(function_t function, const V& original, const V& x, c
       [](const V&, const V& x, const V& dx) { return V(-1.0) * dx / sqrt(V(1.0) - x * x); },
       // atan().
       [](const V&, const V& x, const V& dx) { return dx / (x * x + 1); },
-      // zero_or_one().
+      // unit_step().
       [](const V& o, const V&, const V&) {
         CURRENT_THROW(FnCASZeroOrOneIsNonDifferentiable());
         return o;
       },
-      // zero_or_x().
-      [](const V&, const V& x, const V& dx) { return zero_or_one(x) * dx; }};
+      // ramp().
+      [](const V&, const V& x, const V& dx) { return unit_step(x) * dx; }};
   return function < function_t::end ? differentiator[static_cast<size_t>(function)](original, x, dx).index() : 0;
 }
 

--- a/FnCAS/fncas/differentiate.h
+++ b/FnCAS/fncas/differentiate.h
@@ -36,10 +36,10 @@ namespace fncas {
 static const double_t APPROXIMATE_DERIVATIVE_EPS = 1e-4;
 
 template <typename F>
-double_t approximate_derivative(F f,
-                                const std::vector<double_t>& x,
-                                node_index_type i,
-                                const double_t EPS = APPROXIMATE_DERIVATIVE_EPS) {
+inline double_t approximate_derivative(F f,
+                                       const std::vector<double_t>& x,
+                                       node_index_type i,
+                                       const double_t EPS = APPROXIMATE_DERIVATIVE_EPS) {
   std::vector<double_t> x1(x);
   std::vector<double_t> x2(x);
   x1[i] -= EPS;

--- a/FnCAS/fncas/exceptions.h
+++ b/FnCAS/fncas/exceptions.h
@@ -40,6 +40,10 @@ struct FnCASException : current::Exception {
 // This is not allowed. FnCAS keeps global state per thread, which leads to this constraint.
 struct FnCASConcurrentEvaluationAttemptException : FnCASException {};
 
+// Exceptions for attempting to differentiate a function that doesn't have a derivative.
+struct FnCASFunctionNonDifferentiable : FnCASException {};
+struct FnCASZeroOrOneIsNonDifferentiable : FnCASFunctionNonDifferentiable {};
+
 // This exception is thrown when the optimization process fails,
 // most notably when the objective function becomes not `fncas::IsNormal()`, which is NaN.
 struct FnCASOptimizationException : FnCASException {

--- a/FnCAS/fncas/exceptions.h
+++ b/FnCAS/fncas/exceptions.h
@@ -36,14 +36,20 @@ struct FnCASException : current::Exception {
 };
 
 // This exception is thrown when more than one expression per thread
-// is attempted to be evaluated concurrently under FNCAS.
-// This is not allowed. FNCAS keeps global state per thread, which leads to this constraint.
+// is attempted to be evaluated concurrently under FnCAS.
+// This is not allowed. FnCAS keeps global state per thread, which leads to this constraint.
 struct FnCASConcurrentEvaluationAttemptException : FnCASException {};
 
 // This exception is thrown when the optimization process fails,
 // most notably when the objective function becomes not `fncas::IsNormal()`, which is NaN.
 struct FnCASOptimizationException : FnCASException {
   using FnCASException::FnCASException;
+};
+
+// This exception is thrown when the call to `Backtracking` in `mathutil.h` results in no viable step found.
+// It's generally an error, but a particulal optimization algorithms may choose to handle it.
+struct BacktrackingException : FnCASOptimizationException {
+  using FnCASOptimizationException::FnCASOptimizationException;
 };
 
 }  // namespace fncas

--- a/FnCAS/fncas/jit.h
+++ b/FnCAS/fncas/jit.h
@@ -315,31 +315,31 @@ struct compile_impl final {
               fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.argument_index()) * 8);
               fprintf(f, "  mulpd xmm0, xmm0\n");
               fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
-            } else if (node.function() == function_t::zero_or_one) {
+            } else if (node.function() == function_t::unit_step) {
               fprintf(f,
-                      "  ; a[%lld] = zero_or_one(a[%lld]);  # `zero_or_one` is a special case.\n",
+                      "  ; a[%lld] = unit_step(a[%lld]);  # `unit_step` is a special case.\n",
                       static_cast<long long>(dependent_i),
                       static_cast<long long>(node.argument_index()));
               fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.argument_index()) * 8);
               fprintf(f, "  mov rax, %s  ; 0\n", std::to_string(*reinterpret_cast<const int64_t*>(&d_0)).c_str());
               fprintf(f, "  movq xmm1, rax\n");
               fprintf(f, "  ucomisd xmm0, xmm1\n");
-              fprintf(f, "  jb zero_or_one_%lld\n", static_cast<long long>(dependent_i));
+              fprintf(f, "  jb unit_step_%lld\n", static_cast<long long>(dependent_i));
               fprintf(f, "  mov rax, %s  ; 1\n", std::to_string(*reinterpret_cast<const int64_t*>(&d_1)).c_str());
-              fprintf(f, "zero_or_one_%lld:\n", static_cast<long long>(dependent_i));
+              fprintf(f, "unit_step_%lld:\n", static_cast<long long>(dependent_i));
               fprintf(f, "  mov [rsi+%lld], rax\n", static_cast<long long>(dependent_i) * 8);
-            } else if (node.function() == function_t::zero_or_x) {
+            } else if (node.function() == function_t::ramp) {
               fprintf(f,
-                      "  ; a[%lld] = zero_or_x(a[%lld]);  # `zero_or_x` is a special case.\n",
+                      "  ; a[%lld] = ramp(a[%lld]);  # `ramp` is a special case.\n",
                       static_cast<long long>(dependent_i),
                       static_cast<long long>(node.argument_index()));
               fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.argument_index()) * 8);
               fprintf(f, "  mov rax, %s  ; 0\n", std::to_string(*reinterpret_cast<const int64_t*>(&d_0)).c_str());
               fprintf(f, "  movq xmm1, rax\n");
               fprintf(f, "  ucomisd xmm0, xmm1\n");
-              fprintf(f, "  ja zero_or_x_%lld\n", static_cast<long long>(dependent_i));
+              fprintf(f, "  ja ramp_%lld\n", static_cast<long long>(dependent_i));
               fprintf(f, "  movq xmm0, rax\n");
-              fprintf(f, "zero_or_x_%lld:\n", static_cast<long long>(dependent_i));
+              fprintf(f, "ramp_%lld:\n", static_cast<long long>(dependent_i));
               fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
             } else {
               fprintf(f,
@@ -370,8 +370,8 @@ struct compile_impl final {
       CURRENT_ASSERT(f);
       fprintf(f, "#include <math.h>\n");
       fprintf(f, "#define sqr(x) ((x) * (x))\n");
-      fprintf(f, "#define zero_or_one(x) ((x) >= 0 ? 1 : 0)\n");
-      fprintf(f, "#define zero_or_x(x) ((x) >= 0 ? (x) : 0)\n");
+      fprintf(f, "#define unit_step(x) ((x) >= 0 ? 1 : 0)\n");
+      fprintf(f, "#define ramp(x) ((x) >= 0 ? (x) : 0)\n");
     }
 
     void compile_eval_f(node_index_type index) {

--- a/FnCAS/fncas/jit.h
+++ b/FnCAS/fncas/jit.h
@@ -23,11 +23,13 @@
  * SOFTWARE.
  * *******************************************************************************/
 
-// FNCAS on-the-fly compilation logic.
-// FNCAS_JIT must be defined to enable, supported values are 'NASM' and 'CLANG'.
+// FnCAS on-the-fly compilation logic.
+// FNCAS_JIT must be defined to enable, the supported values are 'NASM' and 'CLANG'.
 
 #ifndef FNCAS_JIT_H
 #define FNCAS_JIT_H
+
+#ifndef FNCAS_USE_LONG_DOUBLE
 
 // Do include this header in the `make test` target for checking there are no leaked symbols.
 #ifdef CURRENT_MAKE_CHECK_MODE
@@ -51,51 +53,120 @@
 
 #include "base.h"
 #include "node.h"
+#include "differentiate.h"
 
 namespace fncas {
+
+static_assert(std::is_same<double, double_t>::value, "FnCAS JIT assumes `double_t` is the native double.");
 
 // Linux-friendly code to compile into .so and link against it at runtime.
 // Not portable.
 
-struct compiled_expression : noncopyable {
+inline const char* operation_as_nasm_instruction(operation_t operation) {
+  static const char* representation[static_cast<size_t>(operation_t::end)] = {
+      "addpd", "subpd", "mulpd", "divpd",
+  };
+  return operation < operation_t::end ? representation[static_cast<size_t>(operation)] : "?";
+}
+
+struct compiled_expression final : noncopyable {
   typedef long long (*DIM)();
-  typedef double (*EVAL)(const double* x, double* a);
+  typedef long long (*HEAP_SIZE)();
+  typedef double (*FUNCTION)(const double* x, double* a);
+  typedef void (*GRADIENT)(const double* x, double* a);
+
   void* lib_;
   DIM dim_;
-  EVAL eval_;
+  HEAP_SIZE heap_size_;
+  FUNCTION function_;
+  GRADIENT gradient_;
+
   const std::string lib_filename_;
-  explicit compiled_expression(const std::string& lib_filename) : lib_filename_(lib_filename) {
+
+  using gradient_indexes_t = std::vector<node_index_type>;
+  gradient_indexes_t gradient_indexes_;
+
+  explicit compiled_expression(const std::string& lib_filename,
+                               const gradient_indexes_t& gradient_indexes = gradient_indexes_t())
+      : lib_filename_(lib_filename), gradient_indexes_(gradient_indexes) {
     lib_ = dlopen(lib_filename.c_str(), RTLD_LAZY);
     CURRENT_ASSERT(lib_);
-    dim_ = reinterpret_cast<DIM>(dlsym(lib_, "dim"));
-    eval_ = reinterpret_cast<EVAL>(dlsym(lib_, "eval"));
+    dim_ = reinterpret_cast<HEAP_SIZE>(dlsym(lib_, "dim"));
+    heap_size_ = reinterpret_cast<HEAP_SIZE>(dlsym(lib_, "heap_size"));
+    function_ = reinterpret_cast<FUNCTION>(dlsym(lib_, "eval_f"));
+    gradient_ = reinterpret_cast<GRADIENT>(dlsym(lib_, "eval_g"));
     CURRENT_ASSERT(dim_);
-    CURRENT_ASSERT(eval_);
+    CURRENT_ASSERT(heap_size_);
   }
+
   ~compiled_expression() {
     if (lib_) {
       dlclose(lib_);
     }
   }
+
+  bool HasFunction() const { return function_; }
+  bool HasGradient() const { return gradient_; }
+
   compiled_expression(const compiled_expression&) = delete;
   void operator=(const compiled_expression&) = delete;
+
   compiled_expression(compiled_expression&& rhs)
       : lib_(std::move(rhs.lib_)),
         dim_(std::move(rhs.dim_)),
-        eval_(std::move(rhs.eval_)),
+        heap_size_(std::move(rhs.heap_size_)),
+        function_(std::move(rhs.function_)),
+        gradient_(std::move(rhs.gradient_)),
         lib_filename_(std::move(rhs.lib_filename_)) {
     rhs.lib_ = nullptr;
   }
-  double operator()(const double* x) const {
-    std::vector<double>& tmp = internals_singleton().ram_for_compiled_evaluations_;
-    node_index_type dim = static_cast<node_index_type>(dim_());
-    if (tmp.size() < static_cast<size_t>(dim)) {
-      tmp.resize(dim);
+
+  double compute_compiled_f(const double* x) const {
+    CURRENT_ASSERT(dim_);
+    CURRENT_ASSERT(heap_size_);
+    CURRENT_ASSERT(function_);
+
+    std::vector<double>& heap = internals_singleton().heap_for_compiled_evaluations_;
+    const size_t desired_heap_size = heap_size_();
+    if (heap.size() < desired_heap_size) {
+      heap.resize(desired_heap_size);
     }
-    return eval_(x, &tmp[0]);
+
+    return function_(x, &heap[0]);
   }
-  double operator()(const std::vector<double>& x) const { return operator()(&x[0]); }
-  node_index_type dim() const { return dim_ ? static_cast<node_index_type>(dim_()) : 0; }
+
+  double compute_compiled_f(const std::vector<double>& x) const { return compute_compiled_f(&x[0]); }
+
+  std::vector<double> compute_compiled_g(const double* x) const {
+    CURRENT_ASSERT(dim_);
+    CURRENT_ASSERT(heap_size_);
+    CURRENT_ASSERT(gradient_);
+    const auto dim = static_cast<size_t>(dim_());
+    CURRENT_ASSERT(gradient_indexes_.size() == dim);
+
+    std::vector<double>& heap = internals_singleton().heap_for_compiled_evaluations_;
+    const size_t desired_heap_size = heap_size_();
+    if (heap.size() < desired_heap_size) {
+      heap.resize(desired_heap_size);
+    }
+
+    gradient_(x, &heap[0]);
+
+    CURRENT_ASSERT(gradient_indexes_.size() == dim);
+    std::vector<double> result(dim);
+    for (size_t i = 0; i < gradient_indexes_.size(); ++i) {
+      CURRENT_ASSERT(static_cast<size_t>(gradient_indexes_[i]) < heap.size());
+      result[i] = heap[gradient_indexes_[i]];
+    }
+
+    return result;
+  }
+
+  std::vector<double> compute_compiled_g(const std::vector<double>& x) const { return compute_compiled_g(&x[0]); }
+
+  node_index_type dim() const { return dim_ ? static_cast<size_t>(dim_()) : 0; }
+  size_t heap_size() const { return heap_size_ ? static_cast<size_t>(heap_size_()) : 0; }
+
   static void syscall(const std::string& command) {
     int retval = system(command.c_str());
     if (retval) {
@@ -104,220 +175,354 @@ struct compiled_expression : noncopyable {
       exit(-1);
     }
   }
+
   const std::string& lib_filename() const { return lib_filename_; }
 };
 
-// generate_c_code_for_node() writes C code to evaluate the expression to the file.
-inline void generate_c_code_for_node(node_index_type index, FILE* f) {
-  fprintf(f, "#include <math.h>\n");
-  fprintf(f, "double eval(const double* x, double* a) {\n");
-  node_index_type max_dim = index;
-  std::stack<node_index_type> stack;
-  stack.push(index);
-  while (!stack.empty()) {
-    const node_index_type i = stack.top();
-    stack.pop();
-    const node_index_type dependent_i = ~i;
-    if (i > dependent_i) {
-      max_dim = std::max(max_dim, static_cast<node_index_type>(i));
-      node_impl& node = node_vector_singleton()[i];
-      if (node.type() == type_t::variable) {
-        int32_t v = node.variable();
-        fprintf(f, "  a[%lld] = x[%d];\n", static_cast<long long>(i), v);
-      } else if (node.type() == type_t::value) {
-        fprintf(f,
-                "  a[%lld] = %a;\n",
-                static_cast<long long>(i),
-                node.value());  // "%a" is hexadecimal full precision.
-      } else if (node.type() == type_t::operation) {
-        stack.push(~i);
-        stack.push(node.lhs_index());
-        stack.push(node.rhs_index());
-      } else if (node.type() == type_t::function) {
-        stack.push(~i);
-        stack.push(node.argument_index());
-      } else {
-        CURRENT_ASSERT(false);
-      }
-    } else {
-      node_impl& node = node_vector_singleton()[dependent_i];
-      if (node.type() == type_t::operation) {
-        fprintf(f,
-                "  a[%lld] = a[%lld] %s a[%lld];\n",
-                static_cast<long long>(dependent_i),
-                static_cast<long long>(node.lhs_index()),
-                operation_as_string(node.operation()),
-                static_cast<long long>(node.rhs_index()));
-      } else if (node.type() == type_t::function) {
-        fprintf(f,
-                "  a[%lld] = %s(a[%lld]);\n",
-                static_cast<long long>(dependent_i),
-                function_as_string(node.function()),
-                static_cast<long long>(node.argument_index()));
-      } else {
-        CURRENT_ASSERT(false);
-      }
-    }
-  }
-  fprintf(f, "  return a[%lld];\n", static_cast<long long>(index));
-  fprintf(f, "}\n");
-  fprintf(f, "long long dim() { return %lld; }\n", static_cast<long long>(max_dim + 1));
-}
-
-// generate_asm_code_for_node() writes NASM code to evaluate the expression to the file.
-inline const char* operation_as_nasm_instruction(operation_t operation) {
-  static const char* representation[static_cast<size_t>(operation_t::end)] = {
-      "addpd", "subpd", "mulpd", "divpd",
-  };
-  return operation < operation_t::end ? representation[static_cast<size_t>(operation)] : "?";
-}
-
-inline void generate_asm_code_for_node(node_index_type index, FILE* f) {
-  fprintf(f, "[bits 64]\n");
-  fprintf(f, "\n");
-  fprintf(f, "global eval, dim\n");
-  fprintf(f, "extern sqrt, exp, log, sin, cos, tan, asin, acos, atan\n");
-  fprintf(f, "\n");
-  fprintf(f, "section .text\n");
-  fprintf(f, "\n");
-  fprintf(f, "eval:\n");
-  fprintf(f, "  push rbp\n");
-  fprintf(f, "  mov rbp, rsp\n");
-  node_index_type max_dim = index;
-  std::stack<node_index_type> stack;
-  stack.push(index);
-  while (!stack.empty()) {
-    const node_index_type i = stack.top();
-    stack.pop();
-    const node_index_type dependent_i = ~i;
-    if (i > dependent_i) {
-      max_dim = std::max(max_dim, static_cast<node_index_type>(i));
-      node_impl& node = node_vector_singleton()[i];
-      if (node.type() == type_t::variable) {
-        int32_t v = node.variable();
-        fprintf(f, "  ; a[%lld] = x[%d];\n", static_cast<long long>(i), v);
-        fprintf(f, "  mov rax, [rdi+%d]\n", v * 8);
-        fprintf(f, "  mov [rsi+%lld], rax\n", static_cast<long long>(i) * 8);
-      } else if (node.type() == type_t::value) {
-        fprintf(f,
-                "  ; a[%lld] = %a;\n",
-                static_cast<long long>(i),
-                node.value());  // "%a" is hexadecimal full precision.
-        fprintf(f, "  mov rax, %s\n", std::to_string(*reinterpret_cast<int64_t*>(&node.value())).c_str());
-        fprintf(f, "  mov [rsi+%lld], rax\n", static_cast<long long>(i) * 8);
-      } else if (node.type() == type_t::operation) {
-        stack.push(~i);
-        stack.push(node.lhs_index());
-        stack.push(node.rhs_index());
-      } else if (node.type() == type_t::function) {
-        stack.push(~i);
-        stack.push(node.argument_index());
-      } else {
-        CURRENT_ASSERT(false);
-      }
-    } else {
-      node_impl& node = node_vector_singleton()[dependent_i];
-      if (node.type() == type_t::operation) {
-        fprintf(f,
-                "  ; a[%lld] = a[%lld] %s a[%lld];\n",
-                static_cast<long long>(dependent_i),
-                static_cast<long long>(node.lhs_index()),
-                operation_as_string(node.operation()),
-                static_cast<long long>(node.rhs_index()));
-        fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.lhs_index()) * 8);
-        fprintf(f, "  movq xmm1, [rsi+%lld]\n", static_cast<long long>(node.rhs_index()) * 8);
-        fprintf(f, "  %s xmm0, xmm1\n", operation_as_nasm_instruction(node.operation()));
-        fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
-      } else if (node.type() == type_t::function) {
-        fprintf(f,
-                "  ; a[%lld] = %s(a[%lld]);\n",
-                static_cast<long long>(dependent_i),
-                function_as_string(node.function()),
-                static_cast<long long>(node.argument_index()));
-        fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.argument_index()) * 8);
-        fprintf(f, "  push rdi\n");
-        fprintf(f, "  push rsi\n");
-        fprintf(f, "  call %s wrt ..plt\n", function_as_string(node.function()));
-        fprintf(f, "  pop rsi\n");
-        fprintf(f, "  pop rdi\n");
-        fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
-      } else {
-        CURRENT_ASSERT(false);
-      }
-    }
-  }
-  fprintf(f, "  ; return a[%lld]\n", static_cast<long long>(index));
-  fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(index) * 8);
-  fprintf(f, "  mov rsp, rbp\n");
-  fprintf(f, "  pop rbp\n");
-  fprintf(f, "  ret\n");
-  fprintf(f, "\n");
-  fprintf(f, "dim:\n");
-  fprintf(f, "  push rbp\n");
-  fprintf(f, "  mov rbp, rsp\n");
-  fprintf(f, "  mov rax, %lld\n", static_cast<long long>(max_dim + 1));
-  fprintf(f, "  mov rsp, rbp\n");
-  fprintf(f, "  pop rbp\n");
-  fprintf(f, "  ret\n");
-}
-
-struct compile_impl {
-  struct NASM {
-    static void compile(const std::string& filebase, node_index_type index) {
-      FILE* f = fopen((filebase + ".asm").c_str(), "w");
+struct compile_impl final {
+  class NASM final {
+   public:
+    NASM(const std::string& filebase, bool has_g) : filebase(filebase), f(fopen((filebase + ".asm").c_str(), "w")) {
       CURRENT_ASSERT(f);
-      generate_asm_code_for_node(index, f);
+
+      fprintf(f, "[bits 64]\n");
+      fprintf(f, "\n");
+      fprintf(f, "global %s, dim, heap_size\n", !has_g ? "eval_f" : "eval_g");
+      fprintf(f, "extern sqrt, exp, log, sin, cos, tan, asin, acos, atan\n");
+      fprintf(f, "\n");
+      fprintf(f, "section .text\n");
+      fprintf(f, "\n");
+    }
+
+    void compile_eval_f(node_index_type index) {
+      fprintf(f, "eval_f:\n");
+      fprintf(f, "  push rbp\n");
+      fprintf(f, "  mov rbp, rsp\n");
+      generate_asm_code_for_node(index);
+      fprintf(f, "  ; return a[%lld]\n", static_cast<long long>(index));
+      fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(index) * 8);
+      fprintf(f, "  mov rsp, rbp\n");
+      fprintf(f, "  pop rbp\n");
+      fprintf(f, "  ret\n");
+    }
+
+    void compile_eval_g(node_index_type f_index, const std::vector<node_index_type>& g_indexes) {
+      CURRENT_ASSERT(g_indexes.size() == internals_singleton().dim_);
+      fprintf(f, "eval_g:\n");
+      fprintf(f, "  push rbp\n");
+      fprintf(f, "  mov rbp, rsp\n");
+      generate_asm_code_for_node(f_index);
+      for (size_t i = 0; i < g_indexes.size(); ++i) {
+        generate_asm_code_for_node(g_indexes[i]);
+        fprintf(f, "  ; g[%lld] is a[%lld]\n", static_cast<long long>(i), static_cast<long long>(g_indexes[i]));
+      }
+      fprintf(f, "  ; return a[%lld]\n", static_cast<long long>(f_index));
+      fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(f_index) * 8);
+      fprintf(f, "  mov rsp, rbp\n");
+      fprintf(f, "  pop rbp\n");
+      fprintf(f, "  ret\n");
+    }
+
+    ~NASM() {
+      fprintf(f, "\n");
+      fprintf(f, "dim:\n");
+      fprintf(f, "  push rbp\n");
+      fprintf(f, "  mov rbp, rsp\n");
+      fprintf(f, "  mov rax, %lld\n", static_cast<long long>(internals_singleton().dim_));
+      fprintf(f, "  mov rsp, rbp\n");
+      fprintf(f, "  pop rbp\n");
+      fprintf(f, "  ret\n");
+      fprintf(f, "\n");
+      fprintf(f, "heap_size:\n");
+      fprintf(f, "  push rbp\n");
+      fprintf(f, "  mov rbp, rsp\n");
+      fprintf(f, "  mov rax, %lld\n", static_cast<long long>(max_dim + 1));
+      fprintf(f, "  mov rsp, rbp\n");
+      fprintf(f, "  pop rbp\n");
+      fprintf(f, "  ret\n");
       fclose(f);
 
-      const char* compile_cmdline = "nasm -f elf64 %s.asm -o %s.o";
+      const char* compile_cmdline = "nasm -O0 -f elf64 %s.asm -o %s.o";
       const char* link_cmdline = "ld -lm -shared -o %s.so %s.o";
 
       compiled_expression::syscall(current::strings::Printf(compile_cmdline, filebase.c_str(), filebase.c_str()));
       compiled_expression::syscall(current::strings::Printf(link_cmdline, filebase.c_str(), filebase.c_str()));
     }
+
+   private:
+    const std::string& filebase;
+    FILE* f;
+    std::vector<bool> computed;
+    node_index_type max_dim = 0;
+
+    // generate_asm_code_for_node() writes NASM code to evaluate the expression to the file.
+    void generate_asm_code_for_node(node_index_type index) {
+      std::stack<node_index_type> stack;
+      stack.push(index);
+      while (!stack.empty()) {
+        const node_index_type i = stack.top();
+        stack.pop();
+        const node_index_type dependent_i = ~i;
+        if (i > dependent_i) {
+          max_dim = std::max(max_dim, static_cast<node_index_type>(i));
+          if (computed.size() <= static_cast<size_t>(i)) {
+            computed.resize(static_cast<size_t>(i) + 1);
+          }
+          if (!computed[i]) {
+            computed[i] = true;
+            node_impl& node = node_vector_singleton()[i];
+            if (node.type() == type_t::variable) {
+              int32_t v = node.variable();
+              fprintf(f, "  ; a[%lld] = x[%d];\n", static_cast<long long>(i), v);
+              fprintf(f, "  mov rax, [rdi+%d]\n", v * 8);
+              fprintf(f, "  mov [rsi+%lld], rax\n", static_cast<long long>(i) * 8);
+            } else if (node.type() == type_t::value) {
+              fprintf(f,
+                      "  ; a[%lld] = %a;\n",
+                      static_cast<long long>(i),
+                      node.value());  // "%a" is hexadecimal full precision.
+              fprintf(f, "  mov rax, %s\n", std::to_string(*reinterpret_cast<int64_t*>(&node.value())).c_str());
+              fprintf(f, "  mov [rsi+%lld], rax\n", static_cast<long long>(i) * 8);
+            } else if (node.type() == type_t::operation) {
+              stack.push(~i);
+              stack.push(node.lhs_index());
+              stack.push(node.rhs_index());
+            } else if (node.type() == type_t::function) {
+              stack.push(~i);
+              stack.push(node.argument_index());
+            } else {
+              CURRENT_ASSERT(false);
+            }
+          }
+        } else {
+          node_impl& node = node_vector_singleton()[dependent_i];
+          if (node.type() == type_t::operation) {
+            fprintf(f,
+                    "  ; a[%lld] = a[%lld] %s a[%lld];\n",
+                    static_cast<long long>(dependent_i),
+                    static_cast<long long>(node.lhs_index()),
+                    operation_as_string(node.operation()),
+                    static_cast<long long>(node.rhs_index()));
+            fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.lhs_index()) * 8);
+            fprintf(f, "  movq xmm1, [rsi+%lld]\n", static_cast<long long>(node.rhs_index()) * 8);
+            fprintf(f, "  %s xmm0, xmm1\n", operation_as_nasm_instruction(node.operation()));
+            fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
+          } else if (node.type() == type_t::function) {
+            if (node.function() == function_t::sqr) {
+              fprintf(f,
+                      "  ; a[%lld] = sqr(a[%lld]);  # `sqr` is a special case.\n",
+                      static_cast<long long>(dependent_i),
+                      static_cast<long long>(node.argument_index()));
+              fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.argument_index()) * 8);
+              fprintf(f, "  mulpd xmm0, xmm0\n");
+              fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
+            } else {
+              fprintf(f,
+                      "  ; a[%lld] = %s(a[%lld]);\n",
+                      static_cast<long long>(dependent_i),
+                      function_as_string(node.function()),
+                      static_cast<long long>(node.argument_index()));
+              fprintf(f, "  movq xmm0, [rsi+%lld]\n", static_cast<long long>(node.argument_index()) * 8);
+              fprintf(f, "  push rdi\n");
+              fprintf(f, "  push rsi\n");
+              fprintf(f, "  call %s wrt ..plt\n", function_as_string(node.function()));
+              fprintf(f, "  pop rsi\n");
+              fprintf(f, "  pop rdi\n");
+              fprintf(f, "  movq [rsi+%lld], xmm0\n", static_cast<long long>(dependent_i) * 8);
+            }
+          } else {
+            CURRENT_ASSERT(false);
+          }
+        }
+      }
+    }
   };
-  struct CLANG {
-    static void compile(const std::string& filebase, node_index_type index) {
-      FILE* f = fopen((filebase + ".c").c_str(), "w");
+
+  class CLANG final {
+   public:
+    CLANG(const std::string& filebase, bool has_g) : filebase(filebase), f(fopen((filebase + ".c").c_str(), "w")) {
+      static_cast<void>(has_g);
       CURRENT_ASSERT(f);
-      generate_c_code_for_node(index, f);
+      fprintf(f, "#include <math.h>\n");
+      fprintf(f, "#define sqr(x) ((x) * (x))\n");
+    }
+
+    void compile_eval_f(node_index_type index) {
+      fprintf(f, "double eval_f(const double* x, double* a) {\n");
+      generate_c_code_for_node(index);
+      fprintf(f, "  return a[%lld];\n", static_cast<long long>(index));
+      fprintf(f, "}\n");
+    }
+
+    void compile_eval_g(node_index_type f_index, const std::vector<node_index_type>& g_indexes) {
+      CURRENT_ASSERT(g_indexes.size() == internals_singleton().dim_);
+      fprintf(f, "double eval_g(const double* x, double* a) {\n");
+      generate_c_code_for_node(f_index);
+      for (size_t i = 0; i < g_indexes.size(); ++i) {
+        generate_c_code_for_node(g_indexes[i]);
+      }
+      for (size_t i = 0; i < g_indexes.size(); ++i) {
+        fprintf(f, "  // g[%lld] is a[%lld]\n", static_cast<long long>(i), static_cast<long long>(g_indexes[i]));
+      }
+      fprintf(f, "  return a[%lld];\n", static_cast<long long>(f_index));
+      fprintf(f, "}\n");
+    }
+
+    ~CLANG() {
+      fprintf(f, "long long dim() { return %lld; }\n", static_cast<long long>(internals_singleton().dim_));
+      fprintf(f, "long long heap_size() { return %lld; }\n", static_cast<long long>(max_dim + 1));
+
       fclose(f);
 
-      const char* compile_cmdline = "clang -fPIC -shared -nostartfiles %s.c -o %s.so";
+      const char* compile_cmdline = "clang -fPIC -shared -nostartfiles %s.c -o %s.so";  // `-O3` is too slow.
       std::string cmdline = current::strings::Printf(compile_cmdline, filebase.c_str(), filebase.c_str());
       compiled_expression::syscall(cmdline);
     }
+
+   private:
+    const std::string& filebase;
+    FILE* f;
+    std::vector<bool> computed;
+    node_index_type max_dim = 0;
+
+    // generate_c_code_for_node() writes C code to evaluate the expression to the file.
+    void generate_c_code_for_node(node_index_type index) {
+      std::stack<node_index_type> stack;
+      stack.push(index);
+      while (!stack.empty()) {
+        const node_index_type i = stack.top();
+        stack.pop();
+        const node_index_type dependent_i = ~i;
+        if (i > dependent_i) {
+          max_dim = std::max(max_dim, static_cast<node_index_type>(i));
+          if (computed.size() <= static_cast<size_t>(i)) {
+            computed.resize(static_cast<size_t>(i) + 1);
+          }
+          if (!computed[i]) {
+            computed[i] = true;
+            node_impl& node = node_vector_singleton()[i];
+            if (node.type() == type_t::variable) {
+              int32_t v = node.variable();
+              fprintf(f, "  a[%lld] = x[%d];\n", static_cast<long long>(i), v);
+            } else if (node.type() == type_t::value) {
+              fprintf(f,
+                      "  a[%lld] = %a;\n",
+                      static_cast<long long>(i),
+                      node.value());  // "%a" is hexadecimal full precision.
+            } else if (node.type() == type_t::operation) {
+              stack.push(~i);
+              stack.push(node.lhs_index());
+              stack.push(node.rhs_index());
+            } else if (node.type() == type_t::function) {
+              stack.push(~i);
+              stack.push(node.argument_index());
+            } else {
+              CURRENT_ASSERT(false);
+            }
+          }
+        } else {
+          node_impl& node = node_vector_singleton()[dependent_i];
+          if (node.type() == type_t::operation) {
+            fprintf(f,
+                    "  a[%lld] = a[%lld] %s a[%lld];\n",
+                    static_cast<long long>(dependent_i),
+                    static_cast<long long>(node.lhs_index()),
+                    operation_as_string(node.operation()),
+                    static_cast<long long>(node.rhs_index()));
+          } else if (node.type() == type_t::function) {
+            fprintf(f,
+                    "  a[%lld] = %s(a[%lld]);\n",
+                    static_cast<long long>(dependent_i),
+                    function_as_string(node.function()),
+                    static_cast<long long>(node.argument_index()));
+          } else {
+            CURRENT_ASSERT(false);
+          }
+        }
+      }
+    }
   };
-  // Confirm FNCAS_JIT is a valid identifier.
+
+  // Confirm the symbol `#define`-d as `FNCAS_JIT` is a valid identifier.
   struct _TMP {
     struct FNCAS_JIT {};
   };
   typedef FNCAS_JIT selected;
 };
 
-inline compiled_expression compile(node_index_type index) {
+inline compiled_expression compile_eval_f(node_index_type index) {
   const std::string filebase(current::FileSystem::GenTmpFileName());
   const std::string filename_so = filebase + ".so";
   current::FileSystem::RmFile(filename_so, current::FileSystem::RmFileParameters::Silent);
-  compile_impl::selected::compile(filebase, index);
+  {
+    compile_impl::selected code_generator(filebase, false);
+    code_generator.compile_eval_f(index);
+  }
   return compiled_expression(filename_so);
 }
 
-inline compiled_expression compile(const V& node) { return compile(node.index_); }
+inline compiled_expression compile_eval_f(const V& node) { return compile_eval_f(node.index_); }
 
-struct f_compiled : f {
+inline compiled_expression compile_eval_g(node_index_type f_index, const std::vector<node_index_type>& g_indexes) {
+  const std::string filebase(current::FileSystem::GenTmpFileName());
+  const std::string filename_so = filebase + ".so";
+  current::FileSystem::RmFile(filename_so, current::FileSystem::RmFileParameters::Silent);
+  {
+    compile_impl::selected code_generator(filebase, true);
+    code_generator.compile_eval_g(f_index, g_indexes);
+  }
+  return compiled_expression(filename_so, g_indexes);
+}
+
+inline compiled_expression compile_eval_g(const V& f_node, const std::vector<V>& g_nodes) {
+  std::vector<node_index_type> g_node_indexes;
+  g_node_indexes.reserve(g_nodes.size());
+  for (const auto& gi : g_nodes) {
+    g_node_indexes.push_back(gi.index_);
+  }
+  return compile_eval_g(f_node.index_, g_node_indexes);
+}
+
+struct f_compiled final : f {
   fncas::compiled_expression c_;
-  explicit f_compiled(const V& node) : c_(compile(node)) {}
-  explicit f_compiled(const f_intermediate& f) : c_(compile(f.f_)) {}
+
+  explicit f_compiled(const V& node) : c_(compile_eval_f(node)) { CURRENT_ASSERT(c_.HasFunction()); }
+  explicit f_compiled(const f_intermediate& f) : c_(compile_eval_f(f.f_)) { CURRENT_ASSERT(c_.HasFunction()); }
+
   f_compiled(const f_compiled&) = delete;
   void operator=(const f_compiled&) = delete;
-  f_compiled(f_compiled&& rhs) : c_(std::move(rhs.c_)) {}
-  virtual double operator()(const std::vector<double>& x) const { return c_(x); }
-  virtual int32_t dim() const { return c_.dim(); }
+  f_compiled(f_compiled&& rhs) : c_(std::move(rhs.c_)) { CURRENT_ASSERT(c_.HasFunction()); }
+
+  double operator()(const std::vector<double>& x) const override { return c_.compute_compiled_f(x); }
+
+  size_t dim() const override { return c_.dim(); }
+  size_t heap_size() const override { return c_.heap_size(); }
+
+  const std::string& lib_filename() const { return c_.lib_filename(); }
+};
+
+struct g_compiled final : g {
+  fncas::compiled_expression c_;
+
+  explicit g_compiled(const f_intermediate& f, const g_intermediate& g) : c_(compile_eval_g(f.f_, g.g_)) {
+    CURRENT_ASSERT(c_.HasGradient());
+  }
+
+  g_compiled(const g_compiled&) = delete;
+  void operator=(const g_compiled&) = delete;
+  g_compiled(g_compiled&& rhs) : c_(std::move(rhs.c_)) { CURRENT_ASSERT(c_.HasGradient()); }
+
+  std::vector<double_t> operator()(const std::vector<double_t>& x) const override { return c_.compute_compiled_g(x); }
+
+  size_t dim() const override { return c_.dim(); }
+  size_t heap_size() const override { return c_.heap_size(); }
+
   const std::string& lib_filename() const { return c_.lib_filename(); }
 };
 
 }  // namespace fncas
+
+#endif  // #ifndef FNCAS_USE_LONG_DOUBLE
 
 #endif  // #ifdef FNCAS_JIT
 

--- a/FnCAS/fncas/mathutil.h
+++ b/FnCAS/fncas/mathutil.h
@@ -51,8 +51,8 @@ CURRENT_STRUCT(ValueAndPoint) {
 inline bool IsNormal(double_t arg) { return (std::isnormal(arg) || arg == 0.0); }
 
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
-                                                                                              const std::vector<T>& b) {
+typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
+                                                                                       const std::vector<T>& b) {
 #ifndef NDEBUG
   CURRENT_ASSERT(a.size() == b.size());
 #endif
@@ -67,9 +67,9 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
-                                                                                              const std::vector<T>& b,
-                                                                                              double_t kb) {
+typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
+                                                                                       const std::vector<T>& b,
+                                                                                       double_t kb) {
 #ifndef NDEBUG
   CURRENT_ASSERT(a.size() == b.size());
 #endif
@@ -84,10 +84,10 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
-                                                                                              const std::vector<T>& b,
-                                                                                              double_t ka,
-                                                                                              double_t kb) {
+typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
+                                                                                       const std::vector<T>& b,
+                                                                                       double_t ka,
+                                                                                       double_t kb) {
 #ifndef NDEBUG
   CURRENT_ASSERT(a.size() == b.size());
 #endif
@@ -102,8 +102,8 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type DotProduct(const std::vector<T>& v1,
-                                                                                 const std::vector<T>& v2) {
+typename std::enable_if<std::is_arithmetic<T>::value, T>::type DotProduct(const std::vector<T>& v1,
+                                                                          const std::vector<T>& v2) {
 #ifndef NDEBUG
   CURRENT_ASSERT(v1.size() == v2.size());
 #endif
@@ -111,12 +111,12 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type DotProduct
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type L2Norm(const std::vector<T>& v) {
+typename std::enable_if<std::is_arithmetic<T>::value, T>::type L2Norm(const std::vector<T>& v) {
   return DotProduct(v, v);
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value>::type FlipSign(std::vector<T>& v) {
+typename std::enable_if<std::is_arithmetic<T>::value>::type FlipSign(std::vector<T>& v) {
   std::transform(std::begin(v), std::end(v), std::begin(v), std::negate<T>());
 }
 
@@ -136,14 +136,14 @@ inline double_t PolakRibiere(const std::vector<double_t>& g, const std::vector<d
 // sequentially shrinking the step size. Returns new optimal point.
 // Algorithm parameters: 0 < alpha < 1, 0 < beta < 1.
 template <class F, class G>
-inline ValueAndPoint Backtracking(F&& f,
-                                  G&& g,
-                                  const std::vector<double_t>& current_point,
-                                  const std::vector<double_t>& direction,
-                                  OptimizerStats& stats,
-                                  const double_t alpha = 0.5,
-                                  const double_t beta = 0.8,
-                                  const size_t max_steps = 100) {
+ValueAndPoint Backtracking(F&& f,
+                           G&& g,
+                           const std::vector<double_t>& current_point,
+                           const std::vector<double_t>& direction,
+                           OptimizerStats& stats,
+                           const double_t alpha = 0.5,
+                           const double_t beta = 0.8,
+                           const size_t max_steps = 100) {
   const auto& logger = OptimizerLogger();
   stats.JournalBacktrackingCall();
   stats.JournalFunction();

--- a/FnCAS/fncas/mathutil.h
+++ b/FnCAS/fncas/mathutil.h
@@ -58,7 +58,7 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 #endif
   for (size_t i = 0; i < a.size(); ++i) {
     a[i] += b[i];
-    if (fabs(a[i]) < 1e-100) {
+    if (std::abs(a[i]) < 1e-100) {
       // NOTE(dkorolev): Fight the underflow.
       a[i] = 0.0;
     }
@@ -75,7 +75,7 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 #endif
   for (size_t i = 0; i < a.size(); ++i) {
     a[i] += kb * b[i];
-    if (fabs(a[i]) < 1e-100) {
+    if (std::abs(a[i]) < 1e-100) {
       // NOTE(dkorolev): Fight the underflow.
       a[i] = 0.0;
     }
@@ -93,7 +93,7 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 #endif
   for (size_t i = 0; i < a.size(); ++i) {
     a[i] = ka * a[i] + kb * b[i];
-    if (fabs(a[i]) < 1e-100) {
+    if (std::abs(a[i]) < 1e-100) {
       // NOTE(dkorolev): Fight the underflow.
       a[i] = 0.0;
     }

--- a/FnCAS/fncas/mathutil.h
+++ b/FnCAS/fncas/mathutil.h
@@ -27,6 +27,7 @@
 #define FNCAS_MATHUTIL_H
 
 #include "base.h"
+#include "exceptions.h"
 #include "logger.h"
 
 #include <algorithm>
@@ -41,13 +42,13 @@
 namespace fncas {
 
 CURRENT_STRUCT(ValueAndPoint) {
-  CURRENT_FIELD(value, double, 0.0);
-  CURRENT_FIELD(point, std::vector<double>);
+  CURRENT_FIELD(value, double_t, 0.0);
+  CURRENT_FIELD(point, std::vector<double_t>);
   bool operator<(const ValueAndPoint& rhs) const { return value < rhs.value; }
-  CURRENT_CONSTRUCTOR(ValueAndPoint)(double value, const std::vector<double>& x) : value(value), point(x) {}
+  CURRENT_CONSTRUCTOR(ValueAndPoint)(double_t value, const std::vector<double_t>& x) : value(value), point(x) {}
 };
 
-inline bool IsNormal(double arg) { return (std::isnormal(arg) || arg == 0.0); }
+inline bool IsNormal(double_t arg) { return (std::isnormal(arg) || arg == 0.0); }
 
 template <typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
@@ -68,7 +69,7 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 template <typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
                                                                                               const std::vector<T>& b,
-                                                                                              double kb) {
+                                                                                              double_t kb) {
 #ifndef NDEBUG
   CURRENT_ASSERT(a.size() == b.size());
 #endif
@@ -85,8 +86,8 @@ inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::ty
 template <typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value, std::vector<T>>::type SumVectors(std::vector<T> a,
                                                                                               const std::vector<T>& b,
-                                                                                              double ka,
-                                                                                              double kb) {
+                                                                                              double_t ka,
+                                                                                              double_t kb) {
 #ifndef NDEBUG
   CURRENT_ASSERT(a.size() == b.size());
 #endif
@@ -121,8 +122,8 @@ inline typename std::enable_if<std::is_arithmetic<T>::value>::type FlipSign(std:
 
 // Polak-Ribiere formula for conjugate gradient method
 // http://en.wikipedia.org/wiki/Nonlinear_conjugate_gradient_method
-inline double PolakRibiere(const std::vector<double>& g, const std::vector<double>& g_prev) {
-  const double beta = (L2Norm(g) - DotProduct(g, g_prev)) / L2Norm(g_prev);
+inline double_t PolakRibiere(const std::vector<double_t>& g, const std::vector<double_t>& g_prev) {
+  const double_t beta = (L2Norm(g) - DotProduct(g, g_prev)) / L2Norm(g_prev);
   if (IsNormal(beta)) {
     return beta;
   } else {
@@ -135,35 +136,52 @@ inline double PolakRibiere(const std::vector<double>& g, const std::vector<doubl
 // sequentially shrinking the step size. Returns new optimal point.
 // Algorithm parameters: 0 < alpha < 1, 0 < beta < 1.
 template <class F, class G>
-inline ValueAndPoint Backtracking(F&& eval_function,
-                                  G&& eval_gradient,
-                                  const std::vector<double>& current_point,
-                                  const std::vector<double>& direction,
-                                  const double alpha = 0.5,
-                                  const double beta = 0.8,
+inline ValueAndPoint Backtracking(F&& f,
+                                  G&& g,
+                                  const std::vector<double_t>& current_point,
+                                  const std::vector<double_t>& direction,
+                                  OptimizerStats& stats,
+                                  const double_t alpha = 0.5,
+                                  const double_t beta = 0.8,
                                   const size_t max_steps = 100) {
-  OptimizerLogger().Log(std::string("Backtracking: Starting point ") + JSON(current_point) + ", direction " +
-                        JSON(direction));
-  const double current_f_value = eval_function(current_point);
-  std::vector<double> test_point = SumVectors(current_point, direction);
-  double test_f_value = eval_function(test_point);
-  OptimizerLogger().Log(std::string("Backtracking: Starting value = ") + current::ToString(test_f_value));
-  const std::vector<double> current_gradient = eval_gradient(current_point);
-  const double gradient_l2norm = L2Norm(current_gradient);
-  double t = 1.0;
+  const auto& logger = OptimizerLogger();
+  stats.JournalBacktrackingCall();
+  stats.JournalFunction();
+  const double_t current_f_value = f(current_point);
+  std::vector<double_t> test_point = SumVectors(current_point, direction);
+  stats.JournalFunction();
+  double_t test_f_value = f(test_point);
+  if (logger) {
+    logger.Log(std::string("Backtracking: Starting value, OK if NAN or INF, is ") + current::ToString(test_f_value));
+  }
+  stats.JournalGradient();
+  const std::vector<double_t> current_gradient = g(current_point);
+  const double_t gradient_l2norm = L2Norm(current_gradient);
+  double_t t = 1.0;
 
   size_t bt_iteration = 0;
   while (test_f_value > (current_f_value - alpha * t * gradient_l2norm) || !IsNormal(test_f_value)) {
+    stats.JournalBacktrackingStep();
     t *= beta;
     test_point = SumVectors(current_point, direction, t);
-    test_f_value = eval_function(test_point);
+    stats.JournalFunction();
+    test_f_value = f(test_point);
     if (bt_iteration++ == max_steps) {
       break;
     }
   }
-  OptimizerLogger().Log(std::string("Backtracking: Final value = ") + current::ToString(test_f_value));
 
-  return ValueAndPoint(test_f_value, test_point);
+  if (IsNormal(test_f_value)) {
+    if (logger) {
+      logger.Log(std::string("Backtracking: Final value = ") + current::ToString(test_f_value));
+    }
+    return ValueAndPoint(test_f_value, test_point);
+  } else {
+    if (logger) {
+      logger.Log("Backtracking: No non-NAN and non-INF step found.");
+    }
+    CURRENT_THROW(BacktrackingException("!fncas::IsNormal(test_f_value)"));
+  }
 }
 
 }  // namespace fncas

--- a/FnCAS/fncas/node.h
+++ b/FnCAS/fncas/node.h
@@ -41,15 +41,20 @@
 #include "../../Bricks/exception.h"
 #include "../../Bricks/util/singleton.h"
 
-// Admittedly, `sqr()` is kind of helpful in machine learning. -- D.K.
+// Some mathematical functions useful in data science.
+// For simplicity, I'm injecting them into the global namespace now. -- D.K.
+
 inline fncas::double_t sqr(fncas::double_t x) { return x * x; }
+inline fncas::double_t zero_or_one(fncas::double_t x) { return x >= 0 ? 1 : 0; }
+inline fncas::double_t zero_or_x(fncas::double_t x) { return x > 0 ? x : 0; }
 
 namespace fncas {
 
 // Parsed expressions are stored in an array of node_impl objects.
-// Instances of node_impl take 10 bytes each and are packed.
-// Each node_impl refers to a value, an input variable, an operation or math function invocation.
-// Singleton vector<node_impl> is the allocator, therefore the code is single-threaded.
+// Instances of `node_impl` take 10 bytes each and are packed.
+// Each node_impl refers to a value, an input variable, an operation or math function invokation.
+// The `ThreadLocalSingleton` containing `vector<node_impl>` is the allocator, thus
+// at most one expression per thread (at most one scope of `fncas::X`) can be "recorded" at a time.
 
 inline const char* operation_as_string(operation_t operation) {
   static const char* representation[static_cast<size_t>(operation_t::end)] = {"+", "-", "*", "/"};
@@ -58,7 +63,7 @@ inline const char* operation_as_string(operation_t operation) {
 
 inline const char* function_as_string(function_t function) {
   static const char* representation[static_cast<size_t>(function_t::end)] = {
-      "sqr", "sqrt", "exp", "log", "sin", "cos", "tan", "asin", "acos", "atan"};
+      "sqr", "sqrt", "exp", "log", "sin", "cos", "tan", "asin", "acos", "atan", "zero_or_one", "zero_or_x"};
   return function < function_t::end ? representation[static_cast<size_t>(function)] : "?";
 }
 
@@ -74,7 +79,7 @@ inline T apply_operation(operation_t operation, T lhs, T rhs) {
 template <typename T>
 inline T apply_function(function_t function, T argument) {
   static std::function<T(T)> evaluator[static_cast<size_t>(function_t::end)] = {
-      sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan};
+      sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, zero_or_one, zero_or_x};
   return function < function_t::end ? evaluator[static_cast<size_t>(function)](argument)
                                     : std::numeric_limits<T>::quiet_NaN();
 }
@@ -442,6 +447,8 @@ DECLARE_FUNCTION(tan);
 DECLARE_FUNCTION(asin);
 DECLARE_FUNCTION(acos);
 DECLARE_FUNCTION(atan);
+DECLARE_FUNCTION(zero_or_one);
+DECLARE_FUNCTION(zero_or_x);
 
 // Unary plus and unary minus.
 inline fncas::V operator+(const fncas::V& x) { return x; }

--- a/FnCAS/fncas/node.h
+++ b/FnCAS/fncas/node.h
@@ -42,7 +42,7 @@
 #include "../../Bricks/util/singleton.h"
 
 // Admittedly, `sqr()` is kind of helpful in machine learning. -- D.K.
-inline fncas::fncas_value_type sqr(fncas::fncas_value_type x) { return x * x; }
+inline fncas::double_t sqr(fncas::double_t x) { return x * x; }
 
 namespace fncas {
 
@@ -83,28 +83,30 @@ struct node_impl;
 struct X;
 struct internals_impl {
   // The dimensionality of the function that is currently being worked with.
-  int32_t dim_;
+  size_t dim_;
+
+  // The pointer to a thread-local vector of "variables" used for expression parsing.
   X* x_ptr_;
 
   // All expression nodes created so far, with fixed indexes.
   std::vector<node_impl> node_vector_;
 
   // Values per node computed so far.
-  std::vector<fncas_value_type> node_value_;
+  std::vector<double_t> node_value_;
   std::vector<int8_t> node_computed_;
 
   // df_[var_index][node_index] => node index for d (node[node_index]) / d (x[variable_index]), -1 if unknown.
   std::vector<std::vector<node_index_type>> df_;
 
   // A block of RAM to be used as the buffer for externally compiled functions.
-  std::vector<fncas_value_type> ram_for_compiled_evaluations_;
+  std::vector<double_t> heap_for_compiled_evaluations_;
 
   void reset() {
     dim_ = 0;
     x_ptr_ = nullptr;
     node_vector_.clear();
     df_.clear();
-    ram_for_compiled_evaluations_.clear();
+    heap_for_compiled_evaluations_.clear();
   }
 };
 
@@ -119,9 +121,9 @@ struct node_impl {
     CURRENT_ASSERT(type() == type_t::variable);
     return *reinterpret_cast<int32_t*>(&data_[2]);
   }
-  fncas_value_type& value() {
+  double_t& value() {
     CURRENT_ASSERT(type() == type_t::value);
-    return *reinterpret_cast<fncas_value_type*>(&data_[2]);
+    return *reinterpret_cast<double_t*>(&data_[2]);
   }
   operation_t& operation() {
     CURRENT_ASSERT(type() == type_t::operation);
@@ -149,10 +151,10 @@ static_assert(sizeof(node_impl) == 18, "sizeof(node_impl) should be 18. Check st
 // eval_node() should use manual stack implementation to avoid SEGFAULT. Using plain recursion
 // will overflow the stack for every formula containing repeated operation on the top level.
 enum class reuse_cache : int8_t { invalidate = 0, reuse = 1 };
-inline fncas_value_type eval_node(node_index_type index,
-                                  const std::vector<fncas_value_type>& x,
-                                  reuse_cache reuse = reuse_cache::invalidate) {
-  std::vector<fncas_value_type>& V = internals_singleton().node_value_;
+inline double_t eval_node(node_index_type index,
+                          const std::vector<double_t>& x,
+                          reuse_cache reuse = reuse_cache::invalidate) {
+  std::vector<double_t>& V = internals_singleton().node_value_;
   std::vector<int8_t>& B = internals_singleton().node_computed_;
   if (reuse == reuse_cache::invalidate) {
     B.clear();
@@ -167,7 +169,7 @@ inline fncas_value_type eval_node(node_index_type index,
       if (!growing_vector_access(B, i, static_cast<int8_t>(false))) {
         node_impl& f = node_vector_singleton()[i];
         if (f.type() == type_t::variable) {
-          int32_t v = f.variable();
+          const int32_t v = f.variable();
           CURRENT_ASSERT(v >= 0 && v < static_cast<int32_t>(x.size()));
           growing_vector_access(V, i, 0.0) = x[v];
           growing_vector_access(B, i, static_cast<int8_t>(false)) = true;
@@ -184,22 +186,21 @@ inline fncas_value_type eval_node(node_index_type index,
           stack.push(f.argument_index());
         } else {
           CURRENT_ASSERT(false);
-          return std::numeric_limits<fncas_value_type>::quiet_NaN();
+          return std::numeric_limits<double_t>::quiet_NaN();
         }
       }
     } else {
       node_impl& f = node_vector_singleton()[dependent_i];
       if (f.type() == type_t::operation) {
         growing_vector_access(V, dependent_i, 0.0) =
-            apply_operation<fncas_value_type>(f.operation(), V[f.lhs_index()], V[f.rhs_index()]);
+            apply_operation<double_t>(f.operation(), V[f.lhs_index()], V[f.rhs_index()]);
         growing_vector_access(B, dependent_i, static_cast<int8_t>(false)) = true;
       } else if (f.type() == type_t::function) {
-        growing_vector_access(V, dependent_i, 0.0) =
-            apply_function<fncas_value_type>(f.function(), V[f.argument_index()]);
+        growing_vector_access(V, dependent_i, 0.0) = apply_function<double_t>(f.function(), V[f.argument_index()]);
         growing_vector_access(B, dependent_i, static_cast<int8_t>(false)) = true;
       } else {
         CURRENT_ASSERT(false);
-        return std::numeric_limits<fncas_value_type>::quiet_NaN();
+        return std::numeric_limits<double_t>::quiet_NaN();
       }
     }
   }
@@ -225,11 +226,11 @@ struct node_index_allocator {
   node_index_allocator() = delete;
 };
 
-// Template used as a header-only way to move implemneation to another source file.
+// Template, used as a header-only way to move implementation to another source or header file.
 struct V;
 template <typename T>
 struct node_differentiate_impl {
-  //  V differentiate(const x& x_ref, int32_t variable_index) const;
+  //  V differentiate(const x& x_ref, size_t variable_index) const;
 };
 
 struct V : node_index_allocator {
@@ -238,14 +239,14 @@ struct V : node_index_allocator {
 
  public:
   V() : node_index_allocator(allocate_new()) {}
-  V(fncas_value_type x) : node_index_allocator(allocate_new()) {
+  V(double_t x) : node_index_allocator(allocate_new()) {
     type() = type_t::value;
     value() = x;
   }
   V(from_index i) : node_index_allocator(i) {}
   type_t& type() const { return node_vector_singleton()[index_].type(); }
   int32_t& variable() const { return node_vector_singleton()[index_].variable(); }
-  fncas_value_type& value() const { return node_vector_singleton()[index_].value(); }
+  double_t& value() const { return node_vector_singleton()[index_].value(); }
   operation_t& operation() const { return node_vector_singleton()[index_].operation(); }
   node_index_type& lhs_index() const { return node_vector_singleton()[index_].lhs_index(); }
   node_index_type& rhs_index() const { return node_vector_singleton()[index_].rhs_index(); }
@@ -277,14 +278,13 @@ struct V : node_index_allocator {
       return "?";
     }
   }
-  fncas_value_type operator()(const std::vector<fncas_value_type>& x,
-                              reuse_cache reuse = reuse_cache::invalidate) const {
+  double_t operator()(const std::vector<double_t>& x, reuse_cache reuse = reuse_cache::invalidate) const {
     return eval_node(index_, x, reuse);
   }
   // Template is used here as a form of forward declaration.
   template <typename TX>
-  V differentiate(const TX& x_ref, int32_t variable_index) const {
-    static_assert(std::is_same<TX, X>::value, "V::differentiate(const x& x, int32_t variable_index);");
+  V differentiate(const TX& x_ref, size_t variable_index) const {
+    static_assert(std::is_same<TX, X>::value, "V::differentiate(const x& x, size_t variable_index);");
     // Note: This method will not build unless `fncas_differentiate.h` is included.
     return node_differentiate_impl<TX>::differentiate(x_ref, index_, variable_index);
   }
@@ -295,7 +295,7 @@ static_assert(sizeof(V) == 8, "sizeof(V) should be 8, as sizeof(node_index_type)
 // to record the computation rather than perform it.
 
 struct X : noncopyable {
-  explicit X(int32_t dim) {
+  explicit X(size_t dim) {
     CURRENT_ASSERT(dim > 0);
     auto& meta = internals_singleton();
     if (meta.x_ptr_) {
@@ -315,8 +315,7 @@ struct X : noncopyable {
       meta.dim_ = 0;
     }
   }
-  V operator[](int32_t i) const {
-    CURRENT_ASSERT(i >= 0);
+  V operator[](size_t i) const {
     CURRENT_ASSERT(i < internals_singleton().dim_);
     return V(V::variable(i));
   }
@@ -333,48 +332,54 @@ struct X : noncopyable {
 
 struct f : noncopyable {
   virtual ~f() = default;
-  virtual fncas_value_type operator()(const std::vector<fncas_value_type>& x) const = 0;
-  virtual int32_t dim() const = 0;
+  // The evaluator of the function.
+  virtual double_t operator()(const std::vector<double_t>& x) const = 0;
+  // The dimensionality of the parameters vector for the function.
+  virtual size_t dim() const = 0;
+  // The number of external `double_t` "registers" required to compute it, for compiled versions.
+  virtual size_t heap_size() const { return 0; }
 };
 
-struct f_native : f {
-  std::function<fncas_value_type(const std::vector<fncas_value_type>&)> f_;
-  int32_t d_;
-  f_native(std::function<fncas_value_type(std::vector<fncas_value_type>)> f, int32_t d) : f_(f), d_(d) {}
-  virtual fncas_value_type operator()(const std::vector<fncas_value_type>& x) const { return f_(x); }
-  virtual int32_t dim() const { return d_; }
+struct f_native final : f {
+  std::function<double_t(const std::vector<double_t>&)> f_;
+  size_t dim_;
+  f_native(std::function<double_t(std::vector<double_t>)> f, size_t d) : f_(f), dim_(d) {}
+  double_t operator()(const std::vector<double_t>& x) const override { return f_(x); }
+  size_t dim() const override { return dim_; }
 };
 
-struct f_intermediate : f {
+struct f_intermediate final : f {
   const V f_;
   f_intermediate(const V& f) : f_(f) {}
   f_intermediate(f_intermediate&& rhs) : f_(rhs.f_) {}
-  virtual fncas_value_type operator()(const std::vector<fncas_value_type>& x) const {
-    CURRENT_ASSERT(static_cast<int32_t>(x.size()) == dim());
+  double_t operator()(const std::vector<double_t>& x) const override {
+    CURRENT_ASSERT(x.size() == dim());
     return f_(x);
   }
   std::string debug_as_string() const { return f_.debug_as_string(); }
   // Template is used here as a form of forward declaration.
   template <typename TX>
-  V differentiate(const TX& x_ref, int32_t variable_index) const {
-    static_assert(std::is_same<TX, X>::value, "f_intermediate::differentiate(const x& x, int32_t variable_index);");
+  V differentiate(const TX& x_ref, size_t variable_index) const {
+    static_assert(std::is_same<TX, X>::value, "f_intermediate::differentiate(const x& x, size_t variable_index);");
     CURRENT_ASSERT(&x_ref == internals_singleton().x_ptr_);
     CURRENT_ASSERT(variable_index >= 0);
     CURRENT_ASSERT(variable_index < dim());
     return f_.template differentiate<X>(x_ref, variable_index);
   }
-  virtual int32_t dim() const { return internals_singleton().dim_; }
+  size_t dim() const override { return internals_singleton().dim_; }
 };
 
 // Helper code to allow writing polymorphic functions that can be both evaluated and recorded.
-// Type `V` describes one value (`double`), type `X` describes an array of values (`std::vector<double>`).
+// Type `V` describes one value (`double`), type `X` describes an array of values (`std::vector<double>`),
+// although `double` is in fact `double_t`.
 // Synopsis: `fncas::X2V<X> f(const X& x)` or `V f(const fncas::V2X<V>& x);`.
 
 template <typename T>
 struct x2v_impl {};
-template <>
-struct x2v_impl<std::vector<fncas_value_type>> {
-  typedef fncas_value_type type;
+
+template <typename T>
+struct x2v_impl<std::vector<T>> {
+  typedef T type;
 };
 template <>
 struct x2v_impl<X> {
@@ -382,10 +387,8 @@ struct x2v_impl<X> {
 };
 
 template <typename T>
-struct v2x_impl {};
-template <>
-struct v2x_impl<fncas_value_type> {
-  typedef std::vector<fncas_value_type> type;
+struct v2x_impl {
+  typedef std::vector<T> type;
 };
 template <>
 struct v2x_impl<V> {

--- a/FnCAS/fncas/node.h
+++ b/FnCAS/fncas/node.h
@@ -41,14 +41,13 @@
 #include "../../Bricks/exception.h"
 #include "../../Bricks/util/singleton.h"
 
-// Some mathematical functions useful in data science.
-// For simplicity, I'm injecting them into the global namespace now. -- D.K.
-
-inline fncas::double_t sqr(fncas::double_t x) { return x * x; }
-inline fncas::double_t zero_or_one(fncas::double_t x) { return x >= 0 ? 1 : 0; }
-inline fncas::double_t zero_or_x(fncas::double_t x) { return x > 0 ? x : 0; }
-
 namespace fncas {
+
+// Non-standard functions useful in data science.
+inline double_t sqr(double_t x) { return x * x; }
+inline double_t unit_step(double_t x) { return x >= 0 ? 1 : 0; }
+inline double_t ramp(double_t x) { return x > 0 ? x : 0; }
+// TODO(dkorolev): Sigmoid, its derivative, normal distribution, ERF, etc.
 
 // Parsed expressions are stored in an array of node_impl objects.
 // Instances of `node_impl` take 10 bytes each and are packed.
@@ -63,7 +62,7 @@ inline const char* operation_as_string(operation_t operation) {
 
 inline const char* function_as_string(function_t function) {
   static const char* representation[static_cast<size_t>(function_t::end)] = {
-      "sqr", "sqrt", "exp", "log", "sin", "cos", "tan", "asin", "acos", "atan", "zero_or_one", "zero_or_x"};
+      "sqr", "sqrt", "exp", "log", "sin", "cos", "tan", "asin", "acos", "atan", "unit_step", "ramp"};
   return function < function_t::end ? representation[static_cast<size_t>(function)] : "?";
 }
 
@@ -79,7 +78,7 @@ T apply_operation(operation_t operation, T lhs, T rhs) {
 template <typename T>
 T apply_function(function_t function, T argument) {
   static std::function<T(T)> evaluator[static_cast<size_t>(function_t::end)] = {
-      sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, zero_or_one, zero_or_x};
+      sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, unit_step, ramp};
   return function < function_t::end ? evaluator[static_cast<size_t>(function)](argument)
                                     : std::numeric_limits<T>::quiet_NaN();
 }
@@ -437,6 +436,8 @@ DECLARE_OP(/, /=, divide);
     return result;                              \
   }
 
+namespace fncas {
+
 DECLARE_FUNCTION(sqr);
 DECLARE_FUNCTION(sqrt);
 DECLARE_FUNCTION(exp);
@@ -447,8 +448,10 @@ DECLARE_FUNCTION(tan);
 DECLARE_FUNCTION(asin);
 DECLARE_FUNCTION(acos);
 DECLARE_FUNCTION(atan);
-DECLARE_FUNCTION(zero_or_one);
-DECLARE_FUNCTION(zero_or_x);
+DECLARE_FUNCTION(unit_step);
+DECLARE_FUNCTION(ramp);
+
+}  // namespace fncas
 
 // Unary plus and unary minus.
 inline fncas::V operator+(const fncas::V& x) { return x; }

--- a/FnCAS/fncas/node.h
+++ b/FnCAS/fncas/node.h
@@ -68,7 +68,7 @@ inline const char* function_as_string(function_t function) {
 }
 
 template <typename T>
-inline T apply_operation(operation_t operation, T lhs, T rhs) {
+T apply_operation(operation_t operation, T lhs, T rhs) {
   static std::function<T(T, T)> evaluator[static_cast<size_t>(operation_t::end)] = {
       std::plus<T>(), std::minus<T>(), std::multiplies<T>(), std::divides<T>(),
   };
@@ -77,7 +77,7 @@ inline T apply_operation(operation_t operation, T lhs, T rhs) {
 }
 
 template <typename T>
-inline T apply_function(function_t function, T argument) {
+T apply_function(function_t function, T argument) {
   static std::function<T(T)> evaluator[static_cast<size_t>(function_t::end)] = {
       sqr, sqrt, exp, log, sin, cos, tan, asin, acos, atan, zero_or_one, zero_or_x};
   return function < function_t::end ? evaluator[static_cast<size_t>(function)](argument)

--- a/FnCAS/test.cc
+++ b/FnCAS/test.cc
@@ -40,13 +40,13 @@ SOFTWARE.
 #include <thread>
 
 template <typename X>
-inline fncas::X2V<X> ParametrizedFunction(const X& x, size_t c) {
+fncas::X2V<X> ParametrizedFunction(const X& x, size_t c) {
   return (x[0] + x[1] * c) * (x[0] + x[1] * c);
 }
 
 // Need an explicit specialization, as `SimpleFunction<std::vector<double_t>>` is used directly in the test.
 template <typename X>
-inline fncas::X2V<X> SimpleFunction(const X& x) {
+fncas::X2V<X> SimpleFunction(const X& x) {
   return ParametrizedFunction(x, 2u);
 }
 
@@ -434,14 +434,14 @@ TEST(FnCAS, ConjugateGDvsBacktrackingGDOnRosenbrockFunction100Steps) {
 
 // To test evaluation and differentiation.
 template <typename X>
-inline fncas::X2V<X> ZeroOrXFunction(const X& x) {
+fncas::X2V<X> ZeroOrXFunction(const X& x) {
   EXPECT_EQ(1u, x.size());
   return zero_or_x(x[0]);
 }
 
 // To test evaluation and differentiation of `f(g(x))` where `f` is `zero_or_x`.
 template <typename X>
-inline fncas::X2V<X> ZeroOrXOfSquareXMinusTen(const X& x) {
+fncas::X2V<X> ZeroOrXOfSquareXMinusTen(const X& x) {
   EXPECT_EQ(1u, x.size());
   return zero_or_x(sqr(x[0]) - 10);  // So that the argument is sometimes negative.
 }

--- a/FnCAS/test.cc
+++ b/FnCAS/test.cc
@@ -114,7 +114,7 @@ TEST(FnCAS, CompiledGradientsWrapper) {
 }
 
 TEST(FnCAS, CompiledSqrGradientWrapper) {
-  // The `sqr()` function is a special case, which it worth unit-testing with different `FNCAS_JIT. -- D.K.
+  // The `fncas::sqr()` function is a special case, which it worth unit-testing with different `FNCAS_JIT. -- D.K.
   std::vector<fncas::double_t> p_3_3({3.0, 3.0});
 
   const fncas::X x(2);
@@ -138,7 +138,7 @@ TEST(FnCAS, SupportsConcurrentThreadsViaThreadLocal) {
     for (size_t i = 0; i < 1000; ++i) {
       fncas::X x(2);
       fncas::f_intermediate fi = ParametrizedFunction(x, i + 1);
-      EXPECT_EQ(sqr(1.0 + 2.0 * (i + 1)), fi({1.0, 2.0}));
+      EXPECT_EQ(fncas::sqr(1.0 + 2.0 * (i + 1)), fi({1.0, 2.0}));
     }
   };
   std::thread t1(advanced_math);
@@ -436,22 +436,22 @@ TEST(FnCAS, ConjugateGDvsBacktrackingGDOnRosenbrockFunction100Steps) {
 template <typename X>
 fncas::X2V<X> ZeroOrXFunction(const X& x) {
   EXPECT_EQ(1u, x.size());
-  return zero_or_x(x[0]);
+  return fncas::ramp(x[0]);
 }
 
-// To test evaluation and differentiation of `f(g(x))` where `f` is `zero_or_x`.
+// To test evaluation and differentiation of `f(g(x))` where `f` is `fncas::ramp`.
 template <typename X>
 fncas::X2V<X> ZeroOrXOfSquareXMinusTen(const X& x) {
   EXPECT_EQ(1u, x.size());
-  return zero_or_x(sqr(x[0]) - 10);  // So that the argument is sometimes negative.
+  return fncas::ramp(fncas::sqr(x[0]) - 10);  // So that the argument is sometimes negative.
 }
 
 TEST(FnCAS, CustomFunctions) {
-  EXPECT_EQ(0.0, zero_or_one(-1.0));
-  EXPECT_EQ(1.0, zero_or_one(+2.0));
+  EXPECT_EQ(0.0, fncas::unit_step(-1.0));
+  EXPECT_EQ(1.0, fncas::unit_step(+2.0));
 
-  EXPECT_EQ(0.0, zero_or_x(-3.0));
-  EXPECT_EQ(4.0, zero_or_x(+4.0));
+  EXPECT_EQ(0.0, fncas::ramp(-3.0));
+  EXPECT_EQ(4.0, fncas::ramp(+4.0));
 
   const fncas::X x(1);
   const fncas::f_intermediate intermediate_function = ZeroOrXFunction(x);
@@ -479,8 +479,8 @@ TEST(FnCAS, ComplexCustomFunctions) {
   const fncas::X x(1);
 
   const fncas::f_intermediate intermediate_function = ZeroOrXOfSquareXMinusTen(x);
-  EXPECT_EQ(0.0, intermediate_function({3.0}));  // zero_or_x(3*3 - 10) == 0
-  EXPECT_EQ(6.0, intermediate_function({4.0}));  // zero_or_x(4*4 - 10) == 6
+  EXPECT_EQ(0.0, intermediate_function({3.0}));  // fncas::ramp(3*3 - 10) == 0
+  EXPECT_EQ(6.0, intermediate_function({4.0}));  // fncas::ramp(4*4 - 10) == 6
 
   fncas::f_compiled compiled_function(intermediate_function);
   EXPECT_EQ(0.0, compiled_function({3.0})) << compiled_function.lib_filename();

--- a/examples/Optimize/Makefile
+++ b/examples/Optimize/Makefile
@@ -1,0 +1,1 @@
+../../scripts/Makefile

--- a/examples/Optimize/README.md
+++ b/examples/Optimize/README.md
@@ -38,7 +38,7 @@ A smoke-test solution (`smoke.cc`) is the Brown-Robinson iterative method:
 
 The optimization-based solution (`optimize.cc`) solves the problem by converting it into an optimization problem. To accomplish this:
 
-* The very linear programming constraints are used as constraits:
+* The very linear programming constraints are used as constraints:
   * Player one's payoff from each pure strategy is less or equal than the equilibrium payoff.
   * Player two's payoff from each pure strategy is greater or equal than the equilibrium payoff.
 * Two tricks are used to make the problem convex:

--- a/examples/Optimize/README.md
+++ b/examples/Optimize/README.md
@@ -1,0 +1,48 @@
+## Optimize
+
+### Intro
+
+This directory contains the example of using the `FnCAS` library to solve an optimization problem.
+
+The problem considered is the two-player zero-sum matrix game: For an `N` by `N` matrix `A` where `A[i][j]` is the payoff from player two to player one as players have picked up strategies `i` and `j`respectively, find the optimal mixed strategies for both players. The mixed strategy for each player is a simplex of dimension `N` where each element is the probability of the player picking this strategy, which corresponds to the row or column of the matrix for players one and two respectively.
+
+### Reasoning
+
+The zero-sum matrix game is a special case of linear programming problem. It is a good fit for this example, as:
+
+* The solution is computationally easy to verify, but computationally expensive to find.
+* For all but very narrow cases, the solution is unique.
+* There exists a simple iterative algorithm, which, albeit slow, converges to the optimal solution.
+* Random matrices do well as regression test inputs.
+
+### Mathematics
+
+It is the Nash equilibrium that the solution follows the minimax principle: The most player one can win from player two is equal to the least player two can lose to player one, and vice versa.
+
+The example in this directory implements two solutions:
+
+* `smoke`: The slow, iterative one.
+* `optimize`: The more effective, gradient-descent-based one.
+
+## Implementations
+
+### Smoke Test
+
+A smoke-test solution (`smoke.cc`) is the Brown-Robinson iterative method:
+* Each player has a "bag of strategies" to play, and begins with this bag containing one occurrence of each strategy. This player's mixed strategy is assumed to be the weighted sum of all the strategies in their bag.
+* Players take turns at optimizing their bags.
+* At each optimization half-step per-player, knowing the opponent's mixed strategy -- the contents of their bag -- the player under consideration picks their strategy that best counters the present state of the opponent's bag, and adds this newly picked strategy into their own bag.
+* For this exercise, to construct the solution we look at the strategies added into players' bags in the past half of the iterative process. This improves convergence slightly, as early iterations often pick the strategies that don't even present in the final solution, and, while the process would converge nonetheless, it would take longer to outweigh them than to disregard them.
+
+### Optimization-Based Solution
+
+The optimization-based solution (`optimize.cc`) solves the problem by converting it into an optimization problem. To accomplish this:
+
+* The the very linear programming constraints are used as constraits:
+  * Player one's payoff from each pure strategy is less or equal than the equilibrium payoff.
+  * Player two's payoff from each pure strategy is greater or equal than the equilibrium payoff.
+* Two tricks are used to make the problem convex:
+  * Each player's strategy is a simplex that's just `s[i] = sqr(x[i]) / sum(sqr(x[i]))`. (I've tried other. -- D.K.)
+  * The penalty is the "softmax penalty" function, which is `sqr(v + sqrt(v * v))`. (I've tried other. -- D.K.)
+
+As this example is only a regression test for the larger-scale optimizer, I didn't bother do more than just the above. -- D.K.

--- a/examples/Optimize/README.md
+++ b/examples/Optimize/README.md
@@ -4,7 +4,7 @@
 
 This directory contains the example of using the `FnCAS` library to solve an optimization problem.
 
-The problem considered is the two-player zero-sum matrix game: For an `N` by `N` matrix `A` where `A[i][j]` is the payoff from player two to player one as players have picked up strategies `i` and `j`respectively, find the optimal mixed strategies for both players. The mixed strategy for each player is a simplex of dimension `N` where each element is the probability of the player picking this strategy, which corresponds to the row or column of the matrix for players one and two respectively.
+The problem considered is the two-player zero-sum matrix game: For an `N` by `N` matrix `A` where `A[i][j]` is the payoff from player two to player one as players have picked up strategies `i` and `j` respectively, find the optimal mixed strategies for both players. The mixed strategy for each player is a simplex of dimension `N` where each element is the probability of the player picking this strategy, which corresponds to the row or column of the matrix for players one and two respectively.
 
 ### Reasoning
 

--- a/examples/Optimize/README.md
+++ b/examples/Optimize/README.md
@@ -38,7 +38,7 @@ A smoke-test solution (`smoke.cc`) is the Brown-Robinson iterative method:
 
 The optimization-based solution (`optimize.cc`) solves the problem by converting it into an optimization problem. To accomplish this:
 
-* The the very linear programming constraints are used as constraits:
+* The very linear programming constraints are used as constraits:
   * Player one's payoff from each pure strategy is less or equal than the equilibrium payoff.
   * Player two's payoff from each pure strategy is greater or equal than the equilibrium payoff.
 * Two tricks are used to make the problem convex:

--- a/examples/Optimize/README.md
+++ b/examples/Optimize/README.md
@@ -4,7 +4,7 @@
 
 This directory contains the example of using the `FnCAS` library to solve an optimization problem.
 
-The problem considered is the two-player zero-sum matrix game: For an `N` by `N` matrix `A` where `A[i][j]` is the payoff from player two to player one as players have picked up strategies `i` and `j` respectively, find the optimal mixed strategies for both players. The mixed strategy for each player is a simplex of dimension `N` where each element is the probability of the player picking this strategy, which corresponds to the row or column of the matrix for players one and two respectively.
+The problem considered is the two-player zero-sum matrix game: For an `N` by `N` matrix `A` where `A[i][j]` is the payoff player one gets from player two as players have picked up strategies `i` and `j` respectively, find the optimal mixed strategies for both players. The mixed strategy for each player is a simplex of dimension `N` where each element is the probability of the player picking this strategy, which corresponds to the row or column of the matrix for players one and two respectively.
 
 ### Reasoning
 

--- a/examples/Optimize/main.h
+++ b/examples/Optimize/main.h
@@ -1,0 +1,212 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// Simple tests:
+//
+// ./$BINARY --matrix '[[-1,1],[3,-1]]'               # Simple asymmetric 'coin flip' game.
+// ./$BINARY --matrix '[[0,-1,3],[1,0,-1],[-1,1,0]]'  # Simple asymmetric 'rock-paper-scissors' game.
+
+#ifndef EXAMPLES_OPTIMIZE_MAIN_H
+#define EXAMPLES_OPTIMIZE_MAIN_H
+
+#include "../../Bricks/dflags/dflags.h"
+#include "../../Bricks/util/random.h"
+#include "../../TypeSystem/Serialization/json.h"
+#include "../../FnCAS/fncas/base.h"  // typename `fncas::double_t`.
+
+DECLARE_string(matrix);
+DECLARE_size_t(dim);
+DECLARE_int32(min);
+DECLARE_int32(max);
+DECLARE_uint64(seed);
+DECLARE_double(eps);
+
+std::vector<std::vector<fncas::double_t>> solve(
+    size_t N,
+    const std::vector<std::vector<int>>& A,
+    std::function<bool(const std::vector<std::vector<fncas::double_t>>& strategy)> validate);
+
+inline bool validate(size_t N,
+                     const std::vector<std::vector<int>>& A,
+                     const std::vector<std::vector<fncas::double_t>>& strategy,
+                     bool print) {
+  // Make sure the solution is valid.
+  if (strategy.size() != 2u || strategy[0].size() != N || strategy[1].size() != N) {
+    std::cerr << "The resulting strategies matrix should be of size 2 x N." << std::endl;
+    std::exit(-1);
+  }
+
+  // Compute the equilibrium
+  const fncas::double_t equilibrium = [&]() {
+    fncas::double_t r = 0.0;
+    for (size_t i = 0; i < N; ++i) {
+      for (size_t j = 0; j < N; ++j) {
+        r += A[i][j] * strategy[0][i] * strategy[1][j];
+      }
+    }
+    return r;
+  }();
+
+  if (print) {
+    std::cout << "### Equilibrium\n\nPayoff: `" << equilibrium << "`\n\n";
+  }
+
+  // Validate the solution. Each individual player one's strategy should result in the payoff no greater
+  // than the equlibrium one, and each individual player two's strategy should result in the payoff no less
+  // then the equilibrium one -- with certain threshold as the solution found by this algorithm is approximate.
+  {
+    // Validate for player one.
+    for (size_t i = 0; i < N; ++i) {
+      fncas::double_t player_one_payoff = 0.0;
+      for (size_t j = 0; j < N; ++j) {
+        player_one_payoff += A[i][j] * strategy[1][j];
+      }
+      if (player_one_payoff > equilibrium + FLAGS_eps) {
+        if (print) {
+          std::cerr << "Fail: player one's strategy " << i << " results in payoff " << player_one_payoff
+                    << ", which is greater than the equilibrium " << equilibrium << std::endl;
+        }
+        return false;
+      }
+    }
+  }
+  {
+    // Validate for player two.
+    for (size_t j = 0; j < N; ++j) {
+      fncas::double_t player_two_payoff = 0.0;
+      for (size_t i = 0; i < N; ++i) {
+        player_two_payoff += A[i][j] * strategy[0][i];
+      }
+      if (player_two_payoff < equilibrium - FLAGS_eps) {
+        if (print) {
+          std::cerr << "Fail: player two's strategy " << j << " results in payoff " << player_two_payoff
+                    << ", which is less than the equilibrium " << equilibrium << std::endl;
+        }
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+inline int run(int& argc, char**& argv) {
+  ParseDFlags(&argc, &argv);
+
+  size_t N;
+  std::vector<std::vector<int>> A;
+
+  if (FLAGS_matrix.empty()) {
+    // Generate the game matrix randomly.
+    N = static_cast<size_t>(FLAGS_dim);
+    A = std::vector<std::vector<int>>(N, std::vector<int>(N));
+    if (FLAGS_seed) {
+      SetRandomSeed(FLAGS_seed);
+    }
+    for (auto& row : A) {
+      for (int& e : row) {
+        e = RandomInt(FLAGS_min, FLAGS_max);
+      }
+    }
+  } else {
+    // Parse the game matrix from the command line flag.
+    try {
+      ParseJSON(FLAGS_matrix, A);
+    } catch (const current::Exception& e) {
+      std::cerr << "Exception: " << e.What() << std::endl;
+      return -1;
+    }
+    if (A.empty()) {
+      std::cerr << "The matrix should be nonempty." << std::endl;
+      return -1;
+    }
+    N = A.size();
+    for (const auto& row : A) {
+      if (row.size() != N) {
+        std::cerr << "The matrix should be square, N = " << N << ", bad row: " << JSON(row) << std::endl;
+        return -1;
+      }
+    }
+  }
+
+  std::cout << "### Game Matrix" << std::endl;
+  std::cout << "```" << std::endl;
+  for (const auto& row : A) {
+    for (const int e : row) {
+      std::cout << e << ' ';
+    }
+    std::cout << '\n';
+  }
+  std::cout << "```\n" << std::endl;
+
+  // Call the user code to solve the game.
+  const auto strategy = solve(N,
+                              A,
+                              [&](const std::vector<std::vector<fncas::double_t>>& strategy)
+                                  -> bool { return validate(N, A, strategy, false); });
+
+  // Make sure the solution is valid.
+  if (strategy.size() != 2u || strategy[0].size() != N || strategy[1].size() != N) {
+    std::cerr << "The resulting strategies matrix should be of size 2 x N." << std::endl;
+    return 1;
+  }
+
+  for (size_t p = 0; p < 2; ++p) {
+    fncas::double_t sum = 0.0;
+    for (fncas::double_t x : strategy[p]) {
+      if (x < 0) {
+        std::cerr << "Negative probability in the output." << std::endl;
+        return 1;
+      }
+      sum += x;
+    }
+    if (std::fabs(sum - 1.0) > 1e-6) {
+      std::cerr << "The probabilities in the output do not sum up to one." << std::endl;
+      return 1;
+    }
+  }
+
+  // Print the solution.
+  std::cout << "### Strategies\n";
+  std::cout << "#### Player One\n```\n";
+  for (fncas::double_t p : strategy[0]) {
+    std::cout << (p > 5e-3 ? Printf("%.3lf\n", p) : "-\n");
+  }
+  std::cout << "```\n#### Player Two\n```\n";
+  for (fncas::double_t p : strategy[1]) {
+    std::cout << (p > 5e-3 ? Printf("%.3lf\n", p) : "-\n");
+  }
+  std::cout << "```\n\n";
+
+  if (validate(N, A, strategy, true)) {
+    // All checks have passes, the solution is correct.
+    std::cout << "#### Validation\n\nOK." << std::endl;
+    return 0;
+  } else {
+    std::cout << "#### Fail\n\nValidation failed." << std::endl;
+    return 1;
+  }
+}
+
+#endif  // EXAMPLES_OPTIMIZE_MAIN_H

--- a/examples/Optimize/optimize.cc
+++ b/examples/Optimize/optimize.cc
@@ -98,7 +98,8 @@ struct FunctionToOptimize {
 
     // Construct the cost function that is minimized as the current point is the equlibrium one.
     const std::function<fncas::X2V<X>(fncas::X2V<X>)> softmax_penalty = [&](fncas::X2V<X> v) {
-      return sqr(v + sqrt(v * v));  // "Soft"-max invented by Dima. -- D.K.
+      // `zero_or_x(x)` is `max(0, x)`, differentiable and compilable by FnCAS.
+      return sqr(zero_or_x(v));
     };
 
     fncas::X2V<X> penalty = 0.0;

--- a/examples/Optimize/optimize.cc
+++ b/examples/Optimize/optimize.cc
@@ -53,7 +53,7 @@ DEFINE_bool(logtostderr, false, "Log to stderr.");
 
 template <typename X>
 X magic_weighting(X x) {
-  return sqr(x);  // For the canonical solution, `exp(x)` would do fine. This `sqr` just convereges faster. -- D.K.
+  return fncas::sqr(x);  // For the canonical solution, `exp(x)` would do fine; `sqr` just convereges faster. -- D.K.
 }
 
 template <typename X>
@@ -97,10 +97,8 @@ struct FunctionToOptimize {
     }
 
     // Construct the cost function that is minimized as the current point is the equlibrium one.
-    const std::function<fncas::X2V<X>(fncas::X2V<X>)> softmax_penalty = [&](fncas::X2V<X> v) {
-      // `zero_or_x(x)` is `max(0, x)`, differentiable and compilable by FnCAS.
-      return sqr(zero_or_x(v));
-    };
+    const std::function<fncas::X2V<X>(fncas::X2V<X>)> softmax_penalty =
+        [&](fncas::X2V<X> v) { return fncas::sqr(fncas::ramp(v)); };
 
     fncas::X2V<X> penalty = 0.0;
 

--- a/examples/Optimize/optimize.cc
+++ b/examples/Optimize/optimize.cc
@@ -1,0 +1,176 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// Solves the matrix game by means of a gradient-descent-based optimization.
+
+// #define FNCAS_USE_LONG_DOUBLE
+
+#include "../../port.h"
+
+#ifndef FNCAS_USE_LONG_DOUBLE
+
+// The `FNCAS_JIT` macros are expected to be tweaked by the user of FnCAS. These values are just for the demo.
+#if defined(CURRENT_APPLE)
+#define FNCAS_JIT CLANG  // Assume OS X. -- D.K.
+#elif defined(CURRENT_POSIX)
+#define FNCAS_JIT NASM  // Assume Linux -- D.K.
+#endif
+
+#endif  // #ifndef FNCAS_USE_LONG_DOUBLE
+
+#include "main.h"
+
+#include "../../FnCAS/fncas/fncas.h"
+
+DEFINE_string(matrix, "", "If set, the JSON representation of the game matrix.");
+DEFINE_size_t(dim, 4, "The dimension of square matrix A for the matrix game.");
+DEFINE_int32(min, 1, "The minimum randomly generated value for A[i][j].");
+DEFINE_int32(max, 9, "The minimum randomly generated value for A[i][j].");
+DEFINE_uint64(seed, 19830816, "The random seed to use, zero to generate the input nondeterministically.");
+DEFINE_double(eps, 1e-3, "The value of the epsilon to compare doubles with.");
+DEFINE_bool(logtostderr, false, "Log to stderr.");
+
+template <typename X>
+X magic_weighting(X x) {
+  return sqr(x);  // For the canonical solution, `exp(x)` would do fine. This `sqr` just convereges faster. -- D.K.
+}
+
+template <typename X>
+inline X simplex(X point) {
+  fncas::X2V<X> sum = 0.0;
+  for (auto& x : point) {
+    x = magic_weighting(x);
+    sum += x;
+  }
+  const fncas::X2V<X> k = 1.0 / sum;
+  for (auto& x : point) {
+    x *= k;
+  }
+  return point;
+}
+
+struct FunctionToOptimize {
+  const size_t N;
+  const std::vector<std::vector<int>>& A;
+
+  explicit FunctionToOptimize(size_t N, const std::vector<std::vector<int>>& A) : N(N), A(A) {}
+
+  template <typename X>
+  fncas::X2V<X> ObjectiveFunction(const X& x) const {
+    CURRENT_ASSERT(x.size() == N * 2);
+
+    // Precompute strategy simplexes.
+    std::vector<std::vector<fncas::X2V<X>>> proto_strategy(2, std::vector<fncas::X2V<X>>(N));
+    for (size_t k = 0; k < N; ++k) {
+      proto_strategy[0][k] = x[k];
+      proto_strategy[1][k] = x[k + N];
+    }
+    std::vector<std::vector<fncas::X2V<X>>> strategy({simplex(proto_strategy[0]), simplex(proto_strategy[1])});
+
+    // Compute the current payoff (the "equilibrium", unless the solution is not yet optimal).
+    fncas::X2V<X> mixed_strategies_payoff = 0.0;
+    for (size_t i = 0; i < N; ++i) {
+      for (size_t j = 0; j < N; ++j) {
+        mixed_strategies_payoff += strategy[0][i] * strategy[1][j] * A[i][j];
+      }
+    }
+
+    // Construct the cost function that is minimized as the current point is the equlibrium one.
+    const std::function<fncas::X2V<X>(fncas::X2V<X>)> softmax_penalty = [&](fncas::X2V<X> v) {
+      return sqr(v + sqrt(v * v));  // "Soft"-max invented by Dima. -- D.K.
+    };
+
+    fncas::X2V<X> penalty = 0.0;
+
+    {
+      // Player one: per-opponent-strategy payoffs should be less than or equal to the `mixed_strategies_payoff`.
+      for (size_t i = 0; i < N; ++i) {
+        fncas::X2V<X> player_one_payoff = 0.0;
+        for (size_t j = 0; j < N; ++j) {
+          player_one_payoff += A[i][j] * strategy[1][j];
+        }
+        penalty += softmax_penalty(player_one_payoff - mixed_strategies_payoff);
+      }
+    }
+
+    {
+      // Player two: per-opponent-strategy payoffs should be greater than or equal to the `mixed_strategies_payoff`.
+      for (size_t j = 0; j < N; ++j) {
+        fncas::X2V<X> player_two_payoff = 0.0;
+        for (size_t i = 0; i < N; ++i) {
+          player_two_payoff += A[i][j] * strategy[0][i];
+        }
+        penalty += softmax_penalty(mixed_strategies_payoff - player_two_payoff);
+      }
+    }
+
+    return penalty;
+  }
+};
+
+template <typename T>
+using optimizer_t = fncas::ConjugateGradientOptimizer<T>;  // `GradientDescentOptimizerBT`, `GradientDescentOptimizer`.
+
+std::vector<std::vector<fncas::double_t>> solve(
+    size_t N,
+    const std::vector<std::vector<int>>& A,
+    std::function<bool(const std::vector<std::vector<fncas::double_t>>& strategy)> validate) {
+  const auto build_probabilities =
+      [N](const std::vector<fncas::double_t>& x) -> std::vector<std::vector<fncas::double_t>> {
+        return {simplex(std::vector<fncas::double_t>(x.begin(), x.begin() + N)),
+                simplex(std::vector<fncas::double_t>(x.begin() + N, x.begin() + N * 2))};
+      };
+
+  const auto pretty_print_simplex = [](const std::vector<fncas::double_t>& x) -> std::string {
+    std::ostringstream os;
+    for (fncas::double_t v : x) {
+      os << current::strings::Printf(" %.3lf", v);
+    }
+    return "{" + os.str() + " }";
+  };
+
+  std::unique_ptr<fncas::ScopedLogToStderr> scope;
+  if (FLAGS_logtostderr) {
+    scope = std::make_unique<fncas::ScopedLogToStderr>();
+  }
+
+  return build_probabilities(
+      optimizer_t<FunctionToOptimize>(
+          fncas::OptimizerParameters()
+              .SetValue("max_steps", 50000)
+              .SetPointBeautifier([&](const std::vector<fncas::double_t>& x) {
+                const auto p = build_probabilities(x);
+                return "A = " + pretty_print_simplex(p[0]) + ", B = " + pretty_print_simplex(p[1]);
+              })
+              .SetStoppingCriterion([&](size_t completed_iterations, const std::vector<fncas::double_t>& x) {
+                static_cast<void>(completed_iterations);
+                return validate(build_probabilities(x));
+              }),
+          N,
+          A)
+          .Optimize(std::vector<fncas::double_t>(N * 2, 1.0))
+          .point);
+}
+
+int main(int argc, char** argv) { return run(argc, argv); }

--- a/examples/Optimize/smoke.cc
+++ b/examples/Optimize/smoke.cc
@@ -1,0 +1,138 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2016 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// Solves the matrix game using the Brown-Robinson iterative method.
+// Note: The convergence of this method is very slow. This implementation is only meant to be used as a smoke test.
+
+#include "main.h"
+
+DEFINE_string(matrix, "", "If set, the JSON representation of the game matrix.");
+DEFINE_size_t(dim, 4, "The dimension of square matrix A for the matrix game.");
+DEFINE_int32(min, 1, "The minimum randomly generated value for A[i][j].");
+DEFINE_int32(max, 9, "The minimum randomly generated value for A[i][j].");
+DEFINE_uint64(seed, 19830816, "The random seed to use, zero to generate the input nondeterministically.");
+DEFINE_double(eps, 1e-3, "The acceptable threshold between the equilibrium payoff and the worst outliner.");
+DEFINE_bool(logtostderr, false, "Log to stderr.");
+
+DEFINE_size_t(iterations_between_validations,
+              510510,  // 2*3*5*7*11*13*17
+              "Every how many iterations run should the solution be tested for optimality.");
+
+std::vector<std::vector<double>> solve(size_t N,
+                                       const std::vector<std::vector<int>>& A,
+                                       std::function<bool(const std::vector<std::vector<double>>& strategy)> validate) {
+  // S[0/1]: The strategies of the two players respectively. Normalize by `sum(S[player][*])` to get the simplex.
+  std::vector<std::vector<int64_t>> S(2, std::vector<int64_t>(N, 1));
+
+  // P[0/1]: The payoffs "against" each player given their present strategy.
+  // Effectively, the product of the matrix `A` and the player's strategy.
+  std::vector<std::vector<int64_t>> P(2, std::vector<int64_t>(N, 0));
+
+  // Compute the intial state of payoffs.
+  // The payoff of player two's strategy `j` against current `S[0]` is `P[0][j] = sum_i(A[i][j] * S[0][i])`.
+  // The payoff of player one's strategy `i` against current `S[1]` is `P[1][i] = sum_j(A[i][j] * S[1][j])`.
+  for (size_t i = 0; i < N; ++i) {
+    for (size_t j = 0; j < N; ++j) {
+      P[0][j] += A[i][j];
+      P[1][i] += A[i][j];
+    }
+  }
+
+  // Run optimization iterations maintaining the invariants of `S` and `P`.
+  size_t total_iterations = 0;
+  const auto iteration = [&]() {
+    ++total_iterations;
+    {
+      // See how can player one do better.
+      size_t best_i = 0;
+      int64_t max_payoff = P[1][0];
+      for (size_t i = 1; i < N; ++i) {
+        // Player one is maximizing their payoff from player two.
+        if (P[1][i] > max_payoff) {
+          best_i = i;
+          max_payoff = P[1][i];
+        }
+      }
+      // Player one adds strategy `best_i` into their mix.
+      ++S[0][best_i];
+      for (size_t j = 0; j < N; ++j) {
+        P[0][j] += A[best_i][j];
+      }
+    }
+    {
+      // See how can player two do better.
+      size_t best_j = 0;
+      int64_t min_payoff = P[0][0];
+      for (size_t j = 1; j < N; ++j) {
+        // Player two is minimizing their payoff to player one.
+        if (P[0][j] < min_payoff) {
+          best_j = j;
+          min_payoff = P[0][j];
+        }
+      }
+      // Player two adds strategy `best_j` into their mix.
+      ++S[1][best_j];
+      for (size_t i = 0; i < N; ++i) {
+        P[1][i] += A[i][best_j];
+      }
+    }
+  };
+
+  // Snapshots of `S` every half `--iterations_between_validations`.
+  std::vector<std::vector<std::vector<int64_t>>> counters;
+  const size_t half_number_of_iterations = std::max(static_cast<size_t>(1), FLAGS_iterations_between_validations);
+
+  // Run the incrementally improving iterations.
+  const auto begin_timestamp = current::time::Now();
+  while (true) {
+    for (size_t i = 0; i < half_number_of_iterations; ++i) {
+      iteration();
+    }
+    counters.push_back(S);
+    if (counters.size() >= 3 && (counters.size() % 2) == 1) {
+      // Compute and return the final strategy.
+      const size_t c = counters.size() - 1u;  // `c` is even.
+      const auto& last = counters[c];
+      const auto& mid = counters[c / 2];
+      std::vector<std::vector<double>> strategy(2, std::vector<double>(N));
+      const double k = 1.0 / (half_number_of_iterations * (c / 2));
+      for (size_t p = 0; p < 2; ++p) {
+        for (size_t i = 0; i < N; ++i) {
+          strategy[p][i] = (last[p][i] - mid[p][i]) * k;
+        }
+      }
+      // If the current strategy is the optimal one, we're done. Otherwise, keep iterating.
+      if (validate(strategy)) {
+        if (FLAGS_logtostderr) {
+          std::cerr << "Done in " << total_iterations << " iterations, "
+                    << total_iterations / (1e-6 * (current::time::Now() - begin_timestamp).count()) << " per second."
+                    << std::endl;
+        }
+        return strategy;
+      }
+    }
+  }
+}
+
+int main(int argc, char** argv) { return run(argc, argv); }

--- a/scripts/MakefileImpl
+++ b/scripts/MakefileImpl
@@ -22,7 +22,7 @@ LOCAL_HEADERS_DEPS=$(shell find . -maxdepth 1 -name '*.h' -exec echo '{}' ';' | 
 LOCAL_HEADERS_LIST=$(shell find . -maxdepth 1 -name '*.h' -exec echo '"{}"' ';' | grep -v "current_build.h" | sort -g)
 
 CPLUSPLUS?=g++
-CPPFLAGS=-std=c++11 -Wall -W
+CPPFLAGS=-std=c++11 -Wall -Wno-strict-aliasing -W  # `-Wno-strict-aliasing` to supress FnCAS warnings.
 CPPFLAGS+= -ftemplate-backtrace-limit=0  -ftemplate-depth=10000
 ifeq ($(NDEBUG),1)
   CPPFLAGS+= -O3 -DNDEBUG


### PR DESCRIPTION
## Code

TL;DR:

* Enabled compiling the gradient.
* Added an example solving a somewhat real problem usingf `FnCAS`.
* Refactored and tested stuff through.
 
## TESTED

### On my X1 Carbon.

#### `In FnCAS $`:

Original: `make test`: OK
Uncommented `#define FNCAS_USE_LONG_DOUBLE`: (no JIT) `make test`: OK
With `#define FNCAS_JIT NASM`: `make test`: OK
With `#define FNCAS_JIT CLANG`: `make test`: OK

#### `In examples/Optimize $`:

Original `make`: OK.

With **NASM**: `NDEBUG=1 make && time ./.current/optimize --dim 6 --logtostderr`: OK.

```
ConjugateGradientOptimizer: 74 iterations, 161.757 per second, 1137 f() calls, 148 g() calls, 74 backtracking calls of 989 total steps.

real	0m28.697s  # Including compilation time.
user	0m28.512s
sys	0m0.164s
```

With **CLANG**: `NDEBUG=1 make && time ./.current/optimize --dim 6 --logtostderr`: OK.

```
ConjugateGradientOptimizer: 74 iterations, 142.437 per second, 1137 f() calls, 148 g() calls, 74 backtracking calls of 989 total steps.

real	0m19.509s  # Including compilation time.
user	0m18.736s
sys	0m0.752s
```

With `GradientDescentOptimizerBT` (nasm): NDEBUG=1 make && time ./.current/optimize --dim 6 --logtostderr`: OK.

```
GradientDescentOptimizerBT: 1660 iterations, 167.839 per second, 22730 f() calls, 1660 g() calls, 1660 backtracking calls of 19410 total steps.

real	0m38.514s  # Including compilation time.
user	0m38.276s
sys	0m0.212s
```

With `GradientDescentOptimizer` (nasm): `NDEBUG=1 make && time ./.current/optimize --dim 6 --logtostderr`

```
GradientDescentOptimizer: 5006 iterations, 319.903 per second, 15018 f() calls, 5006 g() calls.

real	0m46.306s  # Including compilation time.
user	0m45.996s
sys	0m0.268s
```

With `#define FNCAS_USE_LONG_DOUBLE` (intermediate mode only, no compiled functions/gradients) : OK

### And these are on Hetz

#### `FnCAS/deprecated_test/smoke $ make`

```
./run_smoke_test.sh
g++ --std=c++11 -O2 -DFNCAS_JIT=NASM ../eval.cc -I $PWD/autogen -o $BINARY -ldl
/tmp/ccfxuEOr.o: In function `action_gen_eval_Xeval<eval::compiled>::start()':
eval.cc:(.text._ZN21action_gen_eval_XevalIN4eval8compiledEE5startEv[_ZN21action_gen_eval_XevalIN4eval8compiledEE5startEv]+0xb5): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
arithmetics: OK OK OK OK
math: OK OK OK OK
sum: OK OK OK OK
g++ --std=c++11 -O2 -DFNCAS_JIT=CLANG ../eval.cc -I $PWD/autogen -o $BINARY -ldl
/tmp/ccv6ePjD.o: In function `action_gen_eval_Xeval<eval::compiled>::start()':
eval.cc:(.text._ZN21action_gen_eval_XevalIN4eval8compiledEE5startEv[_ZN21action_gen_eval_XevalIN4eval8compiledEE5startEv]+0xb5): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
arithmetics: OK OK OK OK
math: OK OK OK OK
sum: OK OK OK OK
OK
```

#### `FnCAS/deprecated_test/perf $ make`

Ref. https://gist.github.com/dkorolev/b04a9d7a9ae3e0f96fa92789e6839b2f

