### PR TITLE
Fix for Windows' `.tellp()`.

### DIFF
--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -154,7 +154,7 @@ class FilePersister {
                                const ss::StreamNamespaceName& namespace_name,
                                const std::string& filename)
         : filename(filename),
-          appender(filename, std::ofstream::app),
+          appender(filename, std::ofstream::app | std::ofstream::ate),
           head_rewriter(filename, std::ofstream::in | std::ofstream::out),
           mutex_ref(mutex_ref),
           head_offset(0) {


### PR DESCRIPTION
Thanks @amarmer @nyospe, CC @mzhurovich @grixa.

TL;DR: On Windows the `std::ofstream` open with `std::ofstream::app` and w/o `std::ofstream::ate` doesn't automatically seek to the end of file for `.tellp()` purposes, resulting in an inconsistent index exception when publishing to the stream.

Thanks,
Dima 