### PR TITLE
Ignored trailing spaces and tabs before and after the HTTP header field values.

### DIFF
--- a/Bricks/net/http/constants.h
+++ b/Bricks/net/http/constants.h
@@ -43,8 +43,7 @@ constexpr char kDefaultHTMLContentType[] = "text/html; charset=utf-8";
 constexpr char kDefaultSVGContentType[] = "image/svg+xml; charset=utf-8";
 constexpr char kDefaultPNGContentType[] = "image/png";
 
-constexpr char kHeaderKeyValueSeparator[] = ":";
-constexpr size_t kHeaderKeyValueSeparatorLength = strings::CompileTimeStringLength(kHeaderKeyValueSeparator);
+constexpr char kHeaderKeyValueSeparator = ':';
 
 constexpr char kContentLengthHeaderKey[] = "Content-Length";
 constexpr char kTransferEncodingHeaderKey[] = "Transfer-Encoding";

--- a/Bricks/net/http/constants.h
+++ b/Bricks/net/http/constants.h
@@ -43,7 +43,7 @@ constexpr char kDefaultHTMLContentType[] = "text/html; charset=utf-8";
 constexpr char kDefaultSVGContentType[] = "image/svg+xml; charset=utf-8";
 constexpr char kDefaultPNGContentType[] = "image/png";
 
-constexpr char kHeaderKeyValueSeparator[] = ": ";
+constexpr char kHeaderKeyValueSeparator[] = ":";
 constexpr size_t kHeaderKeyValueSeparatorLength = strings::CompileTimeStringLength(kHeaderKeyValueSeparator);
 
 constexpr char kContentLengthHeaderKey[] = "Content-Length";

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -325,11 +325,11 @@ class GenericHTTPRequestData : public HELPER {
             }
           }
         } else if (!line_is_blank) {
-          char* p = strstr(&buffer_[current_line_offset], constants::kHeaderKeyValueSeparator);
+          char* p = strchr(&buffer_[current_line_offset], constants::kHeaderKeyValueSeparator);
           if (p) {
-            *p = '\0';
+            *p++ = '\0';
             const char* const key = &buffer_[current_line_offset];
-            const char* value = p + constants::kHeaderKeyValueSeparatorLength;
+            const char* value = p;
 
             // Ignore trailing spaces and tabs before and after the value.
             while (value < next_crlf_ptr && (*value == ' ' || *value == '\t')) {

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -331,11 +331,11 @@ class GenericHTTPRequestData : public HELPER {
             const char* const key = &buffer_[current_line_offset];
             const char* value = p + constants::kHeaderKeyValueSeparatorLength;
 
-            // Ignore trailing spaces and tabs before and after the value
-            while (value < next_crlf_ptr && ::isspace(*value)) {
+            // Ignore trailing spaces and tabs before and after the value.
+            while (value < next_crlf_ptr && (*value == ' ' || *value == '\t')) {
               ++value;
             }
-            while (next_crlf_ptr > value && ::isspace(*(next_crlf_ptr - 1))) {
+            while (next_crlf_ptr > value && (*(next_crlf_ptr - 1) == ' ' || *(next_crlf_ptr - 1) == '\t')) {
               --next_crlf_ptr;
             }
             *next_crlf_ptr = '\0';

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -329,7 +329,17 @@ class GenericHTTPRequestData : public HELPER {
           if (p) {
             *p = '\0';
             const char* const key = &buffer_[current_line_offset];
-            const char* const value = p + constants::kHeaderKeyValueSeparatorLength;
+            const char* value = p + constants::kHeaderKeyValueSeparatorLength;
+
+            // Ignore trailing spaces and tabs before and after the value
+            while (value < next_crlf_ptr && ::isspace(*value)) {
+              ++value;
+            }
+            while (next_crlf_ptr > value && ::isspace(*(next_crlf_ptr - 1))) {
+              --next_crlf_ptr;
+            }
+            *next_crlf_ptr = '\0';
+
             HELPER::OnHeader(key, value);
             if (HeaderNameEquals(key, constants::kContentLengthHeaderKey)) {
               body_length = static_cast<size_t>(atoi(value));

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -332,10 +332,11 @@ class GenericHTTPRequestData : public HELPER {
             const char* value = p;
 
             // Ignore trailing spaces and tabs before and after the value.
-            while (value < next_crlf_ptr && (*value == ' ' || *value == '\t')) {
+            const auto IsSpaceOrTab = [](const char c) { return c == ' ' || c == '\t'; };
+            while (value < next_crlf_ptr && IsSpaceOrTab(*value)) {
               ++value;
             }
-            while (next_crlf_ptr > value && (*(next_crlf_ptr - 1) == ' ' || *(next_crlf_ptr - 1) == '\t')) {
+            while (next_crlf_ptr > value && IsSpaceOrTab(*(next_crlf_ptr - 1))) {
               --next_crlf_ptr;
             }
             *next_crlf_ptr = '\0';

--- a/Bricks/net/http/test.cc
+++ b/Bricks/net/http/test.cc
@@ -129,13 +129,13 @@ TEST(PosixHTTPServerTest, SmokeWithTrailingSpaces) {
   connection.BlockingWrite("BODY", true);
   connection.BlockingWrite("\r\n", false);
   ExpectToReceive(
-                  "HTTP/1.1 200 OK\r\n"
-                  "Content-Type: text/plain\r\n"
-                  "Connection: close\r\n"
-                  "Content-Length: 10\r\n"
-                  "\r\n"
-                  "Data: BODY",
-                  connection);
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain\r\n"
+      "Connection: close\r\n"
+      "Content-Length: 10\r\n"
+      "\r\n"
+      "Data: BODY",
+      connection);
   t.join();
 }
 

--- a/Bricks/net/http/test.cc
+++ b/Bricks/net/http/test.cc
@@ -106,6 +106,39 @@ TEST(PosixHTTPServerTest, Smoke) {
   t.join();
 }
 
+TEST(PosixHTTPServerTest, SmokeWithTrailingSpaces) {
+  thread t([](Socket s) {
+    HTTPServerConnection c(s.Accept());
+    EXPECT_EQ("127.0.0.1", c.LocalIPAndPort().ip);
+    EXPECT_EQ(FLAGS_net_http_test_port, c.LocalIPAndPort().port);
+    EXPECT_EQ("127.0.0.1", c.RemoteIPAndPort().ip);
+    EXPECT_LT(0, c.RemoteIPAndPort().port);
+    EXPECT_EQ("POST", c.HTTPRequest().Method());
+    EXPECT_EQ("/", c.HTTPRequest().RawPath());
+    c.SendHTTPResponse("Data: " + c.HTTPRequest().Body());
+  }, Socket(FLAGS_net_http_test_port));
+  Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
+  EXPECT_EQ("127.0.0.1", connection.LocalIPAndPort().ip);
+  EXPECT_LT(0, connection.LocalIPAndPort().port);
+  EXPECT_EQ("127.0.0.1", connection.RemoteIPAndPort().ip);
+  EXPECT_EQ(FLAGS_net_http_test_port, connection.RemoteIPAndPort().port);
+  connection.BlockingWrite("POST / HTTP/1.1\r\n", true);
+  connection.BlockingWrite("Host:\t\t  localhost  \r\n", true);
+  connection.BlockingWrite("Content-Length:4  \t \t \r\n", true);
+  connection.BlockingWrite("\r\n", true);
+  connection.BlockingWrite("BODY", true);
+  connection.BlockingWrite("\r\n", false);
+  ExpectToReceive(
+                  "HTTP/1.1 200 OK\r\n"
+                  "Content-Type: text/plain\r\n"
+                  "Connection: close\r\n"
+                  "Content-Length: 10\r\n"
+                  "\r\n"
+                  "Data: BODY",
+                  connection);
+  t.join();
+}
+
 TEST(PosixHTTPServerTest, SmokeWithArray) {
   thread t([](Socket s) {
     HTTPServerConnection c(s.Accept());


### PR DESCRIPTION
According to rfc7230:
```
header-field   = field-name ":" OWS field-value OWS
```
where:
```
OWS            = *( SP / HTAB )
                    ; optional whitespace
```