### PR TITLE
Blocks/URL: Simplified the `URL` class public API and impl; added `username` and `password`.

### DIFF
--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -135,7 +135,7 @@ class GenericHTTPClientPOSIX final {
       if (response_code_as_int >= 300 && response_code_as_int <= 399 && !http_request_->location.empty()) {
         // Note: This is by no means a complete redirect implementation.
         redirected = true;
-        parsed_url = URL(http_request_->location, parsed_url);
+        parsed_url.RedirectToURL(http_request_->location);
         response_url_after_redirects_ = parsed_url.ComposeURL();
       }
     } while (redirected);

--- a/Blocks/URL/test.cc
+++ b/Blocks/URL/test.cc
@@ -34,143 +34,400 @@ using namespace current::url;
 TEST(URLTest, SmokeTest) {
   URL u;
 
+  // For URLs where no scheme or port is specified in the original string, no scheme or port is stored.
+
+  // WARNING: Browser implementation differs: `www.google.com` is pathname.
   u = URL("www.google.com");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `www.google.com/test` is pathname.
   u = URL("www.google.com/test");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/test", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/test", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `443/test` is pathname.
+  u = URL("www.google.com:443");
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(443, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("https://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `8080/test` is pathname.
   u = URL("www.google.com:8080");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ("", u.scheme);
   EXPECT_EQ(8080, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  // Unknown port `8080` falls back to default scheme in `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:8080/", u.ComposeURL());
 
   u = URL("meh://www.google.com:27960");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
   EXPECT_EQ("meh", u.scheme);
   EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/", u.ComposeURL());
 
   u = URL("meh://www.google.com:27960/bazinga");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/bazinga", u.path);
   EXPECT_EQ("meh", u.scheme);
   EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/bazinga", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `localhost/` is pathname.
   u = URL("localhost/");
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost/test` is pathname.
+  u = URL("localhost/test");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/test");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `:1234/test` is assumed pathname.
+  u = URL(":1234/test");
+  EXPECT_EQ("", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(1234, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  // NOTE: `ComposeURL` ignores the `port` if `host` is empty.
+  EXPECT_EQ("/test", u.ComposeURL());
+
+  u = URL("/test");
+  EXPECT_EQ("", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("/test", u.ComposeURL());
+
+  // Can parse a protocol-relative URL: `//host.name:80/path`.
+  u = URL("//host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  // NOTE: `ComposeURL` does not add the leading two slashes if scheme is empty.
+  EXPECT_EQ("http://host.name/path", u.ComposeURL());
+
+  // Can parse a username-password pair: `http://user1:pass345@host.name:80/path`.
+  u = URL("http://user1:pass345@host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("user1", u.username);
+  EXPECT_EQ("pass345", u.password);
+  EXPECT_EQ("http://user1:pass345@host.name/path", u.ComposeURL());
 
-  u = URL("localhost:/");
+  // Can parse a username alone: `http://user1@host.name:80/path`.
+  u = URL("http://user1@host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("user1", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://user1@host.name/path", u.ComposeURL());
+}
+
+TEST(URLTest, FillWithDefaultsTest) {
+  URL u;
+
+  // For URLs where no scheme or port is specified in the original string, no scheme or port is stored.
+
+  // WARNING: Browser implementation differs: `www.google.com` is pathname.
+  u = URL("www.google.com").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com/test` is pathname.
+  u = URL("www.google.com/test").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `443/test` is pathname.
+  u = URL("www.google.com:443").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("https", u.scheme);
+  EXPECT_EQ(443, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("https://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `8080/test` is pathname.
+  u = URL("www.google.com:8080").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);  // Unknown port `8080` falls back to default scheme in `FillWithDefaults`.
+  EXPECT_EQ(8080, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://www.google.com:8080/", u.ComposeURL());
+
+  u = URL("meh://www.google.com:27960").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("meh", u.scheme);
+  EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/", u.ComposeURL());
+
+  u = URL("meh://www.google.com:27960/bazinga").FillWithDefaults();
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/bazinga", u.path);
+  EXPECT_EQ("meh", u.scheme);
+  EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("meh://www.google.com:27960/bazinga", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost/` is pathname.
+  u = URL("localhost/").FillWithDefaults();
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
 
-  u = URL("localhost/test");
+  // WARNING: Browser implementation differs: `localhost/test` is pathname.
+  u = URL("localhost/test").FillWithDefaults();
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/test", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
 
-  u = URL("localhost:/test");
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/test").FillWithDefaults();
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/test", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `:1234/test` is assumed pathname.
+  u = URL(":1234/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);  // Unknown port `1234` falls back to default scheme in `FillWithDefaults`.
+  EXPECT_EQ(1234, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost:1234/test", u.ComposeURL());
+
+  u = URL("/test").FillWithDefaults();
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  u = URL("//hostname/path").FillWithDefaults();
+  EXPECT_EQ("hostname", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.username);
+  EXPECT_EQ("", u.password);
+  EXPECT_EQ("http://hostname/path", u.ComposeURL());
 }
 
-TEST(URLTest, CompositionTest) {
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com:80").ComposeURL());
-  EXPECT_EQ("http://www.google.com:8080/", URL("www.google.com:8080").ComposeURL());
-  EXPECT_EQ("http://www.google.com:8080/", URL("http://www.google.com:8080").ComposeURL());
-  EXPECT_EQ("meh://www.google.com:8080/", URL("meh://www.google.com:8080").ComposeURL());
-}
-
-TEST(URLTest, DerivesSchemeFromPreviousPort) {
-  // Smoke tests for non-default scheme, setting the 2nd parameter to the URL() constructor.
-  EXPECT_EQ("www.google.com/", URL("www.google.com", "").ComposeURL());
-  EXPECT_EQ("telnet://www.google.com:23/", URL("www.google.com", "telnet", "", 23).ComposeURL());
-  // Keeps the scheme if it was explicitly specified, even for the port that maps to a different scheme.
-  EXPECT_EQ("foo://www.google.com:80/", URL("foo://www.google.com", "", "", 80).ComposeURL());
+TEST(URLTest, ComposeURLDerivesSchemeFromPort) {
   // Maps port 80 into "http://".
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com", "", "", 80).ComposeURL());
+  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
+
   // Maps port 443 into "https://".
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com", "", "", 443).ComposeURL());
+  EXPECT_EQ("https://www.google.com/", URL("www.google.com:443").ComposeURL());
+
+  // Since there is no scheme and no rule for port "23", default scheme is used by `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:23/", URL("www.google.com:23").ComposeURL());
+
+  // Keeps the scheme if it was explicitly specified, even for the port that maps to a different scheme.
+  EXPECT_EQ("foo://www.google.com/", URL("foo://www.google.com").ComposeURL());
+  EXPECT_EQ("foo://www.google.com:80/", URL("foo://www.google.com:80").ComposeURL());
+  EXPECT_EQ("http://www.google.com:443/", URL("http://www.google.com:443").ComposeURL());
+
   // Assumes port 80 for "http://".
-  EXPECT_EQ("http://www.google.com:79/", URL("www.google.com", "http", "", 79).ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com", "http", "", 80).ComposeURL());
-  EXPECT_EQ("http://www.google.com:81/", URL("www.google.com", "http", "", 81).ComposeURL());
+  EXPECT_EQ("http://www.google.com:79/", URL("http://www.google.com:79").ComposeURL());
+  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com:80").ComposeURL());
+  EXPECT_EQ("http://www.google.com:81/", URL("http://www.google.com:81").ComposeURL());
+
   // Assumes port 443 for "https://".
-  EXPECT_EQ("https://www.google.com:442/", URL("www.google.com", "https", "", 442).ComposeURL());
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com", "https", "", 443).ComposeURL());
-  EXPECT_EQ("https://www.google.com:444/", URL("www.google.com", "https", "", 444).ComposeURL());
-  // Since there is no rule from "23" to "telnet", no scheme is specified.
-  EXPECT_EQ("www.google.com:23/", URL("www.google.com", "", "", 23).ComposeURL());
+  EXPECT_EQ("https://www.google.com:442/", URL("https://www.google.com:442").ComposeURL());
+  EXPECT_EQ("https://www.google.com/", URL("https://www.google.com:443").ComposeURL());
+  EXPECT_EQ("https://www.google.com:444/", URL("https://www.google.com:444").ComposeURL());
 }
 
-TEST(URLTest, RedirectPreservesSchemeHostAndPortTest) {
-  EXPECT_EQ("http://localhost/foo", URL("/foo", URL("localhost")).ComposeURL());
-  EXPECT_EQ("meh://localhost/foo", URL("/foo", URL("meh://localhost")).ComposeURL());
-  EXPECT_EQ("http://localhost:8080/foo", URL("/foo", URL("localhost:8080")).ComposeURL());
-  EXPECT_EQ("meh://localhost:8080/foo", URL("/foo", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("meh://localhost:27960/foo", URL(":27960/foo", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("ftp://foo:8080/", URL("ftp://foo", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("ftp://localhost:8080/bar", URL("ftp:///bar", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("blah://new_host:5000/foo", URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL());
-  EXPECT_EQ("blah://new_host:6000/foo", URL("blah://new_host:6000/foo", URL("meh://localhost:5000")).ComposeURL());
+TEST(URLTest, RedirectToURLTest) {
+  // Relative URL preserves scheme, host, port.
+  EXPECT_EQ("http://localhost/foo", URL("localhost").RedirectToURL("/foo").ComposeURL());
+  EXPECT_EQ("meh://localhost/foo", URL("meh://localhost").RedirectToURL("/foo").ComposeURL());
+  EXPECT_EQ("http://localhost:8080/empty_all_with_previous_empty_scheme", URL("localhost:8080").RedirectToURL("/empty_all_with_previous_empty_scheme").ComposeURL());
+  EXPECT_EQ("meh://localhost:8080/empty_all_with_previous_all", URL("meh://localhost:8080").RedirectToURL("/empty_all_with_previous_all").ComposeURL());
+
+  // Port-only full URL replaces port and preserves host from previous URL.
+  EXPECT_EQ("meh://localhost:27960/empty_scheme_host", URL("meh://localhost:8080").RedirectToURL(":27960/empty_scheme_host").ComposeURL());
+
+  // Schema-only full URL preserves host and port from previous URL.
+  EXPECT_EQ("ftp://localhost:8080/empty_host", URL("meh://localhost:8080").RedirectToURL("ftp:///empty_host").ComposeURL());
+
+  // Full URL replaces scheme, host, port, does not preserve anything from previous URL.
+  EXPECT_EQ("ftp://host_no_port_path/", URL("meh://localhost:8080").RedirectToURL("ftp://host_no_port_path").ComposeURL());
+  EXPECT_EQ("blah://new_host/foo", URL("meh://localhost:5000").RedirectToURL("blah://new_host/foo").ComposeURL());
+  EXPECT_EQ("blah://new_host:6000/foo", URL("meh://localhost:5000").RedirectToURL("blah://new_host:6000/foo").ComposeURL());
+
+  // The username-password pair is always taken from the next URL.
+  EXPECT_EQ("http://user1:pass345@new_host/foo", URL("meh://a:b@localhost:5000").RedirectToURL("http://user1:pass345@new_host/foo").ComposeURL());
 }
 
-TEST(URLTest, ExtractsURLParameters) {
+TEST(URLTest, RedirectToURLWithParametersTest) {
+  const auto redirected_url_parsed = URL("localhost/?replace=this&and=this").RedirectToURL("/foo?bar=baz&qoo=xdoo");
+  EXPECT_EQ("http://localhost/foo?bar=baz&qoo=xdoo", redirected_url_parsed.ComposeURL());
+  EXPECT_EQ("http://localhost/foo", redirected_url_parsed.ComposeURLWithoutParameters());
+
+  EXPECT_EQ("http://localhost:1234/foo?bar=baz&qoo=xdoo#with-fragment", URL("localhost:1234/?replace=this&and=this").RedirectToURL("/foo?bar=baz&qoo=xdoo#with-fragment").ComposeURL());
+
+  const auto redirected_to_full_url_parsed = URL("localhost/?replace=this&and=this").RedirectToURL("http://other.domain/foo?bar=baz&qoo=xdoo");
+  EXPECT_EQ("http://other.domain/foo?bar=baz&qoo=xdoo", redirected_to_full_url_parsed.ComposeURL());
+  EXPECT_EQ("http://other.domain/foo", redirected_to_full_url_parsed.ComposeURLWithoutParameters());
+}
+
+TEST(URLTest, ExtractURLParametersAndComposeURLTest) {
   {
     URL u("www.google.com");
     EXPECT_EQ("", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/", u.ComposeURLWithoutParameters());
   }
   {
-    URL u("www.google.com/a#fragment");
-    EXPECT_EQ("fragment", u.fragment);
+    // Fragment is not passed through `DecodeURIComponent`.
+    URL u("www.google.com/a#encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space");
+    EXPECT_EQ("encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
-    EXPECT_EQ("http://www.google.com/a#fragment", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a#encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/a#fragment?foo=bar&baz=meh");
     EXPECT_EQ("fragment?foo=bar&baz=meh", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/a#fragment?foo=bar&baz=meh", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/b#fragment#foo");
     EXPECT_EQ("fragment#foo", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/b#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/b", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?key=value&key2=value2#fragment#foo");
     EXPECT_EQ("fragment#foo", u.fragment);
+    EXPECT_TRUE(u.query.has("key"));
     EXPECT_EQ("value", u.query["key"]);
     EXPECT_EQ("value", u.query.get("key", "default_value"));
+    EXPECT_TRUE(u.query.has("key2"));
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("http://www.google.com/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
     const auto& as_map = u.AllQueryParameters();
     EXPECT_EQ(2u, as_map.size());
     const auto key = as_map.find("key");
@@ -183,10 +440,19 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("value2", key2->second);
   }
   {
+    URL u("www.google.com/a?encoded%23query=-with_unreserved~chars!and%25reserved%3A%5Bchars%5Dplus%2Band%20space#foo");
+    EXPECT_EQ("foo", u.fragment);
+    EXPECT_TRUE(u.query.has("encoded#query"));
+    EXPECT_EQ("-with_unreserved~chars!and%reserved:[chars]plus+and space", u.query["encoded#query"]);
+    EXPECT_EQ("http://www.google.com/a?encoded%23query=-with_unreserved~chars!and%25reserved%3A%5Bchars%5Dplus%2Band%20space#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
+  }
+  {
     URL u("www.google.com/a?k=a%3Db%26s%3D%25s%23#foo");
     EXPECT_EQ("foo", u.fragment);
     EXPECT_EQ("a=b&s=%s#", u.query["k"]);
     EXPECT_EQ("http://www.google.com/a?k=a%3Db%26s%3D%25s%23#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("/q?key=value&key2=value2#fragment#foo");
@@ -196,12 +462,14 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("/a?k=a%3Db%26s%3D%25s%23#foo");
     EXPECT_EQ("foo", u.fragment);
     EXPECT_EQ("a=b&s=%s#", u.query["k"]);
     EXPECT_EQ("/a?k=a%3Db%26s%3D%25s%23#foo", u.ComposeURL());
+    EXPECT_EQ("/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?foo=&bar&baz=");
@@ -213,6 +481,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("", u.query["baz"]);
     EXPECT_EQ("", u.query.get("baz", "default_value"));
     EXPECT_EQ("http://www.google.com/q?foo=&bar=&baz=", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?foo=bar=baz");
@@ -220,6 +489,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("bar=baz", u.query["foo"]);
     EXPECT_EQ("bar=baz", u.query.get("foo", "default_value"));
     EXPECT_EQ("http://www.google.com/q?foo=bar%3Dbaz", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q? foo = bar = baz ");
@@ -227,6 +497,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ(" bar = baz ", u.query[" foo "]);
     EXPECT_EQ(" bar = baz ", u.query.get(" foo ", "default_value"));
     EXPECT_EQ("http://www.google.com/q?%20foo%20=%20bar%20%3D%20baz%20", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?1=foo");
@@ -234,6 +505,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("foo", u.query["1"]);
     EXPECT_EQ("foo", u.query.get("1", "default_value"));
     EXPECT_EQ("http://www.google.com/q?1=foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?question=forty+two");
@@ -241,6 +513,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("forty two", u.query["question"]);
     EXPECT_EQ("forty two", u.query.get("question", "default_value"));
     EXPECT_EQ("http://www.google.com/q?question=forty%20two", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?%3D+%3D=%3D%3D");
@@ -248,16 +521,24 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("==", u.query["= ="]);
     EXPECT_EQ("==", u.query.get("= =", "default_value"));
     EXPECT_EQ("http://www.google.com/q?%3D%20%3D=%3D%3D", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
-}
-
-TEST(URLTest, URLParametersCompositionTest) {
-  EXPECT_EQ("http://www.google.com/search", URL("www.google.com/search").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo#fragment", URL("www.google.com/search?q=foo#fragment").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar", URL("www.google.com/search?q=foo&q2=bar").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar#fragment",
-            URL("www.google.com/search?q=foo&q2=bar#fragment").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search#fragment", URL("www.google.com/search#fragment").ComposeURL());
+  {
+    ASSERT_THROW(URL("?parameters=only"), EmptyURLException);
+    ASSERT_THROW(URL("#fragment-only"), EmptyURLException);
+  }
+  {
+    // The following construct can be used to parse the `application/x-www-form-urlencoded` request body.
+    URL u("/?parameters=only");
+    EXPECT_EQ("", u.scheme);
+    EXPECT_EQ("", u.host);
+    EXPECT_EQ(0, u.port);
+    EXPECT_EQ("/", u.path);
+    EXPECT_EQ("", u.fragment);
+    EXPECT_EQ("only", u.query["parameters"]);
+    EXPECT_EQ("/?parameters=only", u.ComposeURL());
+    EXPECT_EQ("/", u.ComposeURLWithoutParameters());
+  }
 }
 
 TEST(URLTest, EmptyURLException) {
@@ -265,7 +546,14 @@ TEST(URLTest, EmptyURLException) {
   ASSERT_THROW(URL(""), EmptyURLException);
 
   // Empty host is allowed in relative links.
-  EXPECT_EQ("foo://www.website.com:321/second", URL("/second", URL("foo://www.website.com:321/first")).ComposeURL());
+  EXPECT_EQ("/second", URL("/second").ComposeURL());
+  // When redirected, the redirect path overrides the original path.
+  EXPECT_EQ("foo://www.website.com:321/second", URL("foo://www.website.com:321/first").RedirectToURL("/second").ComposeURL());
+
+  // With empty host, port is ignored.
+  EXPECT_EQ("/second", URL(":1234/second").ComposeURL());
+  // When redirected, the redirect port and path overrides the original port and path.
+  EXPECT_EQ("foo://www.website.com:1234/second", URL("foo://www.website.com:321/first").RedirectToURL(":1234/second").ComposeURL());
 }
 
 namespace url_test {

--- a/EventCollector/event_collector.h
+++ b/EventCollector/event_collector.h
@@ -89,7 +89,7 @@ class EventCollectorHTTPServer {
                                             std::lock_guard<std::mutex> lock(mutex_);
                                             entry.t = now.count();
                                             entry.m = r.method;
-                                            entry.u = r.url.url_without_parameters;
+                                            entry.u = r.url.ComposeURLWithoutParameters();
                                             entry.q = r.url.AllQueryParameters();
                                             entry.h = r.headers.AsMap();
                                             entry.c = r.headers.CookiesAsString();

--- a/Midichlorians/Server/server.h
+++ b/Midichlorians/Server/server.h
@@ -123,7 +123,7 @@ class MidichloriansHTTPServer {
             return r.url.AllQueryParameters();
           } else if (r.method == "POST") {
             is_allowed_method = true;
-            extracted_q = current::url::impl::URLParametersExtractor("?" + r.body).AllQueryParameters();
+            extracted_q = current::url::URL("/?" + r.body).AllQueryParameters();
             for (const auto& cit : r.url.AllQueryParameters()) {
               extracted_q.insert(cit);
             }


### PR DESCRIPTION
#### ~~ALSO MERGED INTO https://github.com/C5T/Current/pull/744~~ (https://github.com/C5T/Current/pull/744 closed in favor of https://github.com/C5T/Current/pull/746 which has not yet got the `URL` changes that fix the with-port-to-without-port redirect)

* Removed extra parameters to reduce the API surface that requires support and testing.
* Simplified internal logic (it's still complex and hard to grasp, unfortunately, because we chose to support many partial URL formats and make it smart).
* Made explicit methods for filling with default values and for redirect handling.
* Added support for username and password (there was a TODO for that).
* Simplified `URL` class inheritance, using methods, not constructors/initializers, to easier propagate data from one to another without a need for a class field.
* Replaced public `url_without_parameters` field with a `ComposeURLWithoutParameters` method as the field value is hard to keep in sync with the other properties' values.
* Fixed `EncodeURIComponent` encoding extra characters which should not be encoded according to RFC.
