### PR TITLE
ServeStaticFilesFrom with separate route and URL prefixes. URL redirects refactor.

### DIFF
--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -80,7 +80,7 @@ class GenericHTTPClientPOSIX final {
       redirected = false;
       const std::string composed_url = parsed_url.ComposeURL();
       if (all_urls.count(composed_url)) {
-        CURRENT_THROW(current::net::HTTPRedirectLoopException());
+        CURRENT_THROW(current::net::HTTPRedirectLoopException(current::strings::Join(all_urls, ' ') + ' ' + composed_url));
       }
       all_urls.insert(composed_url);
       current::net::Connection connection(

--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -139,7 +139,7 @@ class GenericHTTPClientPOSIX final {
           CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
         }
         redirected = true;
-        parsed_url = URL(http_request_->location, parsed_url);
+        parsed_url.RedirectToURL(http_request_->location);
         response_url_after_redirects_ = parsed_url.ComposeURL();
       }
     } while (redirected);

--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -132,8 +132,12 @@ class GenericHTTPClientPOSIX final {
       // the numerical response code "200" can be accessed with the same method as the "/path".
       const int response_code_as_int = atoi(http_request_->RawPath().c_str());
       response_code_ = HTTPResponseCode(response_code_as_int);
+      // Follow the redirects automatically.
+      // Note: This is by no means a complete redirect implementation.
       if (response_code_as_int >= 300 && response_code_as_int <= 399 && !http_request_->location.empty()) {
-        // Note: This is by no means a complete redirect implementation.
+        if (!allow_redirects_) {
+          CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
+        }
         redirected = true;
         parsed_url = URL(http_request_->location, parsed_url);
         response_url_after_redirects_ = parsed_url.ComposeURL();
@@ -153,6 +157,7 @@ class GenericHTTPClientPOSIX final {
   std::string request_user_agent_ = "";
   current::net::http::Headers request_headers_;
   const typename HTTP_HELPER::ConstructionParams request_data_construction_params_;
+  bool allow_redirects_ = false;
 
   // Output parameters.
   current::net::HTTPResponseCodeValue response_code_ = HTTPResponseCode.InvalidCode;
@@ -171,6 +176,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const HEAD& request, HTTPClientPOSIX& client) {
@@ -178,6 +184,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const POST& request, HTTPClientPOSIX& client) {
@@ -187,6 +194,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const POSTFromFile& request, HTTPClientPOSIX& client) {
@@ -197,6 +205,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_body_contents_ =
         current::FileSystem::ReadFileAsString(request.file_name);  // Can throw FileException.
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const PUT& request, HTTPClientPOSIX& client) {
@@ -206,6 +215,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const PATCH& request, HTTPClientPOSIX& client) {
@@ -215,6 +225,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const DELETE& request, HTTPClientPOSIX& client) {
@@ -222,6 +233,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;  // LCOV_EXCL_LINE  -- tested in GET above.
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const KeepResponseInMemory&, HTTPClientPOSIX&) {}
@@ -231,13 +243,10 @@ struct ImplWrapper<HTTPClientPOSIX> {
   }
 
   template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
-  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+  inline static void ParseOutput(const REQUEST_PARAMS& /*request_params*/,
                                  const RESPONSE_PARAMS& /*response_params*/,
                                  const HTTPClientPOSIX& response,
                                  HTTPResponse& output) {
-    if (!request_params.allow_redirects && request_params.url != response.response_url_after_redirects_) {
-      CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
-    }
     output.url = response.response_url_after_redirects_;
     output.code = response.response_code_;
     const auto& http_request = response.HTTPRequest();

--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -275,11 +275,14 @@ class HTTPServerPOSIX final {
 
           const std::string content_type(current::net::GetFileMimeType(item_info.basename, ""));
           if (!content_type.empty()) {
+            const bool path_components_empty = item_info.path_components_cref.empty();
+            const std::string path_components_joined = current::strings::Join(item_info.path_components_cref, '/');
+
             // `route_for_directory` has no trailing slash.
             const std::string route_for_directory =
                 options.public_route_prefix +
-                ((options.public_route_prefix == "/" || item_info.path_components_cref.empty()) ? "" : "/") +
-                current::strings::Join(item_info.path_components_cref, '/');
+                ((options.public_route_prefix == "/" || path_components_empty) ? "" : "/") +
+                path_components_joined;
 
             // Ignore files nested in directories named with a leading dot (means hidden in POSIX).
             if (route_for_directory.find("/.") != std::string::npos) {
@@ -305,8 +308,9 @@ class HTTPServerPOSIX final {
 
               std::string trailing_slash_redirect_url =
                   options.public_url_prefix +
-                  ((options.public_url_prefix.back() == '/' || item_info.path_components_cref.empty()) ? "" : "/") +
-                  current::strings::Join(item_info.path_components_cref, '/') + '/';
+                  ((options.public_url_prefix.back() == '/' || path_components_empty) ? "" : "/") +
+                  (path_components_empty ? "" : path_components_joined + "/");
+
               auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true, trailing_slash_redirect_url);
               scope += Register(route_for_directory, *static_file_server);
               static_file_servers_.push_back(std::move(static_file_server));

--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -88,12 +88,21 @@ struct ServeStaticFilesFromCannotServeMoreThanOneIndexFile : ServeStaticFilesExc
 };
 
 struct ServeStaticFilesFromOptions {
-  std::string url_base;
+  // HTTP server route prefix.
+  std::string public_route_prefix;
+
+  // User-facing URL prefix. Used to prefix the route in the trailing slash redirects.
+  std::string public_url_prefix;
+
+  // Names of files to serve if a directory URL is requested, in the priority order (first found will be served).
   std::vector<std::string> index_filenames;
 
-  explicit ServeStaticFilesFromOptions(std::string url_base = "/",
-                                       std::vector<std::string> index_filenames = {"index.html", "index.htm"})
-      : url_base(std::move(url_base)), index_filenames(std::move(index_filenames)) {}
+  explicit ServeStaticFilesFromOptions(std::string public_route_prefix_in = "/",
+                                       std::string public_url_prefix_in = "",
+                                       std::vector<std::string> index_filenames_in = {"index.html", "index.htm"})
+    : public_route_prefix(std::move(public_route_prefix_in)),
+      public_url_prefix(public_url_prefix_in.empty() ? public_route_prefix : std::move(public_url_prefix_in)),
+      index_filenames(std::move(index_filenames_in)) {}
 };
 
 // Helper to serve a static file.
@@ -101,20 +110,26 @@ struct ServeStaticFilesFromOptions {
 struct StaticFileServer {
   std::string content;
   std::string content_type;
-  bool url_path_points_to_directory;
-  StaticFileServer(std::string content, std::string content_type, bool url_path_points_to_directory)
+  bool serves_directory;
+  std::string trailing_slash_redirect_url;
+
+  StaticFileServer(std::string content,
+                   std::string content_type,
+                   bool serves_directory,
+                   std::string trailing_slash_redirect_url = "")
       : content(std::move(content)),
         content_type(std::move(content_type)),
-        url_path_points_to_directory(url_path_points_to_directory) {}
+        serves_directory(serves_directory),
+        trailing_slash_redirect_url(trailing_slash_redirect_url) {}
   void operator()(Request r) {
     if (r.method == "GET") {
-      if (url_path_points_to_directory == r.url_path_had_trailing_slash) {
+      if (serves_directory == r.url_path_had_trailing_slash) {
         // 1) Respond with the content if we're serving a directory and have a trailing slash. Example: `/static/`
         // (`static` is a directory, not a file).
         // 2) Respond with the content if we're serving a file and don't have a trailing slash. Example:
         // `/static/index.html`, `/static/file.png`.
         r.connection.SendHTTPResponse(content, HTTPResponseCode.OK, content_type);
-      } else if (!url_path_points_to_directory && r.url_path_had_trailing_slash) {
+      } else if (!serves_directory && r.url_path_had_trailing_slash) {
         // Respond with HTTP 404 Not Found if we're serving a file and have a trailing slash. Example:
         // `/static/index.html/`.
         r.connection.SendHTTPResponse(current::net::DefaultNotFoundMessage(),
@@ -126,7 +141,7 @@ struct StaticFileServer {
         // URL for the index file served at that directory URL (without filename).
         // See RFC1808, `Resolving Relative URLs`, `Step 6`: https://www.ietf.org/rfc/rfc1808.txt
         r.connection.SendHTTPResponse(
-            "", HTTPResponseCode.Found, content_type, current::net::http::Headers({{"Location", r.url.path + '/'}}));
+            "", HTTPResponseCode.Found, content_type, current::net::http::Headers({{"Location", trailing_slash_redirect_url}}));
       }
     } else {
       r.connection.SendHTTPResponse(current::net::DefaultMethodNotAllowedMessage(),
@@ -247,7 +262,7 @@ class HTTPServerPOSIX final {
 
   HTTPRoutesScope ServeStaticFilesFrom(const std::string& dir,
                                        const ServeStaticFilesFromOptions& options = ServeStaticFilesFromOptions()) {
-    ValidateURLPath(options.url_base);
+    ValidateRoute(options.public_route_prefix);
 
     HTTPRoutesScope scope;
     current::FileSystem::ScanDir(
@@ -260,19 +275,20 @@ class HTTPServerPOSIX final {
 
           const std::string content_type(current::net::GetFileMimeType(item_info.basename, ""));
           if (!content_type.empty()) {
-            // `url_dirname` has no trailing slash.
-            const std::string url_dirname =
-                options.url_base + ((options.url_base == "/" || item_info.path_components_cref.empty()) ? "" : "/") +
+            // `route_for_directory` has no trailing slash.
+            const std::string route_for_directory =
+                options.public_route_prefix +
+                ((options.public_route_prefix == "/" || item_info.path_components_cref.empty()) ? "" : "/") +
                 current::strings::Join(item_info.path_components_cref, '/');
 
             // Ignore files nested in directories named with a leading dot (means hidden in POSIX).
-            if (url_dirname.find("/.") != std::string::npos) {
+            if (route_for_directory.find("/.") != std::string::npos) {
               return;
             }
 
-            const std::string url_pathname = url_dirname + (url_dirname == "/" ? "" : "/") + item_info.basename;
+            const std::string route_for_file = route_for_directory + (route_for_directory == "/" ? "" : "/") + item_info.basename;
 
-            const bool is_index =
+            const bool is_index_file =
                 (std::find(options.index_filenames.begin(), options.index_filenames.end(), item_info.basename) !=
                  options.index_filenames.end());
 
@@ -280,20 +296,24 @@ class HTTPServerPOSIX final {
             // that keeps a map from a (SHA256) hash to the contents.
             std::string content = current::FileSystem::ReadFileAsString(item_info.pathname);
 
-            // If it's an index file, serve it at the route without filename, too.
-            if (is_index) {
-              if (handlers_.find(url_dirname) != handlers_.end()) {
+            // If it's an index file, serve it additionally at the route without the filename (i.e. the directory route).
+            if (is_index_file) {
+              if (handlers_.find(route_for_directory) != handlers_.end()) {
                 CURRENT_THROW(
-                    ServeStaticFilesFromCannotServeMoreThanOneIndexFile(url_dirname + ' ' + item_info.basename));
+                    ServeStaticFilesFromCannotServeMoreThanOneIndexFile(route_for_directory + ' ' + item_info.basename));
               }
 
-              auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true);
-              scope += Register(url_dirname, *static_file_server);
+              std::string trailing_slash_redirect_url =
+                  options.public_url_prefix +
+                  ((options.public_url_prefix.back() == '/' || item_info.path_components_cref.empty()) ? "" : "/") +
+                  current::strings::Join(item_info.path_components_cref, '/') + '/';
+              auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true, trailing_slash_redirect_url);
+              scope += Register(route_for_directory, *static_file_server);
               static_file_servers_.push_back(std::move(static_file_server));
             }
 
             auto static_file_server = std::make_unique<StaticFileServer>(std::move(content), content_type, false);
-            scope += Register(url_pathname, *static_file_server);
+            scope += Register(route_for_file, *static_file_server);
             static_file_servers_.push_back(std::move(static_file_server));
           } else {
             CURRENT_THROW(ServeStaticFilesFromCanNotServeStaticFilesOfUnknownMIMEType(item_info.basename));
@@ -422,7 +442,7 @@ class HTTPServerPOSIX final {
     }
   }
 
-  void ValidateURLPath(const std::string& path) {
+  void ValidateRoute(const std::string& path) {
     if (path.empty() || path[0] != '/') {
       CURRENT_THROW(PathDoesNotStartWithSlash("HTTP URL path does not start with a slash: `" + path + "`."));
     }
@@ -444,7 +464,7 @@ class HTTPServerPOSIX final {
     }
     // LCOV_EXCL_STOP
 
-    ValidateURLPath(path);
+    ValidateRoute(path);
 
     {
       // Step 1: Confirm the request is valid.

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -76,6 +76,11 @@ DEFINE_int32(net_api_test_port,
              "Local port to use for the test API-based HTTP server. NOTE: This port should be different from "
              "ports in other network-based tests, since API-driven HTTP server will hold it open for the whole "
              "lifetime of the binary.");
+DEFINE_int32(net_api_test_port_secondary,
+             PickPortForUnitTest(),
+             "Local port to use for the test API-based HTTP server for multi-port tests. NOTE: This port should be different from "
+             "ports in other network-based tests, since API-driven HTTP server will hold it open for the whole "
+             "lifetime of the binary.");
 DEFINE_string(net_api_test_tmpdir, ".current", "Local path for the test to create temporary files in.");
 
 CURRENT_STRUCT(HTTPAPITestObject) {
@@ -358,25 +363,24 @@ TEST(HTTPAPI, RedirectToRelativeURL) {
 }
 
 TEST(HTTPAPI, RedirectToFullURL) {
-  // TODO(sompylasar): Cannot test redirect to a different port because the HTTP client
-  // is following the redirect and tries to connect to the redirect target,
-  // and we do not have a second port to occupy for the tests.
+  // Need a live port for the redirect target because the HTTP client is following the redirect
+  // and tries to connect to the redirect target, otherwise throws a `SocketConnectException`.
+  const auto scope_redirect_to = HTTP(FLAGS_net_api_test_port_secondary).Register("/to", [](Request r) { r("Done."); });
   const auto scope = HTTP(FLAGS_net_api_test_port)
                          .Register("/from",
                                    [](Request r) {
                                      r("",
                                        HTTPResponseCode.Found,
                                        current::net::constants::kDefaultHTMLContentType,
-                                       Headers({{"Location", Printf("http://localhost:%d/to", FLAGS_net_api_test_port)}}));
-                                   }) +
-                     HTTP(FLAGS_net_api_test_port).Register("/to", [](Request r) { r("Done."); });
+                                       Headers({{"Location", Printf("http://localhost:%d/to", FLAGS_net_api_test_port_secondary)}}));
+                                   });
   // Redirect not allowed by default.
   ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/from", FLAGS_net_api_test_port))), HTTPRedirectNotAllowedException);
   // Redirect allowed when `.AllowRedirects()` is set.
   const auto response = HTTP(GET(Printf("http://localhost:%d/from", FLAGS_net_api_test_port)).AllowRedirects());
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_EQ("Done.", response.body);
-  EXPECT_EQ(Printf("http://localhost:%d/to", FLAGS_net_api_test_port), response.url);
+  EXPECT_EQ(Printf("http://localhost:%d/to", FLAGS_net_api_test_port_secondary), response.url);
 }
 
 TEST(HTTPAPI, RedirectLoop) {

--- a/Blocks/URL/test.cc
+++ b/Blocks/URL/test.cc
@@ -34,165 +34,430 @@ using namespace current::url;
 TEST(URLTest, SmokeTest) {
   URL u;
 
+  // For URLs where no scheme or port is specified in the original string, no scheme or port is stored.
+
+  // WARNING: Browser implementation differs: `www.google.com` is pathname.
   u = URL("www.google.com");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `www.google.com/test` is pathname.
   u = URL("www.google.com/test");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/test", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/test", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `443/test` is pathname.
+  u = URL("www.google.com:443");
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(443, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("https://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `8080/test` is pathname.
   u = URL("www.google.com:8080");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("", u.scheme);  // Since there is no rule for port "8080", no scheme is returned.
+  EXPECT_EQ("", u.scheme);
   EXPECT_EQ(8080, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  // Unknown port `8080` falls back to default scheme in `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:8080/", u.ComposeURL());
 
   u = URL("meh://www.google.com:27960");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
   EXPECT_EQ("meh", u.scheme);
   EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/", u.ComposeURL());
 
   u = URL("meh://www.google.com:27960/bazinga");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/bazinga", u.path);
   EXPECT_EQ("meh", u.scheme);
   EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/bazinga", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `localhost/` is pathname.
   u = URL("localhost/");
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
 
-  u = URL("localhost:/");
-  EXPECT_EQ("localhost", u.host);
-  EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
-
+  // WARNING: Browser implementation differs: `localhost/test` is pathname.
   u = URL("localhost/test");
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/test", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
   u = URL("localhost:/test");
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/test", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `:1234/test` is assumed pathname.
+  u = URL(":1234/test");
+  EXPECT_EQ("", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(1234, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  // NOTE: `ComposeURL` ignores the `port` if `host` is empty.
+  EXPECT_EQ("/test", u.ComposeURL());
 
   u = URL("/test");
   EXPECT_EQ("", u.host);
   EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("/test", u.ComposeURL());
+
+  // Can parse a protocol-relative URL: `//host.name:80/path`.
+  u = URL("//host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  // NOTE: `ComposeURL` does not add the leading two slashes if scheme is empty.
+  EXPECT_EQ("http://host.name/path", u.ComposeURL());
+
+  // Can parse a username-password pair: `http://user1:pass345@host.name:80/path`.
+  u = URL("http://user1:pass345@host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("user1", u.username);
+  EXPECT_EQ("pass345", u.password);
+  EXPECT_EQ("http://user1:pass345@host.name/path", u.ComposeURL());
+
+  // Can parse a username alone: `http://user1@host.name:80/path`.
+  u = URL("http://user1@host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("user1", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://user1@host.name/path", u.ComposeURL());
 }
 
-TEST(URLTest, CompositionTest) {
+TEST(URLTest, FillWithDefaultsTest) {
+  URL u;
+
+  // For URLs where no scheme or port is specified in the original string, no scheme or port is stored.
+
+  // WARNING: Browser implementation differs: `www.google.com` is pathname.
+  u = URL("www.google.com").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com/test` is pathname.
+  u = URL("www.google.com/test").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `443/test` is pathname.
+  u = URL("www.google.com:443").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("https", u.scheme);
+  EXPECT_EQ(443, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("https://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `8080/test` is pathname.
+  u = URL("www.google.com:8080").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);  // Unknown port `8080` falls back to default scheme in `FillWithDefaults`.
+  EXPECT_EQ(8080, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com:8080/", u.ComposeURL());
+
+  u = URL("meh://www.google.com:27960").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("meh", u.scheme);
+  EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/", u.ComposeURL());
+
+  u = URL("meh://www.google.com:27960/bazinga").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/bazinga", u.path);
+  EXPECT_EQ("meh", u.scheme);
+  EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/bazinga", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost/` is pathname.
+  u = URL("localhost/").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost/test` is pathname.
+  u = URL("localhost/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+
+  u = URL("/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `:1234/test` is assumed pathname.
+  u = URL(":1234/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);  // Unknown port `1234` falls back to default scheme in `FillWithDefaults`.
+  EXPECT_EQ(1234, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost:1234/test", u.ComposeURL());
+
+  u = URL("/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  u = URL("//hostname/path").FillWithDefaults();
+  EXPECT_EQ("hostname", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://hostname/path", u.ComposeURL());
+}
+
+TEST(URLTest, ComposeURLTest) {
   EXPECT_EQ("http://www.google.com/", URL("www.google.com").ComposeURL());
   EXPECT_EQ("http://www.google.com/", URL("http://www.google.com").ComposeURL());
   EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
   EXPECT_EQ("http://www.google.com/", URL("http://www.google.com").ComposeURL());
   EXPECT_EQ("http://www.google.com/", URL("http://www.google.com:80").ComposeURL());
-  EXPECT_EQ("www.google.com:8080/", URL("www.google.com:8080").ComposeURL());  // Since there is no rule for port "8080", no scheme is returned.
+  // Since there is no scheme and no rule for port "8080", default scheme is used by `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:8080/", URL("www.google.com:8080").ComposeURL());
   EXPECT_EQ("http://www.google.com:8080/", URL("http://www.google.com:8080").ComposeURL());
   EXPECT_EQ("meh://www.google.com:8080/", URL("meh://www.google.com:8080").ComposeURL());
 }
 
-TEST(URLTest, DerivesSchemeFromPort) {
-  // Smoke tests for non-default scheme, setting the 2nd parameter to the URL() constructor.
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com", "").ComposeURL());
-  EXPECT_EQ("telnet://www.google.com/", URL("www.google.com", "telnet").ComposeURL());
-  EXPECT_EQ("telnet://www.google.com:23/", URL("www.google.com:23", "telnet").ComposeURL());
+TEST(URLTest, ComposeURLDerivesSchemeFromPort) {
+  // Maps port 80 into "http://".
+  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
+
+  // Maps port 443 into "https://".
+  EXPECT_EQ("https://www.google.com/", URL("www.google.com:443").ComposeURL());
+
+  // Since there is no scheme and no rule for port "23", default scheme is used by `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:23/", URL("www.google.com:23").ComposeURL());
+
   // Keeps the scheme if it was explicitly specified, even for the port that maps to a different scheme.
   EXPECT_EQ("foo://www.google.com/", URL("foo://www.google.com").ComposeURL());
   EXPECT_EQ("foo://www.google.com:80/", URL("foo://www.google.com:80").ComposeURL());
-  // Maps port 80 into "http://".
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80", "").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80", "", "", 80).ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com", "", "", 80).ComposeURL());
-  // Maps port 443 into "https://".
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com:443").ComposeURL());
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com:443", "").ComposeURL());
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com:443", "", "", 443).ComposeURL());
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com", "", "", 443).ComposeURL());
+  EXPECT_EQ("http://www.google.com:443/", URL("http://www.google.com:443").ComposeURL());
+
   // Assumes port 80 for "http://".
   EXPECT_EQ("http://www.google.com:79/", URL("http://www.google.com:79").ComposeURL());
   EXPECT_EQ("http://www.google.com/", URL("http://www.google.com:80").ComposeURL());
   EXPECT_EQ("http://www.google.com:81/", URL("http://www.google.com:81").ComposeURL());
+
   // Assumes port 443 for "https://".
   EXPECT_EQ("https://www.google.com:442/", URL("https://www.google.com:442").ComposeURL());
   EXPECT_EQ("https://www.google.com/", URL("https://www.google.com:443").ComposeURL());
   EXPECT_EQ("https://www.google.com:444/", URL("https://www.google.com:444").ComposeURL());
-  // Since there is no rule for port "23", no scheme is returned.
-  EXPECT_EQ("www.google.com:23/", URL("www.google.com:23").ComposeURL());
 }
 
-TEST(URLTest, RedirectPreservesSchemeHostAndPortTest) {
+TEST(URLTest, RedirectToURLTest) {
   // Relative URL preserves scheme, host, port.
-  EXPECT_EQ("http://localhost/foo", URL("/foo", URL("localhost")).ComposeURL());
-  EXPECT_EQ("meh://localhost/foo", URL("/foo", URL("meh://localhost")).ComposeURL());
-  // Since there is no rule for port "8080", and no previous scheme, no scheme is returned.
-  EXPECT_EQ("localhost:8080/empty_all_with_previous_empty_scheme", URL("/empty_all_with_previous_empty_scheme", URL("localhost:8080")).ComposeURL());
-  EXPECT_EQ("meh://localhost:8080/empty_all_with_previous_all", URL("/empty_all_with_previous_all", URL("meh://localhost:8080")).ComposeURL());
+  EXPECT_EQ("http://localhost/foo", URL("localhost").RedirectToURL("/foo").ComposeURL());
+  EXPECT_EQ("meh://localhost/foo", URL("meh://localhost").RedirectToURL("/foo").ComposeURL());
+  EXPECT_EQ("http://localhost:8080/empty_all_with_previous_empty_scheme",
+            URL("localhost:8080").RedirectToURL("/empty_all_with_previous_empty_scheme").ComposeURL());
+  EXPECT_EQ("meh://localhost:8080/empty_all_with_previous_all",
+            URL("meh://localhost:8080").RedirectToURL("/empty_all_with_previous_all").ComposeURL());
 
   // Port-only full URL replaces port and preserves host from previous URL.
-  EXPECT_EQ("meh://localhost:27960/empty_scheme_host", URL(":27960/empty_scheme_host", URL("meh://localhost:8080")).ComposeURL());
+  EXPECT_EQ("meh://localhost:27960/empty_scheme_host",
+            URL("meh://localhost:8080").RedirectToURL(":27960/empty_scheme_host").ComposeURL());
 
   // Schema-only full URL preserves host and port from previous URL.
-  EXPECT_EQ("ftp://localhost:8080/empty_host", URL("ftp:///empty_host", URL("meh://localhost:8080")).ComposeURL());
+  EXPECT_EQ("ftp://localhost:8080/empty_host",
+            URL("meh://localhost:8080").RedirectToURL("ftp:///empty_host").ComposeURL());
 
   // Full URL replaces scheme, host, port, does not preserve anything from previous URL.
-  EXPECT_EQ("ftp://host_no_port_path/", URL("ftp://host_no_port_path", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("blah://new_host/foo", URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL());
-  EXPECT_EQ("blah://new_host:6000/foo", URL("blah://new_host:6000/foo", URL("meh://localhost:5000")).ComposeURL());
+  EXPECT_EQ("ftp://host_no_port_path/",
+            URL("meh://localhost:8080").RedirectToURL("ftp://host_no_port_path").ComposeURL());
+  EXPECT_EQ("blah://new_host/foo", URL("meh://localhost:5000").RedirectToURL("blah://new_host/foo").ComposeURL());
+  EXPECT_EQ("blah://new_host:6000/foo",
+            URL("meh://localhost:5000").RedirectToURL("blah://new_host:6000/foo").ComposeURL());
+
+  // The username-password pair is always taken from the next URL.
+  EXPECT_EQ("http://user1:pass345@new_host/foo",
+            URL("meh://a:b@localhost:5000").RedirectToURL("http://user1:pass345@new_host/foo").ComposeURL());
 }
 
-TEST(URLTest, ExtractsURLParameters) {
+TEST(URLTest, RedirectToURLWithParametersTest) {
+  const auto redirected_url_parsed = URL("localhost/?replace=this&and=this").RedirectToURL("/foo?bar=baz&qoo=xdoo");
+  EXPECT_EQ("http://localhost/foo?bar=baz&qoo=xdoo", redirected_url_parsed.ComposeURL());
+  EXPECT_EQ("http://localhost/foo", redirected_url_parsed.ComposeURLWithoutParameters());
+
+  EXPECT_EQ(
+      "http://localhost:1234/foo?bar=baz&qoo=xdoo#with-fragment",
+      URL("localhost:1234/?replace=this&and=this").RedirectToURL("/foo?bar=baz&qoo=xdoo#with-fragment").ComposeURL());
+
+  const auto redirected_to_full_url_parsed =
+      URL("localhost/?replace=this&and=this").RedirectToURL("http://other.domain/foo?bar=baz&qoo=xdoo");
+  EXPECT_EQ("http://other.domain/foo?bar=baz&qoo=xdoo", redirected_to_full_url_parsed.ComposeURL());
+  EXPECT_EQ("http://other.domain/foo", redirected_to_full_url_parsed.ComposeURLWithoutParameters());
+}
+
+TEST(URLTest, ExtractURLParametersAndComposeURLTest) {
   {
     URL u("www.google.com");
     EXPECT_EQ("", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/", u.ComposeURLWithoutParameters());
   }
   {
-    URL u("www.google.com/a#fragment");
-    EXPECT_EQ("fragment", u.fragment);
+    // Fragment is not passed through `DecodeURIComponent`.
+    URL u("www.google.com/a#encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space");
+    EXPECT_EQ("encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
-    EXPECT_EQ("http://www.google.com/a#fragment", u.ComposeURL());
+    EXPECT_EQ(
+        "http://www.google.com/a#encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space",
+        u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/a#fragment?foo=bar&baz=meh");
     EXPECT_EQ("fragment?foo=bar&baz=meh", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/a#fragment?foo=bar&baz=meh", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/b#fragment#foo");
     EXPECT_EQ("fragment#foo", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/b#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/b", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?key=value&key2=value2#fragment#foo");
     EXPECT_EQ("fragment#foo", u.fragment);
+    EXPECT_TRUE(u.query.has("key"));
     EXPECT_EQ("value", u.query["key"]);
     EXPECT_EQ("value", u.query.get("key", "default_value"));
+    EXPECT_TRUE(u.query.has("key2"));
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("http://www.google.com/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
     const auto& as_map = u.AllQueryParameters();
     EXPECT_EQ(2u, as_map.size());
     const auto key = as_map.find("key");
@@ -205,10 +470,22 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("value2", key2->second);
   }
   {
+    URL u("www.google.com/a?encoded%23query=-with_unreserved~chars!and%25reserved%3A%5Bchars%5Dplus%2Band%20space#foo");
+    EXPECT_EQ("foo", u.fragment);
+    EXPECT_TRUE(u.query.has("encoded#query"));
+    EXPECT_EQ("-with_unreserved~chars!and%reserved:[chars]plus+and space", u.query["encoded#query"]);
+    EXPECT_EQ(
+        "http://www.google.com/"
+        "a?encoded%23query=-with_unreserved~chars!and%25reserved%3A%5Bchars%5Dplus%2Band%20space#foo",
+        u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
+  }
+  {
     URL u("www.google.com/a?k=a%3Db%26s%3D%25s%23#foo");
     EXPECT_EQ("foo", u.fragment);
     EXPECT_EQ("a=b&s=%s#", u.query["k"]);
     EXPECT_EQ("http://www.google.com/a?k=a%3Db%26s%3D%25s%23#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("/q?key=value&key2=value2#fragment#foo");
@@ -218,12 +495,14 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("/a?k=a%3Db%26s%3D%25s%23#foo");
     EXPECT_EQ("foo", u.fragment);
     EXPECT_EQ("a=b&s=%s#", u.query["k"]);
     EXPECT_EQ("/a?k=a%3Db%26s%3D%25s%23#foo", u.ComposeURL());
+    EXPECT_EQ("/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?foo=&bar&baz=");
@@ -235,6 +514,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("", u.query["baz"]);
     EXPECT_EQ("", u.query.get("baz", "default_value"));
     EXPECT_EQ("http://www.google.com/q?foo=&bar=&baz=", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?foo=bar=baz");
@@ -242,6 +522,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("bar=baz", u.query["foo"]);
     EXPECT_EQ("bar=baz", u.query.get("foo", "default_value"));
     EXPECT_EQ("http://www.google.com/q?foo=bar%3Dbaz", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q? foo = bar = baz ");
@@ -249,6 +530,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ(" bar = baz ", u.query[" foo "]);
     EXPECT_EQ(" bar = baz ", u.query.get(" foo ", "default_value"));
     EXPECT_EQ("http://www.google.com/q?%20foo%20=%20bar%20%3D%20baz%20", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?1=foo");
@@ -256,6 +538,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("foo", u.query["1"]);
     EXPECT_EQ("foo", u.query.get("1", "default_value"));
     EXPECT_EQ("http://www.google.com/q?1=foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?question=forty+two");
@@ -263,6 +546,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("forty two", u.query["question"]);
     EXPECT_EQ("forty two", u.query.get("question", "default_value"));
     EXPECT_EQ("http://www.google.com/q?question=forty%20two", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?%3D+%3D=%3D%3D");
@@ -270,16 +554,24 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("==", u.query["= ="]);
     EXPECT_EQ("==", u.query.get("= =", "default_value"));
     EXPECT_EQ("http://www.google.com/q?%3D%20%3D=%3D%3D", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
-}
-
-TEST(URLTest, URLParametersCompositionTest) {
-  EXPECT_EQ("http://www.google.com/search", URL("www.google.com/search").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo#fragment", URL("www.google.com/search?q=foo#fragment").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar", URL("www.google.com/search?q=foo&q2=bar").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar#fragment",
-            URL("www.google.com/search?q=foo&q2=bar#fragment").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search#fragment", URL("www.google.com/search#fragment").ComposeURL());
+  {
+    ASSERT_THROW(URL("?parameters=only"), EmptyURLException);
+    ASSERT_THROW(URL("#fragment-only"), EmptyURLException);
+  }
+  {
+    // The following construct can be used to parse the `application/x-www-form-urlencoded` request body.
+    URL u("/?parameters=only");
+    EXPECT_EQ("", u.scheme);
+    EXPECT_EQ("", u.host);
+    EXPECT_EQ(0, u.port);
+    EXPECT_EQ("/", u.path);
+    EXPECT_EQ("", u.fragment);
+    EXPECT_EQ("only", u.query["parameters"]);
+    EXPECT_EQ("/?parameters=only", u.ComposeURL());
+    EXPECT_EQ("/", u.ComposeURLWithoutParameters());
+  }
 }
 
 TEST(URLTest, EmptyURLException) {
@@ -287,7 +579,16 @@ TEST(URLTest, EmptyURLException) {
   ASSERT_THROW(URL(""), EmptyURLException);
 
   // Empty host is allowed in relative links.
-  EXPECT_EQ("foo://www.website.com:321/second", URL("/second", URL("foo://www.website.com:321/first")).ComposeURL());
+  EXPECT_EQ("/second", URL("/second").ComposeURL());
+  // When redirected, the redirect path overrides the original path.
+  EXPECT_EQ("foo://www.website.com:321/second",
+            URL("foo://www.website.com:321/first").RedirectToURL("/second").ComposeURL());
+
+  // With empty host, port is ignored.
+  EXPECT_EQ("/second", URL(":1234/second").ComposeURL());
+  // When redirected, the redirect port and path overrides the original port and path.
+  EXPECT_EQ("foo://www.website.com:1234/second",
+            URL("foo://www.website.com:321/first").RedirectToURL(":1234/second").ComposeURL());
 }
 
 namespace url_test {

--- a/Blocks/URL/url.h
+++ b/Blocks/URL/url.h
@@ -70,6 +70,7 @@ namespace impl {
 
 namespace {
 const char* const kDefaultScheme = "http";
+const char* const kDefaultHost = "localhost";
 }
 
 struct URLWithoutParametersParser {
@@ -77,76 +78,82 @@ struct URLWithoutParametersParser {
   mutable std::string path = "/";
   std::string scheme = kDefaultScheme;
   uint16_t port = 0;
+  std::string username = "";
+  std::string password = "";
 
+ protected:
   URLWithoutParametersParser() = default;
 
-  // Extra parameters for previous host and port are provided in the constructor to handle redirects.
-  URLWithoutParametersParser(const std::string& url,
-                             const std::string& previous_scheme = "",
-                             const std::string& previous_host = "",
-                             const uint16_t previous_port = 0) {
+  void ParseURLWithoutParameters(const std::string& url) {
     if (url.empty()) {
       CURRENT_THROW(EmptyURLException());
     }
+
+    // Can parse a full URL: `scheme://host.name:80/path`, `scheme://host.name/path`.
+    // Can parse a protocol-relative URL: `//host.name:80/path`, `//host.name/path`.
+    // Can parse a username-password pair: `http://user:pass@host.name/`.
+    // Can parse a username only: `http://user@host.name/`.
+    // Can parse a port-only URL: `:12345/path`.
+    // Can parse a relative URL: `/path/anything`.
+    // Query string and fragment identifier are parsed separately in `URLParametersExtractor`.
+
     scheme = "";
-    size_t offset_past_scheme = 0;
-    const size_t colon_double_slash = url.find("://");
-    if (colon_double_slash != std::string::npos) {
-      scheme = url.substr(0, colon_double_slash);
-      offset_past_scheme = colon_double_slash + 3;
+    size_t parsed_offset = 0;
+    const size_t double_slash = url.find("//");
+    if (double_slash != std::string::npos && (double_slash == 0 || url[double_slash - 1] == ':')) {
+      scheme = (double_slash == 0 ? "" : url.substr(0, double_slash - 1));
+      parsed_offset = double_slash + 2;
     }
 
-    // TODO(dkorolev): Support `http://user:pass@host:80/` in the future.
-    const size_t colon = url.find(':', offset_past_scheme);
-    const size_t slash = url.find('/', offset_past_scheme);
-    host = url.substr(offset_past_scheme, std::min(colon, slash) - offset_past_scheme);
-    if (host.empty()) {
-      host = previous_host;
-      port = previous_port;
+    const size_t host_end = url.find('/', parsed_offset);
+    const size_t at_sign = url.find('@', parsed_offset);
+    if (at_sign != std::string::npos && at_sign < host_end) {
+      const size_t user_pass_colon = url.find(':', parsed_offset);
+      if (user_pass_colon != std::string::npos && user_pass_colon < at_sign) {
+        username = url.substr(parsed_offset, user_pass_colon - parsed_offset);
+        password = url.substr(user_pass_colon + 1, at_sign - (user_pass_colon + 1));
+      } else {
+        username = url.substr(parsed_offset, at_sign - parsed_offset);
+      }
+      parsed_offset = at_sign + 1;
     }
 
-    if (colon != std::string::npos && colon < slash) {
-      port = static_cast<uint16_t>(atoi(url.c_str() + colon + 1));
+    const size_t port_colon = url.find(':', parsed_offset);
+    if (port_colon != std::string::npos && port_colon < host_end) {
+      host = url.substr(parsed_offset, port_colon - parsed_offset);
+      port = static_cast<uint16_t>(atoi(url.c_str() + port_colon + 1));
+    } else {
+      host = url.substr(parsed_offset, host_end - parsed_offset);
     }
 
-    if (slash != std::string::npos) {
-      path = url.substr(slash);
+    if (host_end != std::string::npos) {
+      path = url.substr(host_end);
     } else {
       path = "";
     }
     if (path.empty()) {
       path = "/";
     }
-
-    if (colon_double_slash == std::string::npos) {
-      if (!previous_scheme.empty()) {
-        scheme = previous_scheme;
-      } else if (port > 0) {
-        scheme = DefaultSchemeForPort(port);
-      } else if (previous_port > 0) {
-        scheme = DefaultSchemeForPort(previous_port);
-      } else {
-        scheme = kDefaultScheme;
-      }
-    }
-
-    if (port == 0) {
-      port = DefaultPortForScheme(scheme);
-    }
   }
-
-  URLWithoutParametersParser(const std::string& url, const URLWithoutParametersParser& previous)
-      : URLWithoutParametersParser(url, previous.scheme, previous.host, previous.port) {}
 
   std::string ComposeURL() const {
     if (!host.empty()) {
+      const std::string scheme_for_compose =
+          (!scheme.empty() ? scheme : (port > 0 ? DefaultSchemeForPort(port) : kDefaultScheme));
+      const uint16_t port_for_compose = (port > 0 && port != DefaultPortForScheme(scheme_for_compose) ? port : 0);
+
       std::ostringstream os;
-      if (!scheme.empty()) {
-        os << scheme << "://";
+      os << (!scheme_for_compose.empty() ? scheme_for_compose : kDefaultScheme) << "://";
+      if (!username.empty()) {
+        os << username;
+        if (!password.empty()) {
+          os << ':' << password;
+        }
+        os << '@';
       }
       os << host;
-      if (port > 0 && port != DefaultPortForScheme(scheme)) {
-        os << ':' << port;
+      if (port_for_compose > 0) {
+        os << ':' << port_for_compose;
       }
       os << path;
       return os.str();
@@ -156,6 +163,7 @@ struct URLWithoutParametersParser {
     }
   }
 
+ public:
   static int DefaultPortForScheme(const std::string& scheme) {
     // We don't really "support" other schemes yet -- D.K.
     if (scheme == "http") {
@@ -179,17 +187,20 @@ struct URLWithoutParametersParser {
 };
 
 struct URLParametersExtractor {
+ protected:
   URLParametersExtractor() = default;
-  URLParametersExtractor(std::string url) {
+
+  void ExtractURLParametersFromURL(std::string url, size_t& parameters_start_index) {
+    parameters_start_index = url.length();
     const size_t pound_sign_index = url.find('#');
     if (pound_sign_index != std::string::npos) {
       fragment = url.substr(pound_sign_index + 1);
-      url = url.substr(0, pound_sign_index);
+      parameters_start_index = pound_sign_index;
     }
     const size_t question_mark_index = url.find('?');
-    if (question_mark_index != std::string::npos) {
+    if (question_mark_index != std::string::npos && question_mark_index < pound_sign_index) {
       auto& v = parameters_vector;
-      current::strings::Split(url.substr(question_mark_index + 1),
+      current::strings::Split(url.substr(question_mark_index + 1, parameters_start_index - (question_mark_index + 1)),
                               '&',
                               [&v](const std::string& chunk) {
                                 const size_t i = chunk.find('=');
@@ -204,38 +215,51 @@ struct URLParametersExtractor {
         it.second = DecodeURIComponent(it.second);
       }
       query = QueryParameters(parameters_vector);
-      url = url.substr(0, question_mark_index);
+      parameters_start_index = question_mark_index;
     }
-    url_without_parameters = url;
   }
 
+ public:
   static bool IsHexDigit(char c) { return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'); }
 
+  static bool IsURIComponentSpecialCharacter(char c) {
+    // https://github.com/lyokato/cpp-urilite/blob/723083f98ddf42f2b610b62444c598236b5ce3e8/include/urilite.h#L52-L65
+    // RFC2396 unreserved?
+    return ((c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+            || c == '-' || c == '_' || c == '.' || c == '~'
+            || c == '!' || c == '\'' || c == '(' || c == ')');
+  }
+
   static std::string DecodeURIComponent(const std::string& encoded) {
-    std::string decoded;
+    std::ostringstream decoded;
     for (size_t i = 0; i < encoded.length(); ++i) {
-      if (i + 3 <= encoded.length() && encoded[i] == '%' && IsHexDigit(encoded[i + 1]) && IsHexDigit(encoded[i + 2])) {
-        decoded += static_cast<char>(std::stoi(encoded.substr(i + 1, 2).c_str(), nullptr, 16));
+      const char c = encoded[i];
+      if (c == '+') {
+        decoded << ' ';
+      } else if (c == '%' && i + 3 <= encoded.length() && IsHexDigit(encoded[i + 1]) && IsHexDigit(encoded[i + 2])) {
+        decoded << static_cast<char>(std::stoi(encoded.substr(i + 1, 2).c_str(), nullptr, 16));
         i += 2;
-      } else if (encoded[i] == '+') {
-        decoded += ' ';
       } else {
-        decoded += encoded[i];
+        decoded << c;
       }
     }
-    return decoded;
+    return decoded.str();
   }
 
   static std::string EncodeURIComponent(const std::string& decoded) {
-    std::string encoded;
+    std::ostringstream encoded;
     for (const char c : decoded) {
-      if (::isalpha(c) || ::isdigit(c)) {
-        encoded += c;
+      if (IsURIComponentSpecialCharacter(c)) {
+        encoded << c;
+      } else if (c == ' ') {
+        encoded << "%20";
       } else {
-        encoded += current::strings::Printf("%%%02X", static_cast<int>(c));
+        encoded << current::strings::Printf("%%%02X", static_cast<int>(c));
       }
     }
-    return encoded;
+    return encoded.str();
   }
 
   std::string ComposeParameters() const {
@@ -351,24 +375,67 @@ struct URLParametersExtractor {
   std::vector<std::pair<std::string, std::string>> parameters_vector;
   QueryParameters query;
   std::string fragment;
-  std::string url_without_parameters;
 };
 
 struct URL : URLParametersExtractor, URLWithoutParametersParser {
   URL() = default;
 
-  // Extra parameters for previous host and port are provided in the constructor to handle redirects.
-  URL(const std::string& url,
-      const std::string& previous_scheme = "",
-      const std::string& previous_host = "",
-      const uint16_t previous_port = 0)
-      : URLParametersExtractor(url),
-        URLWithoutParametersParser(
-            URLParametersExtractor::url_without_parameters, previous_scheme, previous_host, previous_port) {}
+  URL(const std::string& url) {
+    size_t parameters_start_index = 0;
+    URLParametersExtractor::ExtractURLParametersFromURL(url, parameters_start_index);
+    URLWithoutParametersParser::ParseURLWithoutParameters(url.substr(0, parameters_start_index));
+  }
 
-  URL(const std::string& url, const URLWithoutParametersParser& previous)
-      : URLParametersExtractor(url),
-        URLWithoutParametersParser(URLParametersExtractor::url_without_parameters, previous) {}
+  URL& FillWithDefaults() {
+    if (scheme.empty()) {
+      if (port == 0) {
+        scheme = kDefaultScheme;
+      } else {
+        scheme = DefaultSchemeForPort(port);
+        if (scheme.empty()) {
+          scheme = kDefaultScheme;
+        }
+      }
+    }
+
+    if (host.empty()) {
+      host = kDefaultHost;
+    }
+
+    if (port == 0) {
+      port = DefaultPortForScheme(scheme);
+    }
+
+    return *this;
+  }
+
+  URL& RedirectToURL(const URL& target_url_parsed) {
+    if (!target_url_parsed.scheme.empty()) {
+      scheme = target_url_parsed.scheme;
+    }
+
+    if (!target_url_parsed.host.empty()) {
+      host = target_url_parsed.host;
+      port = target_url_parsed.port;
+    } else if (target_url_parsed.port > 0) {
+      port = target_url_parsed.port;
+    }
+
+    username = target_url_parsed.username;
+    password = target_url_parsed.password;
+
+    path = target_url_parsed.path;
+
+    parameters_vector = target_url_parsed.parameters_vector;
+    query = target_url_parsed.query;
+    fragment = target_url_parsed.fragment;
+
+    return *this;
+  }
+
+  URL& RedirectToURL(const std::string& url) { return RedirectToURL(URL(url)); }
+
+  std::string ComposeURLWithoutParameters() const { return URLWithoutParametersParser::ComposeURL(); }
 
   std::string ComposeURL() const {
     return URLWithoutParametersParser::ComposeURL() + URLParametersExtractor::ComposeParameters();

--- a/Blocks/URL/url.h
+++ b/Blocks/URL/url.h
@@ -76,7 +76,7 @@ struct URLWithoutParametersParser {
   std::string host = "";
   mutable std::string path = "/";
   std::string scheme = kDefaultScheme;
-  int port = 0;
+  uint16_t port = 0;
 
   URLWithoutParametersParser() = default;
 
@@ -84,7 +84,7 @@ struct URLWithoutParametersParser {
   URLWithoutParametersParser(const std::string& url,
                              const std::string& previous_scheme = "",
                              const std::string& previous_host = "",
-                             const int previous_port = 0) {
+                             const uint16_t previous_port = 0) {
     if (url.empty()) {
       CURRENT_THROW(EmptyURLException());
     }
@@ -106,7 +106,7 @@ struct URLWithoutParametersParser {
     }
 
     if (colon != std::string::npos && colon < slash) {
-      port = atoi(url.c_str() + colon + 1);
+      port = static_cast<uint16_t>(atoi(url.c_str() + colon + 1));
     }
 
     if (slash != std::string::npos) {
@@ -361,7 +361,7 @@ struct URL : URLParametersExtractor, URLWithoutParametersParser {
   URL(const std::string& url,
       const std::string& previous_scheme = "",
       const std::string& previous_host = "",
-      const int previous_port = 0)
+      const uint16_t previous_port = 0)
       : URLParametersExtractor(url),
         URLWithoutParametersParser(
             URLParametersExtractor::url_without_parameters, previous_scheme, previous_host, previous_port) {}

--- a/Bricks/net/exceptions.h
+++ b/Bricks/net/exceptions.h
@@ -89,7 +89,9 @@ struct HTTPException : NetworkException {
 };
 
 struct HTTPRedirectNotAllowedException : HTTPException {};
-struct HTTPRedirectLoopException : HTTPException {};
+struct HTTPRedirectLoopException : HTTPException {
+  using HTTPException::HTTPException;
+};
 struct HTTPPayloadTooLarge : HTTPException {};
 struct ChunkSizeNotAValidHEXValue : HTTPException {};
 

--- a/Bricks/net/tcp/impl/posix.h
+++ b/Bricks/net/tcp/impl/posix.h
@@ -517,10 +517,10 @@ inline addrinfo_t GetAddrInfo(const std::string& host, const std::string& serv =
   hints.ai_protocol = IPPROTO_TCP;
   const int retval = ::getaddrinfo(host.c_str(), serv.c_str(), &hints, &result);
   if (!result) {
-    CURRENT_THROW(SocketResolveAddressException());
+    CURRENT_THROW(SocketResolveAddressException(host + ' ' + serv));
   } else if (retval) {
     freeaddrinfo(result);
-    CURRENT_THROW(SocketResolveAddressException(gai_strerror(retval)));
+    CURRENT_THROW(SocketResolveAddressException(host + ' ' + serv + ' ' + gai_strerror(retval)));
   }
   return addrinfo_t(result);
 }

--- a/EventCollector/event_collector.h
+++ b/EventCollector/event_collector.h
@@ -89,7 +89,7 @@ class EventCollectorHTTPServer {
                                             std::lock_guard<std::mutex> lock(mutex_);
                                             entry.t = now.count();
                                             entry.m = r.method;
-                                            entry.u = r.url.url_without_parameters;
+                                            entry.u = r.url.ComposeURLWithoutParameters();
                                             entry.q = r.url.AllQueryParameters();
                                             entry.h = r.headers.AsMap();
                                             entry.c = r.headers.CookiesAsString();

--- a/Midichlorians/Server/server.h
+++ b/Midichlorians/Server/server.h
@@ -123,7 +123,7 @@ class MidichloriansHTTPServer {
             return r.url.AllQueryParameters();
           } else if (r.method == "POST") {
             is_allowed_method = true;
-            extracted_q = current::url::impl::URLParametersExtractor("?" + r.body).AllQueryParameters();
+            extracted_q = current::url::URL("/?" + r.body).AllQueryParameters();
             for (const auto& cit : r.url.AllQueryParameters()) {
               extracted_q.insert(cit);
             }


### PR DESCRIPTION
The issue I'm solving here is issuing a redirect from the backend with the URL understood by the end user, even if the URL is transformed along the way from the server to the user (e.g. on a proxy).

Unfortunately, this required the changes to the `URL` class behavior: its "previous URL" handling and defaults handling. There were too many variants of use of this class's options, some of which were conflicting with each other (e.g. default scheme with an unknown port or no scheme with an unknown port).

The `HTTPClient` was also changed to throw if the redirects weren't allowed before following any redirect response code.

The `SocketResolveAddressException` was filled with the resolve arguments to have more details about the error in runtime.

CC @dkorolev @grixa @mzhurovich