### PR TITLE
ServeStaticFilesFrom with separate route and URL prefixes.

### DIFF
--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -80,7 +80,7 @@ class GenericHTTPClientPOSIX final {
       redirected = false;
       const std::string composed_url = parsed_url.ComposeURL();
       if (all_urls.count(composed_url)) {
-        CURRENT_THROW(current::net::HTTPRedirectLoopException());
+        CURRENT_THROW(current::net::HTTPRedirectLoopException(current::strings::Join(all_urls, ' ') + ' ' + composed_url));
       }
       all_urls.insert(composed_url);
       current::net::Connection connection(
@@ -132,8 +132,12 @@ class GenericHTTPClientPOSIX final {
       // the numerical response code "200" can be accessed with the same method as the "/path".
       const int response_code_as_int = atoi(http_request_->RawPath().c_str());
       response_code_ = HTTPResponseCode(response_code_as_int);
+      // Follow the redirects automatically.
+      // Note: This is by no means a complete redirect implementation.
       if (response_code_as_int >= 300 && response_code_as_int <= 399 && !http_request_->location.empty()) {
-        // Note: This is by no means a complete redirect implementation.
+        if (!allow_redirects_) {
+          CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
+        }
         redirected = true;
         parsed_url = URL(http_request_->location, parsed_url);
         response_url_after_redirects_ = parsed_url.ComposeURL();
@@ -153,6 +157,7 @@ class GenericHTTPClientPOSIX final {
   std::string request_user_agent_ = "";
   current::net::http::Headers request_headers_;
   const typename HTTP_HELPER::ConstructionParams request_data_construction_params_;
+  bool allow_redirects_ = false;
 
   // Output parameters.
   current::net::HTTPResponseCodeValue response_code_ = HTTPResponseCode.InvalidCode;
@@ -171,6 +176,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const HEAD& request, HTTPClientPOSIX& client) {
@@ -178,6 +184,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const POST& request, HTTPClientPOSIX& client) {
@@ -187,6 +194,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const POSTFromFile& request, HTTPClientPOSIX& client) {
@@ -197,6 +205,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_body_contents_ =
         current::FileSystem::ReadFileAsString(request.file_name);  // Can throw FileException.
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const PUT& request, HTTPClientPOSIX& client) {
@@ -206,6 +215,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const PATCH& request, HTTPClientPOSIX& client) {
@@ -215,6 +225,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const DELETE& request, HTTPClientPOSIX& client) {
@@ -222,6 +233,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;  // LCOV_EXCL_LINE  -- tested in GET above.
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const KeepResponseInMemory&, HTTPClientPOSIX&) {}
@@ -231,13 +243,10 @@ struct ImplWrapper<HTTPClientPOSIX> {
   }
 
   template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
-  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+  inline static void ParseOutput(const REQUEST_PARAMS& /*request_params*/,
                                  const RESPONSE_PARAMS& /*response_params*/,
                                  const HTTPClientPOSIX& response,
                                  HTTPResponse& output) {
-    if (!request_params.allow_redirects && request_params.url != response.response_url_after_redirects_) {
-      CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
-    }
     output.url = response.response_url_after_redirects_;
     output.code = response.response_code_;
     const auto& http_request = response.HTTPRequest();

--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -88,12 +88,21 @@ struct ServeStaticFilesFromCannotServeMoreThanOneIndexFile : ServeStaticFilesExc
 };
 
 struct ServeStaticFilesFromOptions {
-  std::string url_base;
+  // HTTP server route prefix.
+  std::string public_route_prefix;
+
+  // User-facing URL prefix. Used to prefix the route in the trailing slash redirects.
+  std::string public_url_prefix;
+
+  // Names of files to serve if a directory URL is requested, in the priority order (first found will be served).
   std::vector<std::string> index_filenames;
 
-  explicit ServeStaticFilesFromOptions(std::string url_base = "/",
-                                       std::vector<std::string> index_filenames = {"index.html", "index.htm"})
-      : url_base(std::move(url_base)), index_filenames(std::move(index_filenames)) {}
+  explicit ServeStaticFilesFromOptions(std::string public_route_prefix_in = "/",
+                                       std::string public_url_prefix_in = "",
+                                       std::vector<std::string> index_filenames_in = {"index.html", "index.htm"})
+    : public_route_prefix(std::move(public_route_prefix_in)),
+      public_url_prefix(public_url_prefix_in.empty() ? public_route_prefix : std::move(public_url_prefix_in)),
+      index_filenames(std::move(index_filenames_in)) {}
 };
 
 // Helper to serve a static file.
@@ -101,20 +110,27 @@ struct ServeStaticFilesFromOptions {
 struct StaticFileServer {
   std::string content;
   std::string content_type;
-  bool url_path_points_to_directory;
-  StaticFileServer(std::string content, std::string content_type, bool url_path_points_to_directory)
+  bool serves_directory;
+  std::string trailing_slash_redirect_url;
+
+  StaticFileServer(std::string content,
+                   std::string content_type,
+                   bool serves_directory,
+                   std::string trailing_slash_redirect_url = "")
       : content(std::move(content)),
-        content_type(std::move(content_type)),
-        url_path_points_to_directory(url_path_points_to_directory) {}
+        content_type(content_type),
+        serves_directory(serves_directory),
+        trailing_slash_redirect_url(trailing_slash_redirect_url) {}
+
   void operator()(Request r) {
     if (r.method == "GET") {
-      if (url_path_points_to_directory == r.url_path_had_trailing_slash) {
+      if (serves_directory == r.url_path_had_trailing_slash) {
         // 1) Respond with the content if we're serving a directory and have a trailing slash. Example: `/static/`
         // (`static` is a directory, not a file).
         // 2) Respond with the content if we're serving a file and don't have a trailing slash. Example:
         // `/static/index.html`, `/static/file.png`.
         r.connection.SendHTTPResponse(content, HTTPResponseCode.OK, content_type);
-      } else if (!url_path_points_to_directory && r.url_path_had_trailing_slash) {
+      } else if (!serves_directory && r.url_path_had_trailing_slash) {
         // Respond with HTTP 404 Not Found if we're serving a file and have a trailing slash. Example:
         // `/static/index.html/`.
         r.connection.SendHTTPResponse(current::net::DefaultNotFoundMessage(),
@@ -126,7 +142,7 @@ struct StaticFileServer {
         // URL for the index file served at that directory URL (without filename).
         // See RFC1808, `Resolving Relative URLs`, `Step 6`: https://www.ietf.org/rfc/rfc1808.txt
         r.connection.SendHTTPResponse(
-            "", HTTPResponseCode.Found, content_type, current::net::http::Headers({{"Location", r.url.path + '/'}}));
+            "", HTTPResponseCode.Found, content_type, current::net::http::Headers({{"Location", trailing_slash_redirect_url}}));
       }
     } else {
       r.connection.SendHTTPResponse(current::net::DefaultMethodNotAllowedMessage(),
@@ -247,7 +263,7 @@ class HTTPServerPOSIX final {
 
   HTTPRoutesScope ServeStaticFilesFrom(const std::string& dir,
                                        const ServeStaticFilesFromOptions& options = ServeStaticFilesFromOptions()) {
-    ValidateURLPath(options.url_base);
+    ValidateRoute(options.public_route_prefix);
 
     HTTPRoutesScope scope;
     current::FileSystem::ScanDir(
@@ -260,19 +276,29 @@ class HTTPServerPOSIX final {
 
           const std::string content_type(current::net::GetFileMimeType(item_info.basename, ""));
           if (!content_type.empty()) {
-            // `url_dirname` has no trailing slash.
-            const std::string url_dirname =
-                options.url_base + ((options.url_base == "/" || item_info.path_components_cref.empty()) ? "" : "/") +
-                current::strings::Join(item_info.path_components_cref, '/');
+            const bool path_components_empty = item_info.path_components_cref.empty();
+            const std::string path_components_joined = current::strings::Join(item_info.path_components_cref, '/');
+
+            // `route_for_directory` must have leading slash and must not have trailing slash except if it's a root.
+            const std::string route_for_directory =
+                options.public_route_prefix +
+                ((options.public_route_prefix == "/" || path_components_empty) ? "" : "/") +
+                path_components_joined;
+            CURRENT_ASSERT(route_for_directory == "/" || (route_for_directory.front() == '/' && route_for_directory.back() != '/'));
 
             // Ignore files nested in directories named with a leading dot (means hidden in POSIX).
-            if (url_dirname.find("/.") != std::string::npos) {
+            if (route_for_directory.find("/.") != std::string::npos) {
               return;
             }
 
-            const std::string url_pathname = url_dirname + (url_dirname == "/" ? "" : "/") + item_info.basename;
+            // `route_for_file` must have leading slash and must not have trailing slash.
+            const std::string route_for_file =
+                route_for_directory +
+                (route_for_directory == "/" ? "" : "/") +
+                item_info.basename;
+            CURRENT_ASSERT(route_for_file.front() == '/' && route_for_file.back() != '/');
 
-            const bool is_index =
+            const bool is_index_file =
                 (std::find(options.index_filenames.begin(), options.index_filenames.end(), item_info.basename) !=
                  options.index_filenames.end());
 
@@ -280,20 +306,27 @@ class HTTPServerPOSIX final {
             // that keeps a map from a (SHA256) hash to the contents.
             std::string content = current::FileSystem::ReadFileAsString(item_info.pathname);
 
-            // If it's an index file, serve it at the route without filename, too.
-            if (is_index) {
-              if (handlers_.find(url_dirname) != handlers_.end()) {
+            // If it's an index file, serve it additionally at the route without the filename (i.e. the directory route).
+            if (is_index_file) {
+              if (handlers_.find(route_for_directory) != handlers_.end()) {
                 CURRENT_THROW(
-                    ServeStaticFilesFromCannotServeMoreThanOneIndexFile(url_dirname + ' ' + item_info.basename));
+                    ServeStaticFilesFromCannotServeMoreThanOneIndexFile(route_for_directory + ' ' + item_info.basename));
               }
 
-              auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true);
-              scope += Register(url_dirname, *static_file_server);
+              // `trailing_slash_redirect_url` must have trailing slash.
+              std::string trailing_slash_redirect_url =
+                  options.public_url_prefix +
+                  (options.public_url_prefix.back() == '/' ? "" : "/") +
+                  (path_components_empty ? "" : path_components_joined + "/");
+              CURRENT_ASSERT(trailing_slash_redirect_url.length() > 0 && trailing_slash_redirect_url.back() == '/');
+
+              auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true, trailing_slash_redirect_url);
+              scope += Register(route_for_directory, *static_file_server);
               static_file_servers_.push_back(std::move(static_file_server));
             }
 
             auto static_file_server = std::make_unique<StaticFileServer>(std::move(content), content_type, false);
-            scope += Register(url_pathname, *static_file_server);
+            scope += Register(route_for_file, *static_file_server);
             static_file_servers_.push_back(std::move(static_file_server));
           } else {
             CURRENT_THROW(ServeStaticFilesFromCanNotServeStaticFilesOfUnknownMIMEType(item_info.basename));
@@ -422,7 +455,7 @@ class HTTPServerPOSIX final {
     }
   }
 
-  void ValidateURLPath(const std::string& path) {
+  void ValidateRoute(const std::string& path) {
     if (path.empty() || path[0] != '/') {
       CURRENT_THROW(PathDoesNotStartWithSlash("HTTP URL path does not start with a slash: `" + path + "`."));
     }
@@ -444,7 +477,7 @@ class HTTPServerPOSIX final {
     }
     // LCOV_EXCL_STOP
 
-    ValidateURLPath(path);
+    ValidateRoute(path);
 
     {
       // Step 1: Confirm the request is valid.

--- a/Blocks/URL/exceptions.h
+++ b/Blocks/URL/exceptions.h
@@ -25,11 +25,11 @@ SOFTWARE.
 #ifndef BLOCKS_URL_EXCEPTIONS_H
 #define BLOCKS_URL_EXCEPTIONS_H
 
-#include "../../port.h"
 #include "../../Bricks/exception.h"
-#include "../../TypeSystem/struct.h"
 #include "../../TypeSystem/Reflection/reflection.h"
 #include "../../TypeSystem/Schema/schema.h"
+#include "../../TypeSystem/struct.h"
+#include "../../port.h"
 
 namespace current {
 namespace url {

--- a/Blocks/URL/test.cc
+++ b/Blocks/URL/test.cc
@@ -87,6 +87,12 @@ TEST(URLTest, SmokeTest) {
   EXPECT_EQ("/test", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+
+  u = URL("/test");
+  EXPECT_EQ("", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
 }
 
 TEST(URLTest, CompositionTest) {
@@ -132,6 +138,23 @@ TEST(URLTest, RedirectPreservesSchemeHostAndPortTest) {
   EXPECT_EQ("ftp://localhost:8080/bar", URL("ftp:///bar", URL("meh://localhost:8080")).ComposeURL());
   EXPECT_EQ("blah://new_host:5000/foo", URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL());
   EXPECT_EQ("blah://new_host:6000/foo", URL("blah://new_host:6000/foo", URL("meh://localhost:5000")).ComposeURL());
+
+  // Since there is no rule for port "8080", and no previous scheme, no scheme is returned.
+  EXPECT_EQ("localhost:8080/empty_all_with_previous_empty_scheme",
+            URL("/empty_all_with_previous_empty_scheme", URL("localhost:8080")).ComposeURL());
+  EXPECT_EQ("meh://localhost:8080/empty_all_with_previous_all",
+            URL("/empty_all_with_previous_all", URL("meh://localhost:8080")).ComposeURL());
+
+  // Port-only full URL replaces port, preserves scheme and host from previous URL.
+  EXPECT_EQ("meh://localhost:27960/empty_scheme_host",
+            URL(":27960/empty_scheme_host", URL("meh://localhost:8080")).ComposeURL());
+
+  // Schema-only full URL preserves host and port from previous URL.
+  EXPECT_EQ("ftp://localhost:8080/empty_host", URL("ftp:///empty_host", URL("meh://localhost:8080")).ComposeURL());
+
+  // Full URL replaces scheme, host, port, does not preserve anything from previous URL.
+  EXPECT_EQ("ftp://host_no_port_path/", URL("ftp://host_no_port_path", URL("meh://localhost:8080")).ComposeURL());
+  EXPECT_EQ("blah://new_host/foo", URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL());
 }
 
 TEST(URLTest, ExtractsURLParameters) {

--- a/Blocks/URL/url.h
+++ b/Blocks/URL/url.h
@@ -76,7 +76,7 @@ struct URLWithoutParametersParser {
   std::string host = "";
   mutable std::string path = "/";
   std::string scheme = kDefaultScheme;
-  int port = 0;
+  uint16_t port = 0;
 
   URLWithoutParametersParser() = default;
 
@@ -84,7 +84,7 @@ struct URLWithoutParametersParser {
   URLWithoutParametersParser(const std::string& url,
                              const std::string& previous_scheme = kDefaultScheme,
                              const std::string& previous_host = "",
-                             const int previous_port = 0) {
+                             const uint16_t previous_port = 0) {
     if (url.empty()) {
       CURRENT_THROW(EmptyURLException());
     }
@@ -105,7 +105,7 @@ struct URLWithoutParametersParser {
     }
 
     if (colon < slash) {
-      port = atoi(url.c_str() + colon + 1);
+      port = static_cast<uint16_t>(atoi(url.c_str() + colon + 1));
     } else {
       port = previous_port;
     }
@@ -358,7 +358,7 @@ struct URL : URLParametersExtractor, URLWithoutParametersParser {
   URL(const std::string& url,
       const std::string& previous_scheme = kDefaultScheme,
       const std::string& previous_host = "",
-      const int previous_port = 0)
+      const uint16_t previous_port = 0)
       : URLParametersExtractor(url),
         URLWithoutParametersParser(
             URLParametersExtractor::url_without_parameters, previous_scheme, previous_host, previous_port) {}

--- a/Bricks/net/exceptions.h
+++ b/Bricks/net/exceptions.h
@@ -89,7 +89,9 @@ struct HTTPException : NetworkException {
 };
 
 struct HTTPRedirectNotAllowedException : HTTPException {};
-struct HTTPRedirectLoopException : HTTPException {};
+struct HTTPRedirectLoopException : HTTPException {
+  using HTTPException::HTTPException;
+};
 struct HTTPPayloadTooLarge : HTTPException {};
 struct ChunkSizeNotAValidHEXValue : HTTPException {};
 

--- a/Bricks/net/tcp/impl/posix.h
+++ b/Bricks/net/tcp/impl/posix.h
@@ -517,10 +517,10 @@ inline addrinfo_t GetAddrInfo(const std::string& host, const std::string& serv =
   hints.ai_protocol = IPPROTO_TCP;
   const int retval = ::getaddrinfo(host.c_str(), serv.c_str(), &hints, &result);
   if (!result) {
-    CURRENT_THROW(SocketResolveAddressException());
+    CURRENT_THROW(SocketResolveAddressException(host + ' ' + serv));
   } else if (retval) {
     freeaddrinfo(result);
-    CURRENT_THROW(SocketResolveAddressException(gai_strerror(retval)));
+    CURRENT_THROW(SocketResolveAddressException(host + ' ' + serv + ' ' + gai_strerror(retval)));
   }
   return addrinfo_t(result);
 }


### PR DESCRIPTION
The issue I'm solving here is issuing a redirect from the backend with the URL understood by the end user, even if the URL is transformed along the way from the server to the user (e.g. on a proxy).

1. If a directory is requested via a URL without a trailing slash (ex. `http://localhost:1234/directory`), `ServeStaticFilesFrom` knows this is a directory, and instead of serving the index file from that directory right away (keeping the URL at `http://localhost:1234/directory`), it issues a redirect to the URL with a trailing slash (ex. `http://localhost:1234/directory/`) because the URLs to directories with a trailing slash and without a trailing slash are treated differently by the browsers with respect to the relative URL resolution from the index file (ex. `./some.js` for this URL `http://localhost:1234/directory` is this URL `http://localhost:1234/some.js`; but `./some.js` for this URL `http://localhost:1234/directory/` is `http://localhost:1234/directory/some.js`).

2. Between the server with `ServeStaticFilesFrom` and the user of the browser, there may be a proxy server which transforms the URLs (ex. `http://public.example.com/files/file.html` is transformed to `http://localhost:1234/public/api/static/file.html`). This proxy server only does a forward transformation, but not the reverse one, because the response body can also contain user-facing URLs, and the proxy server does not know how to transform the body. This means the server has to know how to build the user-facing URLs i.e. to perform the reverse URL transformation.

3. Before this change, `ServeStaticFilesFrom` was not aware of the shape of the user-facing URLs. In the simplest case, when there is no proxy, this worked because the route at which the server responds matches the user-facing URL (ex. this URL `http://localhost:1234/public/api/directory` when directly accessed from a browser located at `localhost` matches the route `/public/api/directory` at which the file is served, and can be redirected to `/public/api/directory/` with the trailing slash to ensure the correct relative URL resolution on the browser side). On the other hand, when the proxy is involved serving at `http://public.example.com/directory` and is prefixing `/public/api` under the hood, the browser expects `http://public.example.com/directory/` when redirected from `http://public.example.com/directory` but instead gets `http://public.example.com/public/api/directory/` resolved by the browser from the root-relative URL `/public/api/directory/` by prepending the current scheme and host. This results in `HTTP 404 Not Found` because nothing is served at route `/public/api/public/api/directory`.

4. After this change, `ServeStaticFilesFrom` takes an optional public URL prefix which substitutes the route prefix when building the user-facing URLs for the redirects.
The `HTTPClient` was also changed to throw if the redirects weren't allowed before following any redirect response code.

Additionally:
* `SocketResolveAddressException` message now contains the resolve arguments to have more details about the error in runtime.
* `HTTPRedirectLoopException` message now contains the URLs of the loop.

Changes are squashed from branch `serve_static_files_public_url_prefix_different_from_internal_route_prefix` without `url_refactor`, see https://github.com/C5T/Current/pull/744 and https://github.com/C5T/Current/pull/745

Tests not passing in this commit are the reason for the `url_refactor` changes: when a redirect occurs from a URL with a port ("previous URL") to a URL without a port, the port gets propagated to the resulting URL and to the "Location" header.

```
[ RUN      ] URLTest.RedirectPreservesSchemeHostAndPortTest
test.cc:144: Failure
Value of: URL("/empty_all_with_previous_empty_scheme", URL("localhost:8080")).ComposeURL()
  Actual: "http://localhost:8080/empty_all_with_previous_empty_scheme"
Expected: "localhost:8080/empty_all_with_previous_empty_scheme"
test.cc:156: Failure
Value of: URL("ftp://host_no_port_path", URL("meh://localhost:8080")).ComposeURL()
  Actual: "ftp://host_no_port_path:8080/"
Expected: "ftp://host_no_port_path/"
test.cc:157: Failure
Value of: URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL()
  Actual: "blah://new_host:5000/foo"
Expected: "blah://new_host/foo"
[  FAILED  ] URLTest.RedirectPreservesSchemeHostAndPortTest (0 ms)
```

The full stack of the redirect with HTTP server and client cannot be tested with the Current tests setup because they always use ports and cannot redirect to a URL without a port because `HTTPClient` tries to connect to it.

CC @dkorolev @mzhurovich @grixa