### PR TITLE
ScanDirRecursive

### DIFF
--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -207,16 +207,16 @@ class HTTPServerPOSIX final {
     current::FileSystem::ScanDir(
         dir,
         [this, &route_prefix, &scope](const current::FileSystem::ScanDirItemInfo& item_info) {
-          const std::string content_type(current::net::GetFileMimeType(item_info.name, ""));
+          const std::string content_type(current::net::GetFileMimeType(item_info.basename, ""));
           if (!content_type.empty()) {
             // TODO(dkorolev): Wrap keeping file contents into a singleton
             // that keeps a map from a (SHA256) hash to the contents.
             auto static_file_server = std::make_unique<StaticFileServer>(
-                current::FileSystem::ReadFileAsString(item_info.path), content_type);
-            scope += Register(route_prefix + item_info.name, *static_file_server);
+                current::FileSystem::ReadFileAsString(item_info.pathname), content_type);
+            scope += Register(route_prefix + item_info.basename, *static_file_server);
             static_file_servers_.push_back(std::move(static_file_server));
           } else {
-            CURRENT_THROW(current::net::CannotServeStaticFilesOfUnknownMIMEType(item_info.name));
+            CURRENT_THROW(current::net::CannotServeStaticFilesOfUnknownMIMEType(item_info.basename));
           }
         });
     return scope;

--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -206,17 +206,17 @@ class HTTPServerPOSIX final {
     HTTPRoutesScope scope;
     current::FileSystem::ScanDir(
         dir,
-        [this, &dir, &route_prefix, &scope](const std::string& file) {
-          const std::string content_type(current::net::GetFileMimeType(file, ""));
+        [this, &route_prefix, &scope](const current::FileSystem::ScanDirItemInfo& item_info) {
+          const std::string content_type(current::net::GetFileMimeType(item_info.name, ""));
           if (!content_type.empty()) {
             // TODO(dkorolev): Wrap keeping file contents into a singleton
             // that keeps a map from a (SHA256) hash to the contents.
             auto static_file_server = std::make_unique<StaticFileServer>(
-                current::FileSystem::ReadFileAsString(current::FileSystem::JoinPath(dir, file)), content_type);
-            scope += Register(route_prefix + file, *static_file_server);
+                current::FileSystem::ReadFileAsString(item_info.path), content_type);
+            scope += Register(route_prefix + item_info.name, *static_file_server);
             static_file_servers_.push_back(std::move(static_file_server));
           } else {
-            CURRENT_THROW(current::net::CannotServeStaticFilesOfUnknownMIMEType(file));
+            CURRENT_THROW(current::net::CannotServeStaticFilesOfUnknownMIMEType(item_info.name));
           }
         });
     return scope;

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -253,9 +253,8 @@ struct FileSystem {
           const char* const name = find_data.cFileName;
           if (ScanDirCanHandleName(name)) {
             const bool is_directory = (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
-            const ScanDirParameters mask = is_directory
-                                             ? ScanDirParameters::ListDirsOnly
-                                             : ScanDirParameters::ListFilesOnly;
+            const ScanDirParameters mask =
+                is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
             if (static_cast<int>(parameters) & static_cast<int>(mask)) {
               if (!item_handler(ScanDirItemInfo(name, JoinPath(directory, name), is_directory))) {
                 return;
@@ -300,24 +299,22 @@ struct FileSystem {
       }
 #endif
     } else {
-      const std::function<bool(const ScanDirItemInfo&)> item_handler_recursive = [&item_handler, parameters](const ScanDirItemInfo& item_info) {
-        const ScanDirParameters mask = item_info.is_directory
-                                         ? ScanDirParameters::ListDirsOnly
-                                         : ScanDirParameters::ListFilesOnly;
-        if (static_cast<int>(parameters) & static_cast<int>(mask)) {
-          if (!item_handler(item_info)) {
-            return false;
-          }
-        }
-        if (item_info.is_directory) {
-          ScanDirUntil<ITEM_HANDLER>(item_info.pathname, std::forward<ITEM_HANDLER>(item_handler), parameters, ScanDirRecursive::Yes);
-        }
-        return true;
-      };
-      ScanDirUntil(directory,
-                   item_handler_recursive,
-                   ScanDirParameters::ListFilesAndDirs,
-                   ScanDirRecursive::No);
+      const std::function<bool(const ScanDirItemInfo&)> item_handler_recursive =
+          [&item_handler, parameters](const ScanDirItemInfo& item_info) {
+            const ScanDirParameters mask =
+                item_info.is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
+            if (static_cast<int>(parameters) & static_cast<int>(mask)) {
+              if (!item_handler(item_info)) {
+                return false;
+              }
+            }
+            if (item_info.is_directory) {
+              ScanDirUntil<ITEM_HANDLER>(
+                  item_info.pathname, std::forward<ITEM_HANDLER>(item_handler), parameters, ScanDirRecursive::Yes);
+            }
+            return true;
+          };
+      ScanDirUntil(directory, item_handler_recursive, ScanDirParameters::ListFilesAndDirs, ScanDirRecursive::No);
     }
   }
 

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -225,89 +225,113 @@ struct FileSystem {
   };
 
   enum class ScanDirParameters : int { ListFilesOnly = 1, ListDirsOnly = 2, ListFilesAndDirs = 3 };
+  enum class ScanDirRecursive { No, Yes };
 
   static inline bool ScanDirCanHandleName(const char* const name) {
     return (*name && ::strcmp(name, ".") && ::strcmp(name, ".."));
   }
 
-  template <typename F>
+  template <typename ITEM_HANDLER>
   static inline void ScanDirUntil(const std::string& directory,
-                                  F&& f,
-                                  ScanDirParameters parameters = ScanDirParameters::ListFilesOnly) {
+                                  ITEM_HANDLER&& item_handler,
+                                  ScanDirParameters parameters = ScanDirParameters::ListFilesOnly,
+                                  ScanDirRecursive recursive = ScanDirRecursive::No) {
+    if (recursive == ScanDirRecursive::No) {
 #ifdef CURRENT_WINDOWS
-    WIN32_FIND_DATAA find_data;
-    HANDLE handle = ::FindFirstFileA((directory + "\\*.*").c_str(), &find_data);
-    if (handle == INVALID_HANDLE_VALUE) {
-      CURRENT_THROW(DirDoesNotExistException(directory));
-    } else {
-      struct ScopedCloseFindFileHandle {
-        HANDLE handle_;
-        ScopedCloseFindFileHandle(HANDLE handle) : handle_(handle) {}
-        ~ScopedCloseFindFileHandle() { ::FindClose(handle_); }
-      };
-      const ScopedCloseFindFileHandle closer(handle);
-      do {
-        const char* const name = find_data.cFileName;
-        if (ScanDirCanHandleName(name)) {
-          const bool is_directory = (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
-          const ScanDirParameters mask = is_directory
-                                           ? ScanDirParameters::ListDirsOnly
-                                           : ScanDirParameters::ListFilesOnly;
-          if (static_cast<int>(parameters) & static_cast<int>(mask)) {
-            if (!f(ScanDirItemInfo(name, JoinPath(directory, name), is_directory))) {
-              return;
-            }
-          }
-        }
-      } while (::FindNextFileA(handle, &find_data) != 0);
-    }
-#else
-    DIR* dir = ::opendir(directory.c_str());
-    const auto closedir_guard = MakeScopeGuard([dir]() {
-      if (dir) {
-        ::closedir(dir);
-      }
-    });
-    if (dir) {
-      while (struct dirent* entry = ::readdir(dir)) {
-        const char* const name = entry->d_name;
-        if (ScanDirCanHandleName(name)) {
-          // `IsDir` is proved to be required on Ubuntu running in Parallels on a Mac,
-          // with Bricks' directory mounted from Mac's filesystem.
-          // `entry->d_type` is always zero there, see http://comments.gmane.org/gmane.comp.lib.libcg.devel/4236
-          const std::string& path = JoinPath(directory, name);
-          const bool is_directory = IsDir(path);
-          const ScanDirParameters mask =
-              is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
-          if (static_cast<int>(parameters) & static_cast<int>(mask)) {
-            if (!f(ScanDirItemInfo(name, path, is_directory))) {
-              return;
-            }
-          }
-        }
-      }
-    } else {
-      if (errno == ENOENT) {
+      WIN32_FIND_DATAA find_data;
+      HANDLE handle = ::FindFirstFileA((directory + "\\*.*").c_str(), &find_data);
+      if (handle == INVALID_HANDLE_VALUE) {
         CURRENT_THROW(DirDoesNotExistException(directory));
-      } else if (errno == ENOTDIR) {
-        CURRENT_THROW(PathNotDirException(directory));
       } else {
-        CURRENT_THROW(FileException(directory));  // LCOV_EXCL_LINE
+        struct ScopedCloseFindFileHandle {
+          HANDLE handle_;
+          ScopedCloseFindFileHandle(HANDLE handle) : handle_(handle) {}
+          ~ScopedCloseFindFileHandle() { ::FindClose(handle_); }
+        };
+        const ScopedCloseFindFileHandle closer(handle);
+        do {
+          const char* const name = find_data.cFileName;
+          if (ScanDirCanHandleName(name)) {
+            const bool is_directory = (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+            const ScanDirParameters mask = is_directory
+                                             ? ScanDirParameters::ListDirsOnly
+                                             : ScanDirParameters::ListFilesOnly;
+            if (static_cast<int>(parameters) & static_cast<int>(mask)) {
+              if (!item_handler(ScanDirItemInfo(name, JoinPath(directory, name), is_directory))) {
+                return;
+              }
+            }
+          }
+        } while (::FindNextFileA(handle, &find_data) != 0);
       }
-    }
+#else
+      DIR* dir = ::opendir(directory.c_str());
+      const auto closedir_guard = MakeScopeGuard([dir]() {
+        if (dir) {
+          ::closedir(dir);
+        }
+      });
+      if (dir) {
+        while (struct dirent* entry = ::readdir(dir)) {
+          const char* const name = entry->d_name;
+          if (ScanDirCanHandleName(name)) {
+            // `IsDir` is proved to be required on Ubuntu running in Parallels on a Mac,
+            // with Bricks' directory mounted from Mac's filesystem.
+            // `entry->d_type` is always zero there, see http://comments.gmane.org/gmane.comp.lib.libcg.devel/4236
+            const std::string& path = JoinPath(directory, name);
+            const bool is_directory = IsDir(path);
+            const ScanDirParameters mask =
+                is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
+            if (static_cast<int>(parameters) & static_cast<int>(mask)) {
+              if (!item_handler(ScanDirItemInfo(name, path, is_directory))) {
+                return;
+              }
+            }
+          }
+        }
+      } else {
+        if (errno == ENOENT) {
+          CURRENT_THROW(DirDoesNotExistException(directory));
+        } else if (errno == ENOTDIR) {
+          CURRENT_THROW(PathNotDirException(directory));
+        } else {
+          CURRENT_THROW(FileException(directory));  // LCOV_EXCL_LINE
+        }
+      }
 #endif
+    } else {
+      ScanDirUntil(directory,
+                   [&item_handler, parameters](const ScanDirItemInfo& item_info) {
+                     const ScanDirParameters mask = item_info.is_directory
+                                                      ? ScanDirParameters::ListDirsOnly
+                                                      : ScanDirParameters::ListFilesOnly;
+                     if (static_cast<int>(parameters) & static_cast<int>(mask)) {
+                       if (!item_handler(item_info)) {
+                         return false;
+                       }
+                     }
+                     if (item_info.is_directory) {
+                       ScanDirUntil<ITEM_HANDLER>(item_info.path, std::forward<ITEM_HANDLER>(item_handler), parameters, ScanDirRecursive::Yes);
+                     }
+                     return true;
+                   },
+                   ScanDirParameters::ListFilesAndDirs,
+                   ScanDirRecursive::No);
+    }
   }
 
   template <typename ITEM_HANDLER>
   static inline void ScanDir(const std::string& directory,
                              ITEM_HANDLER&& item_handler,
-                             ScanDirParameters parameters = ScanDirParameters::ListFilesOnly) {
+                             ScanDirParameters parameters = ScanDirParameters::ListFilesOnly,
+                             ScanDirRecursive recursive = ScanDirRecursive::No) {
     ScanDirUntil(directory,
                  [&item_handler](const ScanDirItemInfo& item_info) {
                    item_handler(item_info);
                    return true;
                  },
-                 parameters);
+                 parameters,
+                 recursive);
   }
 
   enum class RmFileParameters { ThrowExceptionOnError, Silent };

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -299,22 +299,27 @@ struct FileSystem {
       }
 #endif
     } else {
-      const std::function<bool(const ScanDirItemInfo&)> item_handler_recursive =
-          [&item_handler, parameters](const ScanDirItemInfo& item_info) {
-            const ScanDirParameters mask =
-                item_info.is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
-            if (static_cast<int>(parameters) & static_cast<int>(mask)) {
-              if (!item_handler(item_info)) {
-                return false;
-              }
-            }
-            if (item_info.is_directory) {
-              ScanDirUntil<ITEM_HANDLER>(
-                  item_info.pathname, std::forward<ITEM_HANDLER>(item_handler), parameters, ScanDirRecursive::Yes);
-            }
-            return true;
-          };
-      ScanDirUntil(directory, item_handler_recursive, ScanDirParameters::ListFilesAndDirs, ScanDirRecursive::No);
+      // Inner lambdas have distinct types thus creating template instantiation limit,
+      // which is fixed by casting the lambda to its canonical type.
+      ScanDirUntil(
+          directory,
+          static_cast<const std::function<bool(const ScanDirItemInfo&)>>(
+              [&item_handler, parameters](const ScanDirItemInfo& item_info) {
+                const ScanDirParameters mask =
+                    item_info.is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
+                if (static_cast<int>(parameters) & static_cast<int>(mask)) {
+                  if (!item_handler(item_info)) {
+                    return false;
+                  }
+                }
+                if (item_info.is_directory) {
+                  ScanDirUntil<ITEM_HANDLER>(
+                      item_info.pathname, std::forward<ITEM_HANDLER>(item_handler), parameters, ScanDirRecursive::Yes);
+                }
+                return true;
+              }),
+          ScanDirParameters::ListFilesAndDirs,
+          ScanDirRecursive::No);
     }
   }
 

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -215,13 +215,17 @@ struct FileSystem {
   typedef std::ofstream OutputFile;
 
   struct ScanDirItemInfo {
+    std::string dirname;
     std::string basename;
     std::string pathname;
     bool is_directory;
 
     ScanDirItemInfo() = delete;
-    ScanDirItemInfo(std::string basename, std::string pathname, bool is_directory)
-        : basename(std::move(basename)), pathname(std::move(pathname)), is_directory(is_directory) {}
+    ScanDirItemInfo(std::string dirname, std::string basename, std::string pathname, bool is_directory)
+        : dirname(std::move(dirname)),
+          basename(std::move(basename)),
+          pathname(std::move(pathname)),
+          is_directory(is_directory) {}
   };
 
   enum class ScanDirParameters : int { ListFilesOnly = 1, ListDirsOnly = 2, ListFilesAndDirs = 3 };
@@ -256,7 +260,7 @@ struct FileSystem {
             const ScanDirParameters mask =
                 is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
             if (static_cast<int>(parameters) & static_cast<int>(mask)) {
-              if (!item_handler(ScanDirItemInfo(name, JoinPath(directory, name), is_directory))) {
+              if (!item_handler(ScanDirItemInfo(directory, name, JoinPath(directory, name), is_directory))) {
                 return;
               }
             }
@@ -282,7 +286,7 @@ struct FileSystem {
             const ScanDirParameters mask =
                 is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
             if (static_cast<int>(parameters) & static_cast<int>(mask)) {
-              if (!item_handler(ScanDirItemInfo(name, std::move(path), is_directory))) {
+              if (!item_handler(ScanDirItemInfo(directory, name, std::move(path), is_directory))) {
                 return;
               }
             }

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -215,8 +215,8 @@ struct FileSystem {
   typedef std::ofstream OutputFile;
 
   struct ScanDirItemInfo {
-    const std::string& name;
-    const std::string& path;
+    const std::string name;
+    const std::string path;
     const bool is_directory;
 
     ScanDirItemInfo() = delete;

--- a/Bricks/file/test.cc
+++ b/Bricks/file/test.cc
@@ -234,7 +234,7 @@ TEST(File, ScanDir) {
     explicit Scanner(bool return_value) : return_value_(return_value) {}
     Scanner(const Scanner&) = delete;  // Make sure ScanDir()/ScanDirUntil() don't copy the argument.
     bool operator()(const FileSystem::ScanDirItemInfo& item_info) {
-      files_.push_back(std::make_pair(item_info.name, FileSystem::ReadFileAsString(item_info.path)));
+      files_.push_back(std::make_pair(item_info.basename, FileSystem::ReadFileAsString(item_info.pathname)));
       return return_value_;
     }
     const bool return_value_;
@@ -293,50 +293,50 @@ TEST(File, ScanDirParameters) {
 
   {
     std::set<std::string> names;
-    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
+    std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); });
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); });
     EXPECT_EQ("f", current::strings::Join(names, ','));
-    EXPECT_EQ(f, item_infos.at("f").path);
+    EXPECT_EQ(f, item_infos.at("f").pathname);
     EXPECT_EQ(false, item_infos.at("f").is_directory);
   }
 
   {
     std::set<std::string> names;
-    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
+    std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); },
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); },
         FileSystem::ScanDirParameters::ListFilesOnly);
     EXPECT_EQ("f", current::strings::Join(names, ','));
-    EXPECT_EQ(f, item_infos.at("f").path);
+    EXPECT_EQ(f, item_infos.at("f").pathname);
     EXPECT_EQ(false, item_infos.at("f").is_directory);
   }
 
   {
     std::set<std::string> names;
-    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
+    std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); },
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); },
         FileSystem::ScanDirParameters::ListDirsOnly);
     EXPECT_EQ("d", current::strings::Join(names, ','));
-    EXPECT_EQ(d, item_infos.at("d").path);
+    EXPECT_EQ(d, item_infos.at("d").pathname);
     EXPECT_EQ(true, item_infos.at("d").is_directory);
   }
 
   {
     std::set<std::string> names;
-    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
+    std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); },
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); },
         FileSystem::ScanDirParameters::ListFilesAndDirs);
     EXPECT_EQ("d,f", current::strings::Join(names, ','));
-    EXPECT_EQ(d, item_infos.at("d").path);
+    EXPECT_EQ(d, item_infos.at("d").pathname);
     EXPECT_EQ(true, item_infos.at("d").is_directory);
-    EXPECT_EQ(f, item_infos.at("f").path);
+    EXPECT_EQ(f, item_infos.at("f").pathname);
     EXPECT_EQ(false, item_infos.at("f").is_directory);
   }
 }
@@ -367,7 +367,7 @@ TEST(File, ScanDirRecursive) {
     std::set<std::string> names;
     FileSystem::ScanDir(
         base_dir,
-        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); },
+        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
         FileSystem::ScanDirParameters::ListFilesOnly,
         FileSystem::ScanDirRecursive::Yes);
     EXPECT_EQ("base_dir_file,sub_dir_file,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(names, ','));
@@ -377,7 +377,7 @@ TEST(File, ScanDirRecursive) {
     std::set<std::string> names;
     FileSystem::ScanDir(
         base_dir,
-        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); },
+        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
         FileSystem::ScanDirParameters::ListDirsOnly,
         FileSystem::ScanDirRecursive::Yes);
     EXPECT_EQ("sub_dir,sub_sub_dir,sub_sub_dir_2", current::strings::Join(names, ','));
@@ -387,7 +387,7 @@ TEST(File, ScanDirRecursive) {
     std::set<std::string> names;
     FileSystem::ScanDir(
         base_dir,
-        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); },
+        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
         FileSystem::ScanDirParameters::ListFilesAndDirs,
         FileSystem::ScanDirRecursive::Yes);
     EXPECT_EQ("base_dir_file,sub_dir,sub_dir_file,sub_sub_dir,sub_sub_dir_2,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(names, ','));

--- a/Bricks/file/test.cc
+++ b/Bricks/file/test.cc
@@ -292,38 +292,52 @@ TEST(File, ScanDirParameters) {
   FileSystem::MkDir(d, FileSystem::MkDirParameters::Silent);
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
+    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); });
-    EXPECT_EQ("f", current::strings::Join(xs, ','));
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); });
+    EXPECT_EQ("f", current::strings::Join(names, ','));
+    EXPECT_EQ(f, item_infos.at("f").path);
+    EXPECT_EQ(false, item_infos.at("f").is_directory);
   }
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
+    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); },
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); },
         FileSystem::ScanDirParameters::ListFilesOnly);
-    EXPECT_EQ("f", current::strings::Join(xs, ','));
+    EXPECT_EQ("f", current::strings::Join(names, ','));
+    EXPECT_EQ(f, item_infos.at("f").path);
+    EXPECT_EQ(false, item_infos.at("f").is_directory);
   }
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
+    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); },
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); },
         FileSystem::ScanDirParameters::ListDirsOnly);
-    EXPECT_EQ("d", current::strings::Join(xs, ','));
+    EXPECT_EQ("d", current::strings::Join(names, ','));
+    EXPECT_EQ(d, item_infos.at("d").path);
+    EXPECT_EQ(true, item_infos.at("d").is_directory);
   }
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
+    std::map<std::string, const FileSystem::ScanDirItemInfo> item_infos;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); },
+        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); item_infos.insert(std::make_pair(x.name, x)); },
         FileSystem::ScanDirParameters::ListFilesAndDirs);
-    EXPECT_EQ("d,f", current::strings::Join(xs, ','));
+    EXPECT_EQ("d,f", current::strings::Join(names, ','));
+    EXPECT_EQ(d, item_infos.at("d").path);
+    EXPECT_EQ(true, item_infos.at("d").is_directory);
+    EXPECT_EQ(f, item_infos.at("f").path);
+    EXPECT_EQ(false, item_infos.at("f").is_directory);
   }
 }
 
@@ -350,33 +364,33 @@ TEST(File, ScanDirRecursive) {
   FileSystem::WriteStringToFile("sub_sub_dir_file_2", sub_sub_dir_file_2.c_str());
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); },
+        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); },
         FileSystem::ScanDirParameters::ListFilesOnly,
         FileSystem::ScanDirRecursive::Yes);
-    EXPECT_EQ("base_dir_file,sub_dir_file,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(xs, ','));
+    EXPECT_EQ("base_dir_file,sub_dir_file,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(names, ','));
   }
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); },
+        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); },
         FileSystem::ScanDirParameters::ListDirsOnly,
         FileSystem::ScanDirRecursive::Yes);
-    EXPECT_EQ("sub_dir,sub_sub_dir,sub_sub_dir_2", current::strings::Join(xs, ','));
+    EXPECT_EQ("sub_dir,sub_sub_dir,sub_sub_dir_2", current::strings::Join(names, ','));
   }
 
   {
-    std::set<std::string> xs;
+    std::set<std::string> names;
     FileSystem::ScanDir(
         base_dir,
-        [&xs](const FileSystem::ScanDirItemInfo& x) { xs.insert(x.name); },
+        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.name); },
         FileSystem::ScanDirParameters::ListFilesAndDirs,
         FileSystem::ScanDirRecursive::Yes);
-    EXPECT_EQ("base_dir_file,sub_dir,sub_dir_file,sub_sub_dir,sub_sub_dir_2,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(xs, ','));
+    EXPECT_EQ("base_dir_file,sub_dir,sub_dir_file,sub_sub_dir,sub_sub_dir_2,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(names, ','));
   }
 }
 

--- a/Bricks/file/test.cc
+++ b/Bricks/file/test.cc
@@ -301,7 +301,7 @@ TEST(File, ScanDirParameters) {
                         });
     EXPECT_EQ("f", current::strings::Join(names, ','));
     EXPECT_EQ(f, item_infos.at("f").pathname);
-    EXPECT_EQ(false, item_infos.at("f").is_directory);
+    EXPECT_FALSE(item_infos.at("f").is_directory);
   }
 
   {
@@ -315,7 +315,7 @@ TEST(File, ScanDirParameters) {
                         FileSystem::ScanDirParameters::ListFilesOnly);
     EXPECT_EQ("f", current::strings::Join(names, ','));
     EXPECT_EQ(f, item_infos.at("f").pathname);
-    EXPECT_EQ(false, item_infos.at("f").is_directory);
+    EXPECT_FALSE(item_infos.at("f").is_directory);
   }
 
   {
@@ -329,7 +329,7 @@ TEST(File, ScanDirParameters) {
                         FileSystem::ScanDirParameters::ListDirsOnly);
     EXPECT_EQ("d", current::strings::Join(names, ','));
     EXPECT_EQ(d, item_infos.at("d").pathname);
-    EXPECT_EQ(true, item_infos.at("d").is_directory);
+    EXPECT_TRUE(item_infos.at("d").is_directory);
   }
 
   {
@@ -343,9 +343,9 @@ TEST(File, ScanDirParameters) {
                         FileSystem::ScanDirParameters::ListFilesAndDirs);
     EXPECT_EQ("d,f", current::strings::Join(names, ','));
     EXPECT_EQ(d, item_infos.at("d").pathname);
-    EXPECT_EQ(true, item_infos.at("d").is_directory);
+    EXPECT_TRUE(item_infos.at("d").is_directory);
     EXPECT_EQ(f, item_infos.at("f").pathname);
-    EXPECT_EQ(false, item_infos.at("f").is_directory);
+    EXPECT_FALSE(item_infos.at("f").is_directory);
   }
 }
 

--- a/Bricks/file/test.cc
+++ b/Bricks/file/test.cc
@@ -294,9 +294,11 @@ TEST(File, ScanDirParameters) {
   {
     std::set<std::string> names;
     std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); });
+    FileSystem::ScanDir(base_dir,
+                        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) {
+                          names.insert(x.basename);
+                          item_infos.insert(std::make_pair(x.basename, x));
+                        });
     EXPECT_EQ("f", current::strings::Join(names, ','));
     EXPECT_EQ(f, item_infos.at("f").pathname);
     EXPECT_EQ(false, item_infos.at("f").is_directory);
@@ -305,10 +307,12 @@ TEST(File, ScanDirParameters) {
   {
     std::set<std::string> names;
     std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); },
-        FileSystem::ScanDirParameters::ListFilesOnly);
+    FileSystem::ScanDir(base_dir,
+                        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) {
+                          names.insert(x.basename);
+                          item_infos.insert(std::make_pair(x.basename, x));
+                        },
+                        FileSystem::ScanDirParameters::ListFilesOnly);
     EXPECT_EQ("f", current::strings::Join(names, ','));
     EXPECT_EQ(f, item_infos.at("f").pathname);
     EXPECT_EQ(false, item_infos.at("f").is_directory);
@@ -317,10 +321,12 @@ TEST(File, ScanDirParameters) {
   {
     std::set<std::string> names;
     std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); },
-        FileSystem::ScanDirParameters::ListDirsOnly);
+    FileSystem::ScanDir(base_dir,
+                        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) {
+                          names.insert(x.basename);
+                          item_infos.insert(std::make_pair(x.basename, x));
+                        },
+                        FileSystem::ScanDirParameters::ListDirsOnly);
     EXPECT_EQ("d", current::strings::Join(names, ','));
     EXPECT_EQ(d, item_infos.at("d").pathname);
     EXPECT_EQ(true, item_infos.at("d").is_directory);
@@ -329,10 +335,12 @@ TEST(File, ScanDirParameters) {
   {
     std::set<std::string> names;
     std::map<std::string, FileSystem::ScanDirItemInfo> item_infos;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); item_infos.insert(std::make_pair(x.basename, x)); },
-        FileSystem::ScanDirParameters::ListFilesAndDirs);
+    FileSystem::ScanDir(base_dir,
+                        [&names, &item_infos](const FileSystem::ScanDirItemInfo& x) {
+                          names.insert(x.basename);
+                          item_infos.insert(std::make_pair(x.basename, x));
+                        },
+                        FileSystem::ScanDirParameters::ListFilesAndDirs);
     EXPECT_EQ("d,f", current::strings::Join(names, ','));
     EXPECT_EQ(d, item_infos.at("d").pathname);
     EXPECT_EQ(true, item_infos.at("d").is_directory);
@@ -365,32 +373,30 @@ TEST(File, ScanDirRecursive) {
 
   {
     std::set<std::string> names;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
-        FileSystem::ScanDirParameters::ListFilesOnly,
-        FileSystem::ScanDirRecursive::Yes);
+    FileSystem::ScanDir(base_dir,
+                        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
+                        FileSystem::ScanDirParameters::ListFilesOnly,
+                        FileSystem::ScanDirRecursive::Yes);
     EXPECT_EQ("base_dir_file,sub_dir_file,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(names, ','));
   }
 
   {
     std::set<std::string> names;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
-        FileSystem::ScanDirParameters::ListDirsOnly,
-        FileSystem::ScanDirRecursive::Yes);
+    FileSystem::ScanDir(base_dir,
+                        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
+                        FileSystem::ScanDirParameters::ListDirsOnly,
+                        FileSystem::ScanDirRecursive::Yes);
     EXPECT_EQ("sub_dir,sub_sub_dir,sub_sub_dir_2", current::strings::Join(names, ','));
   }
 
   {
     std::set<std::string> names;
-    FileSystem::ScanDir(
-        base_dir,
-        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
-        FileSystem::ScanDirParameters::ListFilesAndDirs,
-        FileSystem::ScanDirRecursive::Yes);
-    EXPECT_EQ("base_dir_file,sub_dir,sub_dir_file,sub_sub_dir,sub_sub_dir_2,sub_sub_dir_file,sub_sub_dir_file_2", current::strings::Join(names, ','));
+    FileSystem::ScanDir(base_dir,
+                        [&names](const FileSystem::ScanDirItemInfo& x) { names.insert(x.basename); },
+                        FileSystem::ScanDirParameters::ListFilesAndDirs,
+                        FileSystem::ScanDirRecursive::Yes);
+    EXPECT_EQ("base_dir_file,sub_dir,sub_dir_file,sub_sub_dir,sub_sub_dir_2,sub_sub_dir_file,sub_sub_dir_file_2",
+              current::strings::Join(names, ','));
   }
 }
 

--- a/Utils/JSONSchema/test.cc
+++ b/Utils/JSONSchema/test.cc
@@ -36,7 +36,8 @@ static std::vector<std::string> ListGoldenFilesWithExtension(const std::string& 
   std::vector<std::string> names;
   const std::string suffix = '.' + ext;
   current::FileSystem::ScanDir(dir,
-                               [&](const std::string& filename) {
+                               [&](const current::FileSystem::ScanDirItemInfo& item_info) {
+                                 const std::string& filename = item_info.name;
                                  if (filename.length() >= suffix.length()) {
                                    const std::string prefix = filename.substr(0, filename.length() - suffix.length());
                                    if (prefix + suffix == filename) {

--- a/Utils/JSONSchema/test.cc
+++ b/Utils/JSONSchema/test.cc
@@ -37,7 +37,7 @@ static std::vector<std::string> ListGoldenFilesWithExtension(const std::string& 
   const std::string suffix = '.' + ext;
   current::FileSystem::ScanDir(dir,
                                [&](const current::FileSystem::ScanDirItemInfo& item_info) {
-                                 const std::string& filename = item_info.name;
+                                 const std::string& filename = item_info.basename;
                                  if (filename.length() >= suffix.length()) {
                                    const std::string prefix = filename.substr(0, filename.length() - suffix.length());
                                    if (prefix + suffix == filename) {


### PR DESCRIPTION
@mzhurovich @grixa @dkorolev 

Please take a look.

The gist: 
- `ScanDirItemInfo` replaces `std::string filename` to pass additional fields to the `ScanDirUntil` and `ScanDir` callbacks.
- `ScanDirUntil` and `ScanDir` takes `ScanDirRecursive::Yes` to scan directories recursively.

Please also suggest how to minimize copying around `ScanDirItemInfo` (the struct itself and its contents: `name` and `path` strings). I believe this may need improvement. _My naive usage of references led to segmentation fault and reads of uninitialized memory within the tests._

Thanks!