### PR TITLE
Blocks/HTTP/impl/posix_client: Throw `HTTPRedirectNotAllowedException` as soon as a redirecting status code is received.

### DIFF
--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -132,8 +132,12 @@ class GenericHTTPClientPOSIX final {
       // the numerical response code "200" can be accessed with the same method as the "/path".
       const int response_code_as_int = atoi(http_request_->RawPath().c_str());
       response_code_ = HTTPResponseCode(response_code_as_int);
+      // Follow the redirects automatically.
+      // Note: This is by no means a complete redirect implementation.
       if (response_code_as_int >= 300 && response_code_as_int <= 399 && !http_request_->location.empty()) {
-        // Note: This is by no means a complete redirect implementation.
+        if (!allow_redirects_) {
+          CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
+        }
         redirected = true;
         parsed_url = URL(http_request_->location, parsed_url);
         response_url_after_redirects_ = parsed_url.ComposeURL();
@@ -153,6 +157,7 @@ class GenericHTTPClientPOSIX final {
   std::string request_user_agent_ = "";
   current::net::http::Headers request_headers_;
   const typename HTTP_HELPER::ConstructionParams request_data_construction_params_;
+  bool allow_redirects_ = false;
 
   // Output parameters.
   current::net::HTTPResponseCodeValue response_code_ = HTTPResponseCode.InvalidCode;
@@ -171,6 +176,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const HEAD& request, HTTPClientPOSIX& client) {
@@ -178,6 +184,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const POST& request, HTTPClientPOSIX& client) {
@@ -187,6 +194,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const POSTFromFile& request, HTTPClientPOSIX& client) {
@@ -197,6 +205,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_body_contents_ =
         current::FileSystem::ReadFileAsString(request.file_name);  // Can throw FileException.
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const PUT& request, HTTPClientPOSIX& client) {
@@ -206,6 +215,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const PATCH& request, HTTPClientPOSIX& client) {
@@ -215,6 +225,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_headers_ = request.custom_headers;
     client.request_body_contents_ = request.body;
     client.request_body_content_type_ = request.content_type;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const DELETE& request, HTTPClientPOSIX& client) {
@@ -222,6 +233,7 @@ struct ImplWrapper<HTTPClientPOSIX> {
     client.request_url_ = request.url;
     client.request_user_agent_ = request.custom_user_agent;  // LCOV_EXCL_LINE  -- tested in GET above.
     client.request_headers_ = request.custom_headers;
+    client.allow_redirects_ = request.allow_redirects;
   }
 
   inline static void PrepareInput(const KeepResponseInMemory&, HTTPClientPOSIX&) {}
@@ -231,13 +243,10 @@ struct ImplWrapper<HTTPClientPOSIX> {
   }
 
   template <typename REQUEST_PARAMS, typename RESPONSE_PARAMS>
-  inline static void ParseOutput(const REQUEST_PARAMS& request_params,
+  inline static void ParseOutput(const REQUEST_PARAMS& /*request_params*/,
                                  const RESPONSE_PARAMS& /*response_params*/,
                                  const HTTPClientPOSIX& response,
                                  HTTPResponse& output) {
-    if (!request_params.allow_redirects && request_params.url != response.response_url_after_redirects_) {
-      CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
-    }
     output.url = response.response_url_after_redirects_;
     output.code = response.response_code_;
     const auto& http_request = response.HTTPRequest();

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -382,7 +382,8 @@ TEST(HTTPAPI, RedirectLoop) {
                                        current::net::constants::kDefaultHTMLContentType,
                                        Headers({{"Location", "/p1"}}));
                                    });
-  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/p1", FLAGS_net_api_test_port))), HTTPRedirectLoopException);
+  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/p1", FLAGS_net_api_test_port)).AllowRedirects()),
+               HTTPRedirectLoopException);
 }
 #endif
 


### PR DESCRIPTION
Previously, the exception was thrown after all the requests caused by the redirects have been performed.
If the client does not allow redirects, it should not follow them.