### PR TITLE
Blocks/HTTP/impl/posix_client: Fixed following redirect from a URL with non-default port to a full URL without a port.

### DIFF
--- a/Blocks/HTTP/impl/posix_client.h
+++ b/Blocks/HTTP/impl/posix_client.h
@@ -139,7 +139,7 @@ class GenericHTTPClientPOSIX final {
           CURRENT_THROW(current::net::HTTPRedirectNotAllowedException());
         }
         redirected = true;
-        parsed_url = URL(http_request_->location, parsed_url);
+        parsed_url = URL::MakeRedirectedURL(parsed_url, http_request_->location);
         response_url_after_redirects_ = parsed_url.ComposeURL();
       }
     } while (redirected);

--- a/Blocks/URL/test.cc
+++ b/Blocks/URL/test.cc
@@ -34,113 +34,281 @@ using namespace current::url;
 TEST(URLTest, SmokeTest) {
   URL u;
 
+  // For URLs where no scheme or port is specified in the original string, no scheme or port is stored.
+
+  // WARNING: Browser implementation differs: `www.google.com` is pathname.
   u = URL("www.google.com");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("http://www.google.com/", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `www.google.com/test` is pathname.
   u = URL("www.google.com/test");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/test", u.path);
-  EXPECT_EQ("http", u.scheme);
-  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("http://www.google.com/test", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `443/test` is pathname.
+  u = URL("www.google.com:443");
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(443, u.port);
+  EXPECT_EQ("https://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `8080/test` is pathname.
   u = URL("www.google.com:8080");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
-  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ("", u.scheme);
   EXPECT_EQ(8080, u.port);
+  // Unknown port `8080` falls back to default scheme in `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:8080/", u.ComposeURL());
 
   u = URL("meh://www.google.com:27960");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/", u.path);
   EXPECT_EQ("meh", u.scheme);
   EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("meh://www.google.com:27960/", u.ComposeURL());
 
   u = URL("meh://www.google.com:27960/bazinga");
   EXPECT_EQ("www.google.com", u.host);
   EXPECT_EQ("/bazinga", u.path);
   EXPECT_EQ("meh", u.scheme);
   EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("meh://www.google.com:27960/bazinga", u.ComposeURL());
 
+  // WARNING: Browser implementation differs: `localhost/` is pathname.
   u = URL("localhost/");
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost/test` is pathname.
+  u = URL("localhost/test");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL("localhost:/test");
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+
+  // WARNING: Browser implementation differs: `:1234/test` is assumed pathname.
+  u = URL(":1234/test");
+  EXPECT_EQ("", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(1234, u.port);
+  // NOTE: `ComposeURL` ignores the `port` if `host` is empty.
+  EXPECT_EQ("/test", u.ComposeURL());
+
+  // Can parse a relative URL: `/path-name.ext`.
+  u = URL("/path-name.ext");
+  EXPECT_EQ("", u.host);
+  EXPECT_EQ("/path-name.ext", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(0, u.port);
+  EXPECT_EQ("/path-name.ext", u.ComposeURL());
+
+  // Can parse a protocol-relative URL: `//host.name:80/path`.
+  u = URL("//host.name:80/path");
+  EXPECT_EQ("host.name", u.host);
+  EXPECT_EQ("/path", u.path);
+  EXPECT_EQ("", u.scheme);
+  EXPECT_EQ(80, u.port);
+  // NOTE: `ComposeURL` does not add the leading two slashes if scheme is empty.
+  EXPECT_EQ("http://host.name/path", u.ComposeURL());
+}
+
+TEST(URLTest, MakeURLWithDefaultsTest) {
+  URL u;
+
+  // For URLs where no scheme or port is specified in the original string, no scheme or port is stored.
+
+  // WARNING: Browser implementation differs: `www.google.com` is pathname.
+  u = URL::MakeURLWithDefaults(URL("www.google.com"));
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("http://www.google.com/", u.ComposeURL());
 
-  u = URL("localhost:/");
+  // WARNING: Browser implementation differs: `www.google.com/test` is pathname.
+  u = URL::MakeURLWithDefaults(URL("www.google.com/test"));
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/test", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("http://www.google.com/test", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `443/test` is pathname.
+  u = URL::MakeURLWithDefaults(URL("www.google.com:443"));
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("https", u.scheme);
+  EXPECT_EQ(443, u.port);
+  EXPECT_EQ("https://www.google.com/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `www.google.com` is protocol (scheme), `8080/test` is pathname.
+  u = URL::MakeURLWithDefaults(URL("www.google.com:8080"));
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);  // Unknown port `8080` falls back to default scheme in `MakeURLWithDefaults`.
+  EXPECT_EQ(8080, u.port);
+  EXPECT_EQ("http://www.google.com:8080/", u.ComposeURL());
+
+  u = URL::MakeURLWithDefaults(URL("meh://www.google.com:27960"));
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("meh", u.scheme);
+  EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("meh://www.google.com:27960/", u.ComposeURL());
+
+  u = URL::MakeURLWithDefaults(URL("meh://www.google.com:27960/bazinga"));
+  EXPECT_EQ("www.google.com", u.host);
+  EXPECT_EQ("/bazinga", u.path);
+  EXPECT_EQ("meh", u.scheme);
+  EXPECT_EQ(27960, u.port);
+  EXPECT_EQ("meh://www.google.com:27960/bazinga", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost/` is pathname.
+  u = URL::MakeURLWithDefaults(URL("localhost/"));
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
 
-  u = URL("localhost/test");
+  // WARNING: Browser implementation differs: `localhost/test` is pathname.
+  u = URL::MakeURLWithDefaults(URL("localhost/test"));
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/test", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
+  EXPECT_EQ("http://localhost/test", u.ComposeURL());
 
-  u = URL("localhost:/test");
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL::MakeURLWithDefaults(URL("localhost:/"));
+  EXPECT_EQ("localhost", u.host);
+  EXPECT_EQ("/", u.path);
+  EXPECT_EQ("http", u.scheme);
+  EXPECT_EQ(80, u.port);
+  EXPECT_EQ("http://localhost/", u.ComposeURL());
+
+  // WARNING: Browser implementation differs: `localhost` is protocol (scheme), `/test` is pathname.
+  u = URL::MakeURLWithDefaults(URL("localhost:/test"));
   EXPECT_EQ("localhost", u.host);
   EXPECT_EQ("/test", u.path);
   EXPECT_EQ("http", u.scheme);
   EXPECT_EQ(80, u.port);
 }
 
-TEST(URLTest, CompositionTest) {
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com").ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com:80").ComposeURL());
-  EXPECT_EQ("http://www.google.com:8080/", URL("www.google.com:8080").ComposeURL());
-  EXPECT_EQ("http://www.google.com:8080/", URL("http://www.google.com:8080").ComposeURL());
-  EXPECT_EQ("meh://www.google.com:8080/", URL("meh://www.google.com:8080").ComposeURL());
+TEST(URLTest, ComposeURLHandlesEmptyURLComponents) {
+  // Empty host is allowed in relative URLs.
+  EXPECT_EQ("/second", URL("/second").ComposeURL());
+
+  // With empty host, port is ignored.
+  EXPECT_EQ("/second", URL(":1234/second").ComposeURL());
 }
 
-TEST(URLTest, DerivesSchemeFromPreviousPort) {
-  // Smoke tests for non-default scheme, setting the 2nd parameter to the URL() constructor.
-  EXPECT_EQ("www.google.com/", URL("www.google.com", "").ComposeURL());
-  EXPECT_EQ("telnet://www.google.com:23/", URL("www.google.com", "telnet", "", 23).ComposeURL());
-  // Keeps the scheme if it was explicitly specified, even for the port that maps to a different scheme.
-  EXPECT_EQ("foo://www.google.com:80/", URL("foo://www.google.com", "", "", 80).ComposeURL());
+TEST(URLTest, ComposeURLDerivesSchemeFromPort) {
   // Maps port 80 into "http://".
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com", "", "", 80).ComposeURL());
+  EXPECT_EQ("http://www.google.com/", URL("www.google.com:80").ComposeURL());
+
   // Maps port 443 into "https://".
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com", "", "", 443).ComposeURL());
+  EXPECT_EQ("https://www.google.com/", URL("www.google.com:443").ComposeURL());
+
+  // Since there is no scheme and no rule for port "23", default scheme is used by `ComposeURL`.
+  EXPECT_EQ("http://www.google.com:23/", URL("www.google.com:23").ComposeURL());
+
+  // Keeps the scheme if it was explicitly specified, even for the port that maps to a different scheme.
+  EXPECT_EQ("foo://www.google.com/", URL("foo://www.google.com").ComposeURL());
+  EXPECT_EQ("foo://www.google.com:80/", URL("foo://www.google.com:80").ComposeURL());
+  EXPECT_EQ("http://www.google.com:443/", URL("http://www.google.com:443").ComposeURL());
+
   // Assumes port 80 for "http://".
-  EXPECT_EQ("http://www.google.com:79/", URL("www.google.com", "http", "", 79).ComposeURL());
-  EXPECT_EQ("http://www.google.com/", URL("www.google.com", "http", "", 80).ComposeURL());
-  EXPECT_EQ("http://www.google.com:81/", URL("www.google.com", "http", "", 81).ComposeURL());
+  EXPECT_EQ("http://www.google.com:79/", URL("http://www.google.com:79").ComposeURL());
+  EXPECT_EQ("http://www.google.com/", URL("http://www.google.com:80").ComposeURL());
+  EXPECT_EQ("http://www.google.com:81/", URL("http://www.google.com:81").ComposeURL());
+
   // Assumes port 443 for "https://".
-  EXPECT_EQ("https://www.google.com:442/", URL("www.google.com", "https", "", 442).ComposeURL());
-  EXPECT_EQ("https://www.google.com/", URL("www.google.com", "https", "", 443).ComposeURL());
-  EXPECT_EQ("https://www.google.com:444/", URL("www.google.com", "https", "", 444).ComposeURL());
-  // Since there is no rule from "23" to "telnet", no scheme is specified.
-  EXPECT_EQ("www.google.com:23/", URL("www.google.com", "", "", 23).ComposeURL());
+  EXPECT_EQ("https://www.google.com:442/", URL("https://www.google.com:442").ComposeURL());
+  EXPECT_EQ("https://www.google.com/", URL("https://www.google.com:443").ComposeURL());
+  EXPECT_EQ("https://www.google.com:444/", URL("https://www.google.com:444").ComposeURL());
 }
 
-TEST(URLTest, RedirectPreservesSchemeHostAndPortTest) {
-  EXPECT_EQ("http://localhost/foo", URL("/foo", URL("localhost")).ComposeURL());
-  EXPECT_EQ("meh://localhost/foo", URL("/foo", URL("meh://localhost")).ComposeURL());
-  EXPECT_EQ("http://localhost:8080/foo", URL("/foo", URL("localhost:8080")).ComposeURL());
-  EXPECT_EQ("meh://localhost:8080/foo", URL("/foo", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("meh://localhost:27960/foo", URL(":27960/foo", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("ftp://foo:8080/", URL("ftp://foo", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("ftp://localhost:8080/bar", URL("ftp:///bar", URL("meh://localhost:8080")).ComposeURL());
-  EXPECT_EQ("blah://new_host:5000/foo", URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL());
-  EXPECT_EQ("blah://new_host:6000/foo", URL("blah://new_host:6000/foo", URL("meh://localhost:5000")).ComposeURL());
+TEST(URLTest, MakeRedirectedURLTest) {
+  // Relative URL preserves scheme, host, port.
+  EXPECT_EQ("http://localhost/foo", URL::MakeRedirectedURL(URL("localhost"), "/foo").ComposeURL());
+  EXPECT_EQ("meh://localhost/foo", URL::MakeRedirectedURL(URL("meh://localhost"), "/foo").ComposeURL());
+  EXPECT_EQ("http://localhost:8080/empty_all_with_previous_empty_scheme", URL::MakeRedirectedURL(URL("localhost:8080"), "/empty_all_with_previous_empty_scheme").ComposeURL());
+  EXPECT_EQ("meh://localhost:8080/empty_all_with_previous_full", URL::MakeRedirectedURL(URL("meh://localhost:8080"), "/empty_all_with_previous_full").ComposeURL());
+  EXPECT_EQ("foo://www.website.com:321/second", URL::MakeRedirectedURL(URL("foo://www.website.com:321/first"), "/second").ComposeURL());
+
+  // Port-only full URL replaces port and preserves host from previous URL.
+  EXPECT_EQ("meh://localhost:27960/empty_scheme_host", URL::MakeRedirectedURL(URL("meh://localhost:8080"), ":27960/empty_scheme_host").ComposeURL());
+
+  // Schema-only full URL preserves host and port from previous URL.
+  EXPECT_EQ("ftp://localhost:8080/empty_host", URL::MakeRedirectedURL(URL("meh://localhost:8080"), "ftp:///empty_host").ComposeURL());
+
+  // Full URL replaces scheme, host, port, does not preserve anything from previous URL.
+  EXPECT_EQ("ftp://host_no_port_path/", URL::MakeRedirectedURL(URL("meh://localhost:8080"), "ftp://host_no_port_path").ComposeURL());
+  EXPECT_EQ("blah://new_host/foo", URL::MakeRedirectedURL(URL("meh://localhost:5000"), "blah://new_host/foo").ComposeURL());
+  EXPECT_EQ("blah://new_host:6000/foo", URL::MakeRedirectedURL(URL("meh://localhost:5000"), "blah://new_host:6000/foo").ComposeURL());
+  EXPECT_EQ("https://new_host/foo", URL::MakeRedirectedURL(URL("http://localhost/test"), "https://new_host/foo").ComposeURL());
 }
 
-TEST(URLTest, ExtractsURLParameters) {
+TEST(URLTest, MakeRedirectedURLWithParametersTest) {
+  const auto redirected_url_parsed = URL::MakeRedirectedURL(URL("localhost/?replace=this&and=this"), "/foo?bar=baz&qoo=xdoo");
+  EXPECT_EQ("http://localhost/foo?bar=baz&qoo=xdoo", redirected_url_parsed.ComposeURL());
+  EXPECT_EQ("http://localhost/foo", redirected_url_parsed.ComposeURLWithoutParameters());
+
+  EXPECT_EQ("http://localhost:1234/foo?bar=baz&qoo=xdoo#with-fragment", URL::MakeRedirectedURL(URL("localhost:1234/?replace=this&and=this"), "/foo?bar=baz&qoo=xdoo#with-fragment").ComposeURL());
+
+  const auto redirected_to_full_url_parsed = URL::MakeRedirectedURL(URL("localhost/?replace=this&and=this"), "http://other.domain/foo?bar=baz&qoo=xdoo");
+  EXPECT_EQ("http://other.domain/foo?bar=baz&qoo=xdoo", redirected_to_full_url_parsed.ComposeURL());
+  EXPECT_EQ("http://other.domain/foo", redirected_to_full_url_parsed.ComposeURLWithoutParameters());
+}
+
+TEST(URLTest, ComposeURLWithParametersSmokeTest) {
+  EXPECT_EQ("http://www.google.com/search", URL("www.google.com/search").ComposeURL());
+  EXPECT_EQ("http://www.google.com/search?q=foo#fragment", URL("www.google.com/search?q=foo#fragment").ComposeURL());
+  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar", URL("www.google.com/search?q=foo&q2=bar").ComposeURL());
+  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar#fragment",
+            URL("www.google.com/search?q=foo&q2=bar#fragment").ComposeURL());
+  EXPECT_EQ("http://www.google.com/search#fragment", URL("www.google.com/search#fragment").ComposeURL());
+}
+
+TEST(URLTest, ExtractURLParametersAndComposeURLTest) {
   {
     URL u("www.google.com");
     EXPECT_EQ("", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/", u.ComposeURLWithoutParameters());
   }
   {
     // Fragment is not passed through `DecodeURIComponent`.
@@ -150,29 +318,55 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/a#encoded-fragment-with_unreserved~chars!and%25reserved%3A%5Bchars%5D%2Band%20space", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/a#fragment?foo=bar&baz=meh");
     EXPECT_EQ("fragment?foo=bar&baz=meh", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/a#fragment?foo=bar&baz=meh", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/b#fragment#foo");
     EXPECT_EQ("fragment#foo", u.fragment);
+    EXPECT_FALSE(u.query.has("key"));
     EXPECT_EQ("", u.query["key"]);
     EXPECT_EQ("default_value", u.query.get("key", "default_value"));
     EXPECT_EQ("http://www.google.com/b#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/b", u.ComposeURLWithoutParameters());
+  }
+  {
+    URL u("www.google.com/b?empty");
+    EXPECT_EQ("", u.fragment);
+    EXPECT_TRUE(u.query.has("empty"));
+    EXPECT_EQ("", u.query["empty"]);
+    EXPECT_EQ("", u.query.get("empty", "default_value"));
+    EXPECT_EQ("http://www.google.com/b?empty=", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/b", u.ComposeURLWithoutParameters());
+  }
+  {
+    URL u("www.google.com/b?empty_equals=");
+    EXPECT_EQ("", u.fragment);
+    EXPECT_TRUE(u.query.has("empty_equals"));
+    EXPECT_EQ("", u.query["empty_equals"]);
+    EXPECT_EQ("", u.query.get("empty_equals", "default_value"));
+    EXPECT_EQ("http://www.google.com/b?empty_equals=", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/b", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?key=value&key2=value2#fragment#foo");
     EXPECT_EQ("fragment#foo", u.fragment);
+    EXPECT_TRUE(u.query.has("key"));
     EXPECT_EQ("value", u.query["key"]);
     EXPECT_EQ("value", u.query.get("key", "default_value"));
+    EXPECT_TRUE(u.query.has("key2"));
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("http://www.google.com/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
     const auto& as_map = u.AllQueryParameters();
     EXPECT_EQ(2u, as_map.size());
     const auto key = as_map.find("key");
@@ -190,12 +384,14 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_TRUE(u.query.has("encoded#query-with_unreserved~chars!and%reserved:[chars]plus+and space"));
     EXPECT_EQ("", u.query["encoded#query-with_unreserved~chars!and%reserved:[chars]plus+and space"]);
     EXPECT_EQ("http://www.google.com/a?encoded%23query-with_unreserved~chars!and%25reserved%3A%5Bchars%5Dplus%2Band%20space=#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/a?k=a%3Db%26s%3D%25s%23#foo");
     EXPECT_EQ("foo", u.fragment);
     EXPECT_EQ("a=b&s=%s#", u.query["k"]);
     EXPECT_EQ("http://www.google.com/a?k=a%3Db%26s%3D%25s%23#foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("/q?key=value&key2=value2#fragment#foo");
@@ -205,12 +401,14 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("value2", u.query["key2"]);
     EXPECT_EQ("value2", u.query.get("key2", "default_value"));
     EXPECT_EQ("/q?key=value&key2=value2#fragment#foo", u.ComposeURL());
+    EXPECT_EQ("/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("/a?k=a%3Db%26s%3D%25s%23#foo");
     EXPECT_EQ("foo", u.fragment);
     EXPECT_EQ("a=b&s=%s#", u.query["k"]);
     EXPECT_EQ("/a?k=a%3Db%26s%3D%25s%23#foo", u.ComposeURL());
+    EXPECT_EQ("/a", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?foo=&bar&baz=");
@@ -222,6 +420,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("", u.query["baz"]);
     EXPECT_EQ("", u.query.get("baz", "default_value"));
     EXPECT_EQ("http://www.google.com/q?foo=&bar=&baz=", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?foo=bar=baz");
@@ -229,6 +428,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("bar=baz", u.query["foo"]);
     EXPECT_EQ("bar=baz", u.query.get("foo", "default_value"));
     EXPECT_EQ("http://www.google.com/q?foo=bar%3Dbaz", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q? foo = bar = baz ");
@@ -236,6 +436,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ(" bar = baz ", u.query[" foo "]);
     EXPECT_EQ(" bar = baz ", u.query.get(" foo ", "default_value"));
     EXPECT_EQ("http://www.google.com/q?%20foo%20=%20bar%20%3D%20baz%20", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?1=foo");
@@ -243,6 +444,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("foo", u.query["1"]);
     EXPECT_EQ("foo", u.query.get("1", "default_value"));
     EXPECT_EQ("http://www.google.com/q?1=foo", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?question=forty+two");
@@ -250,6 +452,7 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("forty two", u.query["question"]);
     EXPECT_EQ("forty two", u.query.get("question", "default_value"));
     EXPECT_EQ("http://www.google.com/q?question=forty%20two", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
     URL u("www.google.com/q?%3D+%3D=%3D%3D");
@@ -257,39 +460,40 @@ TEST(URLTest, ExtractsURLParameters) {
     EXPECT_EQ("==", u.query["= ="]);
     EXPECT_EQ("==", u.query.get("= =", "default_value"));
     EXPECT_EQ("http://www.google.com/q?%3D%20%3D=%3D%3D", u.ComposeURL());
+    EXPECT_EQ("http://www.google.com/q", u.ComposeURLWithoutParameters());
   }
   {
-    ASSERT_THROW(URL("?parameters=only"), EmptyURLException);
-    ASSERT_THROW(URL("#fragment-only"), EmptyURLException);
-  }
-  {
-    // The following construct can be used to parse the `application/x-www-form-urlencoded` request body.
+    // The following construct is also used in `ParseFormURLEncodedBody`.
     URL u("/?parameters=only");
-    EXPECT_EQ("http", u.scheme);
+    EXPECT_EQ("", u.scheme);
     EXPECT_EQ("", u.host);
-    EXPECT_EQ(80, u.port);
+    EXPECT_EQ(0, u.port);
     EXPECT_EQ("/", u.path);
     EXPECT_EQ("", u.fragment);
     EXPECT_EQ("only", u.query["parameters"]);
     EXPECT_EQ("/?parameters=only", u.ComposeURL());
+    EXPECT_EQ("/", u.ComposeURLWithoutParameters());
   }
 }
 
-TEST(URLTest, URLParametersCompositionTest) {
-  EXPECT_EQ("http://www.google.com/search", URL("www.google.com/search").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo#fragment", URL("www.google.com/search?q=foo#fragment").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar", URL("www.google.com/search?q=foo&q2=bar").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search?q=foo&q2=bar#fragment",
-            URL("www.google.com/search?q=foo&q2=bar#fragment").ComposeURL());
-  EXPECT_EQ("http://www.google.com/search#fragment", URL("www.google.com/search#fragment").ComposeURL());
+TEST(URLTest, ParseQueryString) {
+  const auto& as_map = URL::ParseQueryString("key=value&key2=value2");
+  EXPECT_EQ(2u, as_map.size());
+  const auto key = as_map.find("key");
+  const auto key2 = as_map.find("key2");
+  const auto key3 = as_map.find("key3");
+  ASSERT_TRUE(key != as_map.end());
+  ASSERT_TRUE(key2 != as_map.end());
+  ASSERT_TRUE(key3 == as_map.end());
+  EXPECT_EQ("value", key->second);
+  EXPECT_EQ("value2", key2->second);
 }
 
 TEST(URLTest, EmptyURLException) {
   // Empty URL should throw.
   ASSERT_THROW(URL(""), EmptyURLException);
-
-  // Empty host is allowed in relative links.
-  EXPECT_EQ("foo://www.website.com:321/second", URL("/second", URL("foo://www.website.com:321/first")).ComposeURL());
+  ASSERT_THROW(URL("?parameters=only"), EmptyURLException);
+  ASSERT_THROW(URL("#fragment-only"), EmptyURLException);
 }
 
 namespace url_test {

--- a/EventCollector/event_collector.h
+++ b/EventCollector/event_collector.h
@@ -89,7 +89,7 @@ class EventCollectorHTTPServer {
                                             std::lock_guard<std::mutex> lock(mutex_);
                                             entry.t = now.count();
                                             entry.m = r.method;
-                                            entry.u = r.url.url_without_parameters;
+                                            entry.u = r.url.ComposeURLWithoutParameters();
                                             entry.q = r.url.AllQueryParameters();
                                             entry.h = r.headers.AsMap();
                                             entry.c = r.headers.CookiesAsString();

--- a/Midichlorians/Server/server.h
+++ b/Midichlorians/Server/server.h
@@ -123,7 +123,7 @@ class MidichloriansHTTPServer {
             return r.url.AllQueryParameters();
           } else if (r.method == "POST") {
             is_allowed_method = true;
-            extracted_q = current::url::impl::URLParametersExtractor("?" + r.body).AllQueryParameters();
+            extracted_q = current::url::URL::ParseQueryString(r.body);
             for (const auto& cit : r.url.AllQueryParameters()) {
               extracted_q.insert(cit);
             }


### PR DESCRIPTION
When a redirect occurs from a URL with a port ("previous URL") to a URL without a port, the port was propagated to the resulting URL and to the "Location" header.
Example:
```
test.cc:156: Failure
Value of: URL("ftp://host_no_port_path", URL("meh://localhost:8080")).ComposeURL()
  Actual: "ftp://host_no_port_path:8080/"
Expected: "ftp://host_no_port_path/"
test.cc:157: Failure
Value of: URL("blah://new_host/foo", URL("meh://localhost:5000")).ComposeURL()
  Actual: "blah://new_host:5000/foo"
Expected: "blah://new_host/foo"
```

The redirect URL transformation logic was implemented in the `URL` class constructor.
It was so multi-purpose (both for redirects and for assigning default values) so that there was no easy way to reason about it when fixing this port propagation issue and keep the rest of test cases green.
The multi-inheritance structure of the `URL` class added more to that spaghetti.
The above led to the decision to simplify the `URL` class public API and internal implementation.
* Removed extra parameters to reduce the API surface that requires support and testing.
* Simplified internal logic (it's still complex and hard to grasp, unfortunately, because we chose to support many partial URL formats and make it smart).
* Made explicit static functions for redirect handling and for filling with default values.
* Simplified `URL` class inheritance, using static functions, not constructors/initializers, to easier propagate data from one to another without a need for a class field (removed `url_without_parameters` field).
* Instead of public `url_without_parameters` field, added `ComposeURLWithoutParameters` method because the field value is hard to keep in sync with the other properties' values (the scheme, host, port).
* Added `ParseQueryString` static function to label that intent where needed (see `Midichlorians/Server/server.h`).

The full stack of the redirect with HTTP server and client cannot be tested with the Current tests setup for now because the spawned servers always use ports and cannot redirect to a URL without a port because `HTTPClient` tries to connect to it. There is a way to test the actual use case: to bind to the port `80`, but this requires root access. I've implemented this test and checked with root access but disabled it with `#if 0` for now.