### PR TITLE
Fix compilation and tests on Windows

### DIFF
--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -105,9 +105,16 @@ class GenericHTTPClientPOSIX final {
         // It swallows the `SocketWriteException` exception for huge payloads, as Current's HTTP server logic
         // does intentionally close the HTTP connection prematurely if `Content-Length` exceeds a reasonable limit.
         try {
+#ifndef CURRENT_WINDOWS
           connection.BlockingWrite("Content-Length: " + std::to_string(request_body_contents_.length()) + "\r\n", true);
           connection.BlockingWrite("\r\n", true);
           connection.BlockingWrite(request_body_contents_, false);
+#else
+          // TODO(grigoriyn): this fix for the PayloadTooLarge test on Windows is temporary, need to revisit it.
+          connection.BlockingWrite("Content-Length: " + std::to_string(request_body_contents_.length()) + "\r\n\r\n" +
+                                       request_body_contents_,
+                                   false);
+#endif
         } catch (const net::SocketWriteException&) {
           if (request_body_contents_.length() <= net::constants::kMaxHTTPPayloadSizeInBytes) {
             throw;

--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -110,7 +110,7 @@ class GenericHTTPClientPOSIX final {
           connection.BlockingWrite("\r\n", true);
           connection.BlockingWrite(request_body_contents_, false);
 #else
-          // TODO(grigoriyn): this fix for the PayloadTooLarge test on Windows is temporary, need to revisit it.
+          // TODO(grixa): this fix for the PayloadTooLarge test on Windows is temporary, need to revisit it.
           connection.BlockingWrite("Content-Length: " + std::to_string(request_body_contents_.length()) + "\r\n\r\n" +
                                        request_body_contents_,
                                    false);

--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -272,7 +272,7 @@ struct FileSystem {
         do {
           const char* const name = find_data.cFileName;
           if (ScanDirCanHandleName(name)) {
-            const bool is_directory = (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+            const bool is_directory = (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
             const ScanDirParameters mask =
                 is_directory ? ScanDirParameters::ListDirsOnly : ScanDirParameters::ListFilesOnly;
             if (static_cast<int>(parameters) & static_cast<int>(mask)) {

--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -615,7 +615,10 @@ class GenericHTTPServerConnection final : public HTTPResponder {
 
       // Only support STL containers of chars and bytes, this does not yet cover std::string.
       template <typename T>
-      inline ENABLE_IF<sizeof(typename T::value_type) == 1> Send(T&& data) {
+      inline ENABLE_IF<std::is_same<typename T::value_type, char>::value ||
+                       std::is_same<typename T::value_type, uint8_t>::value ||
+                       std::is_same<typename T::value_type, int8_t>::value>
+      Send(T&& data) {
         SendImpl(std::forward<T>(data));
       }
 

--- a/Bricks/net/http/net_http.sln
+++ b/Bricks/net/http/net_http.sln
@@ -8,13 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Debug|Win32.ActiveCfg = Debug|Win32
 		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Debug|Win32.Build.0 = Debug|Win32
+		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Debug|x64.ActiveCfg = Debug|x64
+		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Debug|x64.Build.0 = Debug|x64
 		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Release|Win32.ActiveCfg = Release|Win32
 		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Release|Win32.Build.0 = Release|Win32
+		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Release|x64.ActiveCfg = Release|x64
+		{9FC2310C-944E-4425-869D-7C2A61DC8A55}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TypeSystem/Serialization/json/json.h
+++ b/TypeSystem/Serialization/json/json.h
@@ -248,7 +248,7 @@ class JSONParser final {
     current_ = &document_;
   }
 
-  operator bool() const { return current_; }
+  operator bool() const { return current_ != nullptr; }
   rapidjson::Value& Current() { return *current_; }
   rapidjson::Value* CurrentAsPtr() { return current_; }
 


### PR DESCRIPTION
- Fix the `Bricks/net/http/impl/server.h` compilation on msvc2015
- Fix the HTTPAPI.PayloadTooLarge test.
- Fix a couple of warnings on msvc2015 