### PR TITLE
Replication benchmark tweaks.

### DIFF
--- a/Bricks/file/file.h
+++ b/Bricks/file/file.h
@@ -50,6 +50,7 @@ SOFTWARE.
 #include "exceptions.h"
 
 #include "../util/make_scope_guard.h"
+#include "../util/random.h"
 
 namespace current {
 
@@ -126,7 +127,7 @@ struct FileSystem {
   static inline std::string GenTmpFileName() {
 #ifndef CURRENT_WINDOWS
     // TODO(dkorolev): Fix temporary file names generation.
-    return strings::Printf("/tmp/.current-tmp-%08x", rand());
+    return strings::Printf("/tmp/.current-tmp-%08x", random::CSRandomInt(0, ~0));
 #else
     char buffer[L_tmpnam_s];  // NOTE(dkorolev): Changed `[L_tmpnam]` into `[L_tmpnam_s]`, as per
                               // https://msdn.microsoft.com/en-us/library/18x8h1bh.aspx

--- a/Bricks/net/exceptions.h
+++ b/Bricks/net/exceptions.h
@@ -27,6 +27,7 @@ SOFTWARE.
 
 #include "../port.h"
 #include "../exception.h"
+#include "../strings/util.h"
 
 namespace current {
 namespace net {
@@ -53,8 +54,14 @@ struct InvalidSocketException : SocketException {};  // LCOV_EXCL_LINE -- not co
 struct AttemptedToUseMovedAwayConnection : SocketException {};
 struct SocketCreateException : SocketException {};  // LCOV_EXCL_LINE -- not covered by unit tests.
 
-struct ServerSocketException : SocketException {};
-struct SocketBindException : ServerSocketException {};
+struct ServerSocketException : SocketException {
+  using SocketException::SocketException;
+};
+
+struct SocketBindException : ServerSocketException {
+  explicit SocketBindException(uint16_t port) : ServerSocketException(current::ToString(port)) {}
+};
+
 struct SocketListenException : ServerSocketException {};  // LCOV_EXCL_LINE -- not covered by unit tests.
 struct SocketAcceptException : ServerSocketException {};  // LCOV_EXCL_LINE -- not covered by unit tests.
 

--- a/Bricks/net/tcp/impl/posix.h
+++ b/Bricks/net/tcp/impl/posix.h
@@ -440,7 +440,7 @@ class Socket final : public SocketHandle {
     CURRENT_BRICKS_NET_LOG("S%05d bind()+listen() ...\n", static_cast<SOCKET>(socket));
 
     if (::bind(socket, reinterpret_cast<sockaddr*>(&addr_server), sizeof(addr_server)) == static_cast<SOCKET>(-1)) {
-      CURRENT_THROW(SocketBindException());
+      CURRENT_THROW(SocketBindException(port));
     }
 
     CURRENT_BRICKS_NET_LOG("S%05d bind()+listen() : bind() OK\n", static_cast<SOCKET>(socket));


### PR DESCRIPTION
Hi!

On my X1 Carbon, Ubuntu 16.04, `NDEBUG=1` build, confirming more than 3x difference in performance between many small and few large log entries: ~22MBps vs. ~78MBps.

Also tweaked the command line flags and the output format.

Thanks,
Dima 

```
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_server --entry_length 500 --entries_count 1000000 --do_not_remove_autogen_data
Generating /tmp/.current-tmp-dc3f217a with 1000000 entries of 500 bytes each.
Spawning the server on port 8383
The server is up on http://localhost:8383/raw_log


dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ls -lash /tmp/.current-tmp-dc3f217a
514M -rw-rw-r-- 1 dima dima 514M Jun 25 19:33 /tmp/.current-tmp-dc3f217a
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ wc -l /tmp/.current-tmp-dc3f217a
1000001 /tmp/.current-tmp-dc3f217a
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_client 
Connecting to the stream at '127.0.0.1:8383/raw_log' OK.
Subscribing to the stream OK.
Replicated 1000000 of 1000000 entries.
Replication finished, calculating the stats OK.
Seconds	EPS	MBps
20.8448	47973.5	22.8756
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_client 
Connecting to the stream at '127.0.0.1:8383/raw_log' OK.
Subscribing to the stream OK.
Replicated 1000000 of 1000000 entries.
Replication finished, calculating the stats OK.
Seconds	EPS	MBps
22.6533	44143.8	21.0494
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_client 
Connecting to the stream at '127.0.0.1:8383/raw_log' OK.
Subscribing to the stream OK.
Replicated 1000000 of 1000000 entries.
Replication finished, calculating the stats OK.
Seconds	EPS	MBps
21.3851	46761.5	22.2976
```

```
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_server --entry_length 1000000 --entries_count 500 --do_not_remove_autogen_data
Generating /tmp/.current-tmp-0502d72d with 500 entries of 1000000 bytes each.
Spawning the server on port 8383
The server is up on http://localhost:8383/raw_log


dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ls -lash /tmp/.current-tmp-0502d72d
477M -rw-rw-r-- 1 dima dima 477M Jun 25 19:35 /tmp/.current-tmp-0502d72d
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ wc -l /tmp/.current-tmp-0502d72d
501 /tmp/.current-tmp-0502d72d
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_client 
Connecting to the stream at '127.0.0.1:8383/raw_log' OK.
Subscribing to the stream OK.
Replicated 500 of 500 entries.
Replication finished, calculating the stats OK.
Seconds	EPS	MBps
6.05777	82.5386	78.715
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_client 
Connecting to the stream at '127.0.0.1:8383/raw_log' OK.
Subscribing to the stream OK.
Replicated 500 of 500 entries.
Replication finished, calculating the stats OK.
Seconds	EPS	MBps
6.02705	82.9593	79.1161
dima@dima-x1:~/github/C5T/Current/examples/Benchmark/replication@master $ ./.current/replication_client 
Connecting to the stream at '127.0.0.1:8383/raw_log' OK.
Subscribing to the stream OK.
Replicated 500 of 500 entries.
Replication finished, calculating the stats OK.
Seconds	EPS	MBps
6.08605	82.155	78.3492
```