### PR TITLE
Support compile time warnings for the `current::strings::Printf`

### DIFF
--- a/Bricks/net/http/impl/server.h
+++ b/Bricks/net/http/impl/server.h
@@ -63,12 +63,12 @@ SOFTWARE.
 #include "../../../strings/printf.h"
 #include "../../../util/singleton.h"
 
-#define CURRENT_BRICKS_LOG_HTTP_EVENT(...) \
-  do { \
-    auto& journal = current::net::HTTPDataJournal(); \
-    if (journal.active) {\
+#define CURRENT_BRICKS_LOG_HTTP_EVENT(...)                             \
+  do {                                                                 \
+    auto& journal = current::net::HTTPDataJournal();                   \
+    if (journal.active) {                                              \
       journal.events.push_back(current::strings::Printf(__VA_ARGS__)); \
-    } \
+    }                                                                  \
   } while (false)
 
 #endif  // CURRENT_BRICKS_DEBUG_HTTP

--- a/Bricks/net/http/test.cc
+++ b/Bricks/net/http/test.cc
@@ -431,20 +431,20 @@ TEST(PosixHTTPServerTest, ChunkedSmoke) {
   };
   std::string body;
   std::string chunk(10, '.');
-  for (size_t i = 0; i < 10000; ++i) {
-    for (size_t j = 0; j < 10; ++j) {
+  for (uint64_t i = 0; i < 10000; ++i) {
+    for (uint64_t j = 0; j < 10; ++j) {
       chunk[j] = 'A' + ((i + j) % 26);
     }
     body += chunk;
   }
-  for (size_t length = body.length(); length > 1500; length -= (length / 7)) {
+  for (uint64_t length = body.length(); length > 1500; length -= (length / 7)) {
     const auto offset = body.length() - length;
-    for (size_t chunks = length; chunks; chunks = chunks * 2 / 3) {
+    for (uint64_t chunks = length; chunks; chunks = chunks * 2 / 3) {
       std::string chunked_body;
       for (uint64_t i = 0; i < chunks; ++i) {
-        const size_t start = offset + static_cast<size_t>(length * i / chunks);
-        const size_t end = offset + static_cast<size_t>(length * (i + 1) / chunks);
-        chunked_body += current::strings::Printf("%lX\r\n", end - start) + body.substr(start, end - start);
+        const uint64_t start = offset + length * i / chunks;
+        const uint64_t end = offset + length * (i + 1) / chunks;
+        chunked_body += current::strings::Printf("%llX\r\n", end - start) + body.substr(start, end - start);
       }
 
       std::thread t(EchoServerThreadEntry, Socket(FLAGS_net_http_test_port));

--- a/Bricks/net/http/test.cc
+++ b/Bricks/net/http/test.cc
@@ -444,7 +444,7 @@ TEST(PosixHTTPServerTest, ChunkedSmoke) {
       for (size_t i = 0; i < chunks; ++i) {
         const size_t start = offset + length * i / chunks;
         const size_t end = offset + length * (i + 1) / chunks;
-        chunked_body += current::strings::Printf("%X\r\n", end - start) + body.substr(start, end - start);
+        chunked_body += current::strings::Printf("%lX\r\n", end - start) + body.substr(start, end - start);
       }
 
       std::thread t(EchoServerThreadEntry, Socket(FLAGS_net_http_test_port));

--- a/Bricks/net/http/test.cc
+++ b/Bricks/net/http/test.cc
@@ -441,9 +441,9 @@ TEST(PosixHTTPServerTest, ChunkedSmoke) {
     const auto offset = body.length() - length;
     for (size_t chunks = length; chunks; chunks = chunks * 2 / 3) {
       std::string chunked_body;
-      for (size_t i = 0; i < chunks; ++i) {
-        const size_t start = offset + length * i / chunks;
-        const size_t end = offset + length * (i + 1) / chunks;
+      for (uint64_t i = 0; i < chunks; ++i) {
+        const size_t start = offset + static_cast<size_t>(length * i / chunks);
+        const size_t end = offset + static_cast<size_t>(length * (i + 1) / chunks);
         chunked_body += current::strings::Printf("%lX\r\n", end - start) + body.substr(start, end - start);
       }
 

--- a/Bricks/strings/printf.h
+++ b/Bricks/strings/printf.h
@@ -33,9 +33,9 @@ SOFTWARE.
 namespace current {
 namespace strings {
 
-#ifndef CURRENT_WINDOWS
-__attribute__((__format__ (__printf__, 1, 2)))
-#endif  // CURRENT_WINDOWS
+#ifdef __GNUC__
+__attribute__((__format__(__printf__, 1, 2)))
+#endif
 inline std::string Printf(const char *fmt, ...) {
   // `Printf()` crops the output to five KiB.
   const int max_formatted_output_length = 5 * 1024;

--- a/Bricks/strings/printf.h
+++ b/Bricks/strings/printf.h
@@ -33,6 +33,9 @@ SOFTWARE.
 namespace current {
 namespace strings {
 
+#ifndef CURRENT_WINDOWS
+__attribute__((__format__ (__printf__, 1, 2)))
+#endif  // CURRENT_WINDOWS
 inline std::string Printf(const char *fmt, ...) {
   // `Printf()` crops the output to five KiB.
   const int max_formatted_output_length = 5 * 1024;


### PR DESCRIPTION
Use `__attribute__(__format__,...)` to enable printf-like warnings.
Unfortunately, there is no an alternative for Windows: msvc2015 has `SAL Annotations` and `_Printf_format_string_` option, but it works only with `/analyze` option (or through `Run Code Analysis on Solution`).