### PR TITLE
Blocks/HTTP/impl/posix_server: ServeStaticFilesFrom public URL prefix.

### DIFF
--- a/Blocks/HTTP/impl/posix_server.h
+++ b/Blocks/HTTP/impl/posix_server.h
@@ -88,12 +88,21 @@ struct ServeStaticFilesFromCannotServeMoreThanOneIndexFile : ServeStaticFilesExc
 };
 
 struct ServeStaticFilesFromOptions {
-  std::string url_base;
+  // HTTP server route prefix.
+  std::string route_prefix;
+
+  // User-facing URL prefix. Used to prefix the route in the trailing slash redirects.
+  std::string public_url_prefix;
+
+  // Names of files to serve if a directory URL is requested, in the priority order (first found will be served).
   std::vector<std::string> index_filenames;
 
-  explicit ServeStaticFilesFromOptions(std::string url_base = "/",
-                                       std::vector<std::string> index_filenames = {"index.html", "index.htm"})
-      : url_base(std::move(url_base)), index_filenames(std::move(index_filenames)) {}
+  explicit ServeStaticFilesFromOptions(std::string route_prefix_in = "/",
+                                       std::string public_url_prefix_in = "",
+                                       std::vector<std::string> index_filenames_in = {"index.html", "index.htm"})
+    : route_prefix(std::move(route_prefix_in)),
+      public_url_prefix(public_url_prefix_in.empty() ? route_prefix : std::move(public_url_prefix_in)),
+      index_filenames(std::move(index_filenames_in)) {}
 };
 
 // Helper to serve a static file.
@@ -101,20 +110,27 @@ struct ServeStaticFilesFromOptions {
 struct StaticFileServer {
   std::string content;
   std::string content_type;
-  bool url_path_points_to_directory;
-  StaticFileServer(std::string content, std::string content_type, bool url_path_points_to_directory)
+  bool serves_directory;
+  std::string trailing_slash_redirect_url;
+
+  StaticFileServer(std::string content,
+                   std::string content_type,
+                   bool serves_directory,
+                   std::string trailing_slash_redirect_url = "")
       : content(std::move(content)),
-        content_type(std::move(content_type)),
-        url_path_points_to_directory(url_path_points_to_directory) {}
+        content_type(content_type),
+        serves_directory(serves_directory),
+        trailing_slash_redirect_url(trailing_slash_redirect_url) {}
+
   void operator()(Request r) {
     if (r.method == "GET") {
-      if (url_path_points_to_directory == r.url_path_had_trailing_slash) {
+      if (serves_directory == r.url_path_had_trailing_slash) {
         // 1) Respond with the content if we're serving a directory and have a trailing slash. Example: `/static/`
         // (`static` is a directory, not a file).
         // 2) Respond with the content if we're serving a file and don't have a trailing slash. Example:
         // `/static/index.html`, `/static/file.png`.
         r.connection.SendHTTPResponse(content, HTTPResponseCode.OK, content_type);
-      } else if (!url_path_points_to_directory && r.url_path_had_trailing_slash) {
+      } else if (!serves_directory && r.url_path_had_trailing_slash) {
         // Respond with HTTP 404 Not Found if we're serving a file and have a trailing slash. Example:
         // `/static/index.html/`.
         r.connection.SendHTTPResponse(current::net::DefaultNotFoundMessage(),
@@ -126,7 +142,7 @@ struct StaticFileServer {
         // URL for the index file served at that directory URL (without filename).
         // See RFC1808, `Resolving Relative URLs`, `Step 6`: https://www.ietf.org/rfc/rfc1808.txt
         r.connection.SendHTTPResponse(
-            "", HTTPResponseCode.Found, content_type, current::net::http::Headers({{"Location", r.url.path + '/'}}));
+            "", HTTPResponseCode.Found, content_type, current::net::http::Headers({{"Location", trailing_slash_redirect_url}}));
       }
     } else {
       r.connection.SendHTTPResponse(current::net::DefaultMethodNotAllowedMessage(),
@@ -247,7 +263,7 @@ class HTTPServerPOSIX final {
 
   HTTPRoutesScope ServeStaticFilesFrom(const std::string& dir,
                                        const ServeStaticFilesFromOptions& options = ServeStaticFilesFromOptions()) {
-    ValidateURLPath(options.url_base);
+    ValidateRoute(options.route_prefix);
 
     HTTPRoutesScope scope;
     current::FileSystem::ScanDir(
@@ -260,19 +276,29 @@ class HTTPServerPOSIX final {
 
           const std::string content_type(current::net::GetFileMimeType(item_info.basename, ""));
           if (!content_type.empty()) {
-            // `url_dirname` has no trailing slash.
-            const std::string url_dirname =
-                options.url_base + ((options.url_base == "/" || item_info.path_components_cref.empty()) ? "" : "/") +
-                current::strings::Join(item_info.path_components_cref, '/');
+            const bool path_components_empty = item_info.path_components_cref.empty();
+            const std::string path_components_joined = current::strings::Join(item_info.path_components_cref, '/');
+
+            // `route_for_directory` must have leading slash and must not have trailing slash except if it's a root.
+            const std::string route_for_directory =
+                options.route_prefix +
+                ((options.route_prefix == "/" || path_components_empty) ? "" : "/") +
+                path_components_joined;
+            CURRENT_ASSERT(route_for_directory == "/" || (route_for_directory.front() == '/' && route_for_directory.back() != '/'));
 
             // Ignore files nested in directories named with a leading dot (means hidden in POSIX).
-            if (url_dirname.find("/.") != std::string::npos) {
+            if (route_for_directory.find("/.") != std::string::npos) {
               return;
             }
 
-            const std::string url_pathname = url_dirname + (url_dirname == "/" ? "" : "/") + item_info.basename;
+            // `route_for_file` must have leading slash and must not have trailing slash.
+            const std::string route_for_file =
+                route_for_directory +
+                (route_for_directory == "/" ? "" : "/") +
+                item_info.basename;
+            CURRENT_ASSERT(route_for_file.front() == '/' && route_for_file.back() != '/');
 
-            const bool is_index =
+            const bool is_index_file =
                 (std::find(options.index_filenames.begin(), options.index_filenames.end(), item_info.basename) !=
                  options.index_filenames.end());
 
@@ -280,20 +306,27 @@ class HTTPServerPOSIX final {
             // that keeps a map from a (SHA256) hash to the contents.
             std::string content = current::FileSystem::ReadFileAsString(item_info.pathname);
 
-            // If it's an index file, serve it at the route without filename, too.
-            if (is_index) {
-              if (handlers_.find(url_dirname) != handlers_.end()) {
+            // If it's an index file, serve it additionally at the route without the filename (i.e. the directory route).
+            if (is_index_file) {
+              if (handlers_.find(route_for_directory) != handlers_.end()) {
                 CURRENT_THROW(
-                    ServeStaticFilesFromCannotServeMoreThanOneIndexFile(url_dirname + ' ' + item_info.basename));
+                    ServeStaticFilesFromCannotServeMoreThanOneIndexFile(route_for_directory + ' ' + item_info.basename));
               }
 
-              auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true);
-              scope += Register(url_dirname, *static_file_server);
+              // `trailing_slash_redirect_url` must have trailing slash.
+              std::string trailing_slash_redirect_url =
+                  options.public_url_prefix +
+                  (options.public_url_prefix.back() == '/' ? "" : "/") +
+                  (path_components_empty ? "" : path_components_joined + "/");
+              CURRENT_ASSERT(trailing_slash_redirect_url.length() > 0 && trailing_slash_redirect_url.back() == '/');
+
+              auto static_file_server = std::make_unique<StaticFileServer>(content, content_type, true, trailing_slash_redirect_url);
+              scope += Register(route_for_directory, *static_file_server);
               static_file_servers_.push_back(std::move(static_file_server));
             }
 
             auto static_file_server = std::make_unique<StaticFileServer>(std::move(content), content_type, false);
-            scope += Register(url_pathname, *static_file_server);
+            scope += Register(route_for_file, *static_file_server);
             static_file_servers_.push_back(std::move(static_file_server));
           } else {
             CURRENT_THROW(ServeStaticFilesFromCanNotServeStaticFilesOfUnknownMIMEType(item_info.basename));
@@ -422,7 +455,7 @@ class HTTPServerPOSIX final {
     }
   }
 
-  void ValidateURLPath(const std::string& path) {
+  void ValidateRoute(const std::string& path) {
     if (path.empty() || path[0] != '/') {
       CURRENT_THROW(PathDoesNotStartWithSlash("HTTP URL path does not start with a slash: `" + path + "`."));
     }
@@ -444,7 +477,7 @@ class HTTPServerPOSIX final {
     }
     // LCOV_EXCL_STOP
 
-    ValidateURLPath(path);
+    ValidateRoute(path);
 
     {
       // Step 1: Confirm the request is valid.

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -76,6 +76,11 @@ DEFINE_int32(net_api_test_port,
              "Local port to use for the test API-based HTTP server. NOTE: This port should be different from "
              "ports in other network-based tests, since API-driven HTTP server will hold it open for the whole "
              "lifetime of the binary.");
+DEFINE_int32(net_api_test_port_secondary,
+             PickPortForUnitTest(),
+             "Local port to use for the test API-based HTTP server for multi-port tests. NOTE: This port should be different from "
+             "ports in other network-based tests, since API-driven HTTP server will hold it open for the whole "
+             "lifetime of the binary.");
 DEFINE_string(net_api_test_tmpdir, ".current", "Local path for the test to create temporary files in.");
 
 CURRENT_STRUCT(HTTPAPITestObject) {
@@ -338,7 +343,7 @@ TEST(HTTPAPI, RespondsWithCustomObject) {
 
 #if !defined(CURRENT_APPLE) || defined(CURRENT_APPLE_HTTP_CLIENT_POSIX)
 // Disabled redirect tests for Apple due to implementation specifics -- M.Z.
-TEST(HTTPAPI, Redirect) {
+TEST(HTTPAPI, RedirectToRelativeURL) {
   const auto scope = HTTP(FLAGS_net_api_test_port)
                          .Register("/from",
                                    [](Request r) {
@@ -355,6 +360,27 @@ TEST(HTTPAPI, Redirect) {
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_EQ("Done.", response.body);
   EXPECT_EQ(Printf("http://localhost:%d/to", FLAGS_net_api_test_port), response.url);
+}
+
+TEST(HTTPAPI, RedirectToFullURL) {
+  // Need a live port for the redirect target because the HTTP client is following the redirect
+  // and tries to connect to the redirect target, otherwise throws a `SocketConnectException`.
+  const auto scope_redirect_to = HTTP(FLAGS_net_api_test_port_secondary).Register("/to", [](Request r) { r("Done."); });
+  const auto scope = HTTP(FLAGS_net_api_test_port)
+                         .Register("/from",
+                                   [](Request r) {
+                                     r("",
+                                       HTTPResponseCode.Found,
+                                       current::net::constants::kDefaultHTMLContentType,
+                                       Headers({{"Location", Printf("http://localhost:%d/to", FLAGS_net_api_test_port_secondary)}}));
+                                   });
+  // Redirect not allowed by default.
+  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/from", FLAGS_net_api_test_port))), HTTPRedirectNotAllowedException);
+  // Redirect allowed when `.AllowRedirects()` is set.
+  const auto response = HTTP(GET(Printf("http://localhost:%d/from", FLAGS_net_api_test_port)).AllowRedirects());
+  EXPECT_EQ(200, static_cast<int>(response.code));
+  EXPECT_EQ("Done.", response.body);
+  EXPECT_EQ(Printf("http://localhost:%d/to", FLAGS_net_api_test_port_secondary), response.url);
 }
 
 TEST(HTTPAPI, RedirectLoop) {
@@ -881,10 +907,12 @@ TEST(HTTPAPI, ServeStaticFilesFrom) {
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
   const std::string sub_dir = FileSystem::JoinPath(dir, "sub_dir");
+  const std::string sub_sub_dir = FileSystem::JoinPath(sub_dir, "sub_sub_dir");
   const std::string sub_dir_no_index = FileSystem::JoinPath(dir, "sub_dir_no_index");
   const std::string sub_dir_hidden = FileSystem::JoinPath(dir, ".sub_dir_hidden");
   FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
   FileSystem::MkDir(sub_dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::MkDir(sub_sub_dir, FileSystem::MkDirParameters::Silent);
   FileSystem::MkDir(sub_dir_no_index, FileSystem::MkDirParameters::Silent);
   FileSystem::MkDir(sub_dir_hidden, FileSystem::MkDirParameters::Silent);
   FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(dir, "index.html").c_str());
@@ -893,6 +921,7 @@ TEST(HTTPAPI, ServeStaticFilesFrom) {
   FileSystem::WriteStringToFile("\211PNG\r\n\032\n", FileSystem::JoinPath(dir, "file.png").c_str());
   FileSystem::WriteStringToFile("<h1>HTML sub_dir index</h1>", FileSystem::JoinPath(sub_dir, "index.htm").c_str());
   FileSystem::WriteStringToFile("alert('JavaScript')", FileSystem::JoinPath(sub_dir, "file_in_sub_dir.js").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_sub_dir index</h1>", FileSystem::JoinPath(sub_sub_dir, "index.html").c_str());
   FileSystem::WriteStringToFile("<h1>HTML hidden</h1>", FileSystem::JoinPath(sub_dir_hidden, "index.html").c_str());
   FileSystem::WriteStringToFile("", FileSystem::JoinPath(dir, ".DS_Store").c_str());
   FileSystem::WriteStringToFile("", FileSystem::JoinPath(sub_dir, ".file_hidden").c_str());
@@ -900,26 +929,69 @@ TEST(HTTPAPI, ServeStaticFilesFrom) {
   const auto scope = HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir);
 
   // Root index file.
-  EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(200, static_cast<int>(HTTP(GET(Printf("http://localhost:%d/", FLAGS_net_api_test_port))).code));
+  {
+    const auto root_response = HTTP(GET(Printf("http://localhost:%d/", FLAGS_net_api_test_port)));
+    EXPECT_EQ(200, static_cast<int>(root_response.code));
+    ASSERT_TRUE(root_response.headers.Has("Content-Type"));
+    EXPECT_EQ("text/html", root_response.headers.Get("Content-Type"));
+    EXPECT_EQ("<h1>HTML index</h1>", root_response.body);
+  }
 
   // Root index file direct link.
-  EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/index.html", FLAGS_net_api_test_port))).body);
+  {
+    const auto root_index_response = HTTP(GET(Printf("http://localhost:%d/index.html", FLAGS_net_api_test_port)));
+    EXPECT_EQ(200, static_cast<int>(root_index_response.code));
+    ASSERT_TRUE(root_index_response.headers.Has("Content-Type"));
+    EXPECT_EQ("text/html", root_index_response.headers.Get("Content-Type"));
+    EXPECT_EQ("<h1>HTML index</h1>", root_index_response.body);
+  }
 
   // Misc files.
-  EXPECT_EQ("<h1>HTML file</h1>", HTTP(GET(Printf("http://localhost:%d/file.html", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ("This is text.", HTTP(GET(Printf("http://localhost:%d/file.txt", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ("\211PNG\r\n\032\n", HTTP(GET(Printf("http://localhost:%d/file.png", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(200, static_cast<int>(HTTP(GET(Printf("http://localhost:%d/file.html", FLAGS_net_api_test_port))).code));
+  {
+    const auto html_response = HTTP(GET(Printf("http://localhost:%d/file.html", FLAGS_net_api_test_port)));
+    EXPECT_EQ(200, static_cast<int>(html_response.code));
+    ASSERT_TRUE(html_response.headers.Has("Content-Type"));
+    EXPECT_EQ("text/html", html_response.headers.Get("Content-Type"));
+    EXPECT_EQ("<h1>HTML file</h1>", html_response.body);
+  }
+  {
+    const auto text_response = HTTP(GET(Printf("http://localhost:%d/file.txt", FLAGS_net_api_test_port)));
+    EXPECT_EQ(200, static_cast<int>(text_response.code));
+    ASSERT_TRUE(text_response.headers.Has("Content-Type"));
+    EXPECT_EQ("text/plain", text_response.headers.Get("Content-Type"));
+    EXPECT_EQ("This is text.", text_response.body);
+  }
+  {
+    const auto png_response = HTTP(GET(Printf("http://localhost:%d/file.png", FLAGS_net_api_test_port)));
+    EXPECT_EQ(200, static_cast<int>(png_response.code));
+    ASSERT_TRUE(png_response.headers.Has("Content-Type"));
+    EXPECT_EQ("image/png", png_response.headers.Get("Content-Type"));
+    EXPECT_EQ("\211PNG\r\n\032\n", png_response.body);
+  }
 
   // Redirect from directory without trailing slash to directory with trailing slash.
-  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/sub_dir", FLAGS_net_api_test_port))),
-               HTTPRedirectNotAllowedException);
-  const auto sub_dir_response =
-      HTTP(GET(Printf("http://localhost:%d/sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
-  EXPECT_EQ("<h1>HTML sub_dir index</h1>", sub_dir_response.body);
-  EXPECT_EQ(200, static_cast<int>(sub_dir_response.code));
-  EXPECT_EQ(Printf("http://localhost:%d/sub_dir/", FLAGS_net_api_test_port), sub_dir_response.url);
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_dir_response =
+        HTTP(GET(Printf("http://localhost:%d/sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/sub_dir/", FLAGS_net_api_test_port), sub_dir_response.url);
+    ASSERT_TRUE(sub_dir_response.headers.Has("Content-Type"));
+    EXPECT_EQ("text/html", sub_dir_response.headers.Get("Content-Type"));
+    EXPECT_EQ("<h1>HTML sub_dir index</h1>", sub_dir_response.body);
+  }
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/sub_dir/sub_sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_sub_dir_response =
+        HTTP(GET(Printf("http://localhost:%d/sub_dir/sub_sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port), sub_sub_dir_response.url);
+    ASSERT_TRUE(sub_sub_dir_response.headers.Has("Content-Type"));
+    EXPECT_EQ("text/html", sub_sub_dir_response.headers.Get("Content-Type"));
+    EXPECT_EQ("<h1>HTML sub_sub_dir index</h1>", sub_sub_dir_response.body);
+  }
 
   // Subdirectory index file.
   EXPECT_EQ("<h1>HTML sub_dir index</h1>",
@@ -985,96 +1057,195 @@ TEST(HTTPAPI, ServeStaticFilesFrom) {
   EXPECT_EQ(405, static_cast<int>(HTTP(DELETE(Printf("http://localhost:%d/file.html", FLAGS_net_api_test_port))).code));
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomURLBase) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefix) {
   FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
   const std::string sub_dir = FileSystem::JoinPath(dir, "sub_dir");
   const std::string sub_sub_dir = FileSystem::JoinPath(sub_dir, "sub_sub_dir");
-  const std::string sub_dir_hidden = FileSystem::JoinPath(dir, ".sub_dir_hidden");
-  const std::string sub_sub_dir_hidden = FileSystem::JoinPath(sub_dir, ".sub_sub_dir_hidden");
   FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
   FileSystem::MkDir(sub_dir, FileSystem::MkDirParameters::Silent);
   FileSystem::MkDir(sub_sub_dir, FileSystem::MkDirParameters::Silent);
-  FileSystem::MkDir(sub_dir_hidden, FileSystem::MkDirParameters::Silent);
-  FileSystem::MkDir(sub_sub_dir_hidden, FileSystem::MkDirParameters::Silent);
   FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(dir, "index.html").c_str());
-  FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(sub_dir, "index.html").c_str());
-  FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(sub_sub_dir, "index.html").c_str());
-  FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(sub_dir_hidden, "index.html").c_str());
-  FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(sub_sub_dir_hidden, "index.html").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_dir index</h1>", FileSystem::JoinPath(sub_dir, "index.html").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_sub_dir index</h1>", FileSystem::JoinPath(sub_sub_dir, "index.html").c_str());
 
-  const auto scope = HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir, ServeStaticFilesFromOptions{"/static/something"});
+  const auto scope = HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir,
+      ServeStaticFilesFromOptions{"/static/something"});
 
   // Root index file.
   EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/", FLAGS_net_api_test_port))).body);
 
-  // Root index file direct link.
-  EXPECT_EQ("<h1>HTML index</h1>",
-            HTTP(GET(Printf("http://localhost:%d/static/something/index.html", FLAGS_net_api_test_port))).body);
-
   // Redirect from directory without trailing slash to directory with trailing slash.
-  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port))),
-               HTTPRedirectNotAllowedException);
-  const auto dir_response = HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port)).AllowRedirects());
-  EXPECT_EQ("<h1>HTML index</h1>", dir_response.body);
-  EXPECT_EQ(200, static_cast<int>(dir_response.code));
-  EXPECT_EQ(Printf("http://localhost:%d/static/something/", FLAGS_net_api_test_port), dir_response.url);
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto dir_response = HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/static/something/", FLAGS_net_api_test_port), dir_response.url);
+    EXPECT_EQ("<h1>HTML index</h1>", dir_response.body);
+  }
 
   // Subdirectory index file.
-  EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ("<h1>HTML index</h1>",
-            HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/index.html", FLAGS_net_api_test_port))).body);
+  EXPECT_EQ("<h1>HTML sub_dir index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/", FLAGS_net_api_test_port))).body);
 
   // Redirect from subdirectory without trailing slash to subdirectory with trailing slash.
-  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port))),
-               HTTPRedirectNotAllowedException);
-  const auto sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
-  EXPECT_EQ("<h1>HTML index</h1>", sub_dir_response.body);
-  EXPECT_EQ(200, static_cast<int>(sub_dir_response.code));
-  EXPECT_EQ(Printf("http://localhost:%d/static/something/sub_dir/", FLAGS_net_api_test_port), sub_dir_response.url);
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/static/something/sub_dir/", FLAGS_net_api_test_port), sub_dir_response.url);
+    EXPECT_EQ("<h1>HTML sub_dir index</h1>", sub_dir_response.body);
+  }
 
   // Subsubdirectory index file.
-  EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ("<h1>HTML index</h1>",
-            HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/index.html", FLAGS_net_api_test_port))).body);
+  EXPECT_EQ("<h1>HTML sub_sub_dir index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port))).body);
 
   // Redirect from subsubdirectory without trailing slash to subsubdirectory with trailing slash.
-  ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port))),
-               HTTPRedirectNotAllowedException);
-  const auto sub_sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
-  EXPECT_EQ("<h1>HTML index</h1>", sub_sub_dir_response.body);
-  EXPECT_EQ(200, static_cast<int>(sub_sub_dir_response.code));
-  EXPECT_EQ(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port), sub_sub_dir_response.url);
-
-  // Hidden subdirectory.
-  EXPECT_EQ(DefaultNotFoundMessage(),
-            HTTP(GET(Printf("http://localhost:%d/static/something/.sub_dir_hidden", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(DefaultNotFoundMessage(),
-            HTTP(GET(Printf("http://localhost:%d/static/something/.sub_dir_hidden/", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(DefaultNotFoundMessage(),
-            HTTP(GET(Printf("http://localhost:%d/static/something/.sub_dir_hidden/index.html", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(404,
-            static_cast<int>(HTTP(GET(Printf("http://localhost:%d/static/something/.sub_dir_hidden", FLAGS_net_api_test_port))).code));
-
-  // Hidden subsubdirectory.
-  EXPECT_EQ(DefaultNotFoundMessage(),
-            HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/.sub_sub_dir_hidden", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(DefaultNotFoundMessage(),
-            HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/.sub_sub_dir_hidden/", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(DefaultNotFoundMessage(),
-            HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/.sub_sub_dir_hidden/index.html", FLAGS_net_api_test_port))).body);
-  EXPECT_EQ(404,
-            static_cast<int>(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/.sub_sub_dir_hidden", FLAGS_net_api_test_port))).code));
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port), sub_sub_dir_response.url);
+    EXPECT_EQ("<h1>HTML sub_sub_dir index</h1>", sub_sub_dir_response.body);
+  }
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomURLBaseWithTrailingSlash) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixAndPublicUrlPrefixRelative) {
+  FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
+  const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
+  const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
+  const std::string sub_dir = FileSystem::JoinPath(dir, "sub_dir");
+  const std::string sub_sub_dir = FileSystem::JoinPath(sub_dir, "sub_sub_dir");
+  FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::MkDir(sub_dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::MkDir(sub_sub_dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(dir, "index.html").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_dir index</h1>", FileSystem::JoinPath(sub_dir, "index.html").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_sub_dir index</h1>", FileSystem::JoinPath(sub_sub_dir, "index.html").c_str());
+
+  // Below, use `localhost` and the secondary test port, not arbitrary domain name and port,
+  // because the HTTP client follows the redirect and tries to resolve its target domain name and connect to the port.
+  // This use case is for when there is a proxy, but we haven't set up one,
+  // so after redirects, the response code and body are always HTTP 200 with "Done.", not the targeted content.
+  const auto scope_redirect_to = HTTP(FLAGS_net_api_test_port)
+                                     .Register("/anything", URLPathArgs::CountMask::Any, [](Request r) { r("Done."); });
+
+  const auto scope = HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir,
+      ServeStaticFilesFromOptions{"/static/something", "/anything"});
+
+  // Root index file.
+  EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/", FLAGS_net_api_test_port))).body);
+
+  // Redirect from directory without trailing slash to directory with trailing slash.
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto dir_response = HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/anything/", FLAGS_net_api_test_port), dir_response.url);
+    EXPECT_EQ("Done.", dir_response.body);
+  }
+
+  // Subdirectory index file.
+  EXPECT_EQ("<h1>HTML sub_dir index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/", FLAGS_net_api_test_port))).body);
+
+  // Redirect from subdirectory without trailing slash to subdirectory with trailing slash.
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/anything/sub_dir/", FLAGS_net_api_test_port), sub_dir_response.url);
+    EXPECT_EQ("Done.", sub_dir_response.body);
+  }
+
+  // Subsubdirectory index file.
+  EXPECT_EQ("<h1>HTML sub_sub_dir index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port))).body);
+
+  // Redirect from subsubdirectory without trailing slash to subsubdirectory with trailing slash.
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/anything/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port), sub_sub_dir_response.url);
+    EXPECT_EQ("Done.", sub_sub_dir_response.body);
+  }
+}
+
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixAndPublicUrlPrefixAbsolute) {
+  FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
+  const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
+  const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
+  const std::string sub_dir = FileSystem::JoinPath(dir, "sub_dir");
+  const std::string sub_sub_dir = FileSystem::JoinPath(sub_dir, "sub_sub_dir");
+  FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::MkDir(sub_dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::MkDir(sub_sub_dir, FileSystem::MkDirParameters::Silent);
+  FileSystem::WriteStringToFile("<h1>HTML index</h1>", FileSystem::JoinPath(dir, "index.html").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_dir index</h1>", FileSystem::JoinPath(sub_dir, "index.html").c_str());
+  FileSystem::WriteStringToFile("<h1>HTML sub_sub_dir index</h1>", FileSystem::JoinPath(sub_sub_dir, "index.html").c_str());
+
+  // Below, use `localhost` and the secondary test port, not arbitrary domain name and port,
+  // because the HTTP client follows the redirect and tries to resolve its target domain name and connect to the port.
+  // This use case is for when there is a proxy, but we haven't set up one,
+  // so after redirects, the response code and body are always HTTP 200 with "Done.", not the targeted content.
+  const auto scope_redirect_to = HTTP(FLAGS_net_api_test_port_secondary)
+                                     .Register("/", URLPathArgs::CountMask::Any, [](Request r) { r("Done."); });
+
+  const auto scope = HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir,
+      ServeStaticFilesFromOptions{"/static/something", Printf("http://localhost:%d/anything", FLAGS_net_api_test_port_secondary)});
+
+  // Root index file.
+  EXPECT_EQ("<h1>HTML index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/", FLAGS_net_api_test_port))).body);
+
+  // Redirect from directory without trailing slash to directory with trailing slash.
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto dir_response = HTTP(GET(Printf("http://localhost:%d/static/something", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/anything/", FLAGS_net_api_test_port_secondary), dir_response.url);
+    EXPECT_EQ("Done.", dir_response.body);
+  }
+
+  // Subdirectory index file.
+  EXPECT_EQ("<h1>HTML sub_dir index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/", FLAGS_net_api_test_port))).body);
+
+  // Redirect from subdirectory without trailing slash to subdirectory with trailing slash.
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/anything/sub_dir/", FLAGS_net_api_test_port_secondary), sub_dir_response.url);
+    EXPECT_EQ("Done.", sub_dir_response.body);
+  }
+
+  // Subsubdirectory index file.
+  EXPECT_EQ("<h1>HTML sub_sub_dir index</h1>", HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port))).body);
+
+  // Redirect from subsubdirectory without trailing slash to subsubdirectory with trailing slash.
+  {
+    ASSERT_THROW(HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port))),
+                 HTTPRedirectNotAllowedException);
+    const auto sub_sub_dir_response = HTTP(GET(Printf("http://localhost:%d/static/something/sub_dir/sub_sub_dir", FLAGS_net_api_test_port)).AllowRedirects());
+    EXPECT_EQ(200, static_cast<int>(sub_sub_dir_response.code));
+    EXPECT_EQ(Printf("http://localhost:%d/anything/sub_dir/sub_sub_dir/", FLAGS_net_api_test_port_secondary), sub_sub_dir_response.url);
+    EXPECT_EQ("Done.", sub_sub_dir_response.body);
+  }
+}
+
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixWithTrailingSlash) {
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir, ServeStaticFilesFromOptions{"/static/"}),
                PathEndsWithSlash);
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsEmptyURLBase) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsEmptyPublicRoutePrefix) {
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir, ServeStaticFilesFromOptions{""}),
                PathDoesNotStartWithSlash);
@@ -1087,7 +1258,7 @@ TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomIndexFiles) {
   FileSystem::MkDir(dir, FileSystem::MkDirParameters::Silent);
   FileSystem::WriteStringToFile("TXT index", FileSystem::JoinPath(dir, "index.txt").c_str());
   const auto scope =
-      HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir, ServeStaticFilesFromOptions{"/", {"index.txt"}});
+      HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir, ServeStaticFilesFromOptions{"/", "", {"index.txt"}});
   EXPECT_EQ("TXT index", HTTP(GET(Printf("http://localhost:%d/", FLAGS_net_api_test_port))).body);
   EXPECT_EQ("TXT index", HTTP(GET(Printf("http://localhost:%d/index.txt", FLAGS_net_api_test_port))).body);
 }

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -1057,7 +1057,7 @@ TEST(HTTPAPI, ServeStaticFilesFrom) {
   EXPECT_EQ(405, static_cast<int>(HTTP(DELETE(Printf("http://localhost:%d/file.html", FLAGS_net_api_test_port))).code));
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefix) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomRoutePrefix) {
   FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
@@ -1113,7 +1113,7 @@ TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefix) {
   }
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixAndPublicUrlPrefixRelative) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomRoutePrefixAndPublicUrlPrefixRelative) {
   FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
@@ -1176,7 +1176,7 @@ TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixAndPublicUrlPref
   }
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixAndPublicUrlPrefixAbsolute) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomRoutePrefixAndPublicUrlPrefixAbsolute) {
   FileSystem::MkDir(FLAGS_net_api_test_tmpdir, FileSystem::MkDirParameters::Silent);
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   const auto dir_remover = current::FileSystem::ScopedRmDir(dir);
@@ -1239,7 +1239,7 @@ TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixAndPublicUrlPref
   }
 }
 
-TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomPublicRoutePrefixWithTrailingSlash) {
+TEST(HTTPAPI, ServeStaticFilesFromOptionsCustomRoutePrefixWithTrailingSlash) {
   const std::string dir = FileSystem::JoinPath(FLAGS_net_api_test_tmpdir, "static");
   ASSERT_THROW(HTTP(FLAGS_net_api_test_port).ServeStaticFilesFrom(dir, ServeStaticFilesFromOptions{"/static/"}),
                PathEndsWithSlash);


### PR DESCRIPTION
The issue I'm solving here is issuing a redirect from the backend with the URL understood by the end user, even if the URL is transformed along the way from the server to the user (e.g. on a proxy).

1. If a directory is requested via a URL without a trailing slash (ex. `http://localhost:1234/directory`), `ServeStaticFilesFrom` knows this is a directory, and instead of serving the index file from that directory right away (keeping the URL at `http://localhost:1234/directory`), it issues a redirect to the URL with a trailing slash (ex. `http://localhost:1234/directory/`) because the URLs to directories with a trailing slash and without a trailing slash are treated differently by the browsers with respect to the relative URL resolution from the index file (ex. `./some.js` for this URL `http://localhost:1234/directory` is this URL `http://localhost:1234/some.js`; but `./some.js` for this URL `http://localhost:1234/directory/` is `http://localhost:1234/directory/some.js`).

2. Between the server with `ServeStaticFilesFrom` and the user of the browser, there may be a proxy server which transforms the URLs (ex. `http://public.example.com/files/file.html` is transformed to `http://localhost:1234/public/api/static/file.html`). This proxy server only does a forward transformation, but not the reverse one, because the response body can also contain user-facing URLs, and the proxy server does not know how to transform the body. This means the server has to know how to build the user-facing URLs i.e. to perform the reverse URL transformation.

3. Before this change, `ServeStaticFilesFrom` was not aware of the shape of the user-facing URLs. In the simplest case, when there is no proxy, this worked because the route at which the server responds matches the user-facing URL (ex. this URL `http://localhost:1234/public/api/directory` when directly accessed from a browser located at `localhost` matches the route `/public/api/directory` at which the file is served, and can be redirected to `/public/api/directory/` with the trailing slash to ensure the correct relative URL resolution on the browser side). On the other hand, when the proxy is involved serving at `http://public.example.com/directory` and is prefixing `/public/api` under the hood, the browser expects `http://public.example.com/directory/` when redirected from `http://public.example.com/directory` but instead gets `http://public.example.com/public/api/directory/` resolved by the browser from the root-relative URL `/public/api/directory/` by prepending the current scheme and host. This results in `HTTP 404 Not Found` because nothing is served at route `/public/api/public/api/directory`.

4. After this change, `ServeStaticFilesFrom` takes an optional public URL prefix which substitutes the route prefix when building the user-facing URLs for the redirects.
The `HTTPClient` was also changed to throw if the redirects weren't allowed before following any redirect response code.