### PR TITLE
TypeSystem: Print empty structs to Markdown, too. Their names need to be documented anyway.

### DIFF
--- a/TypeSystem/Schema/golden/smoke_test_struct.md
+++ b/TypeSystem/Schema/golden/smoke_test_struct.md
@@ -39,6 +39,9 @@
 | `a` | Integer (32-bit signed) |
 
 
+### `Empty`
+_No own fields._
+
 ### `X`
 | **Field** | **Type** | **Description** |
 | ---: | :--- | :--- |

--- a/TypeSystem/Schema/schema.h
+++ b/TypeSystem/Schema/schema.h
@@ -904,12 +904,15 @@ struct LanguageSyntaxImpl<Language::Markdown> final {
       std::ostringstream temporary_os;
       RecursivelyListStructFields(temporary_os, s);
       const std::string fields = temporary_os.str();
+      // Print empty structs to Markdown, too. Their names need to be documented anyway.
+      os_ << "\n### `" << s.CanonicalName() << '`';
+      if (s.super_id != TypeID::CurrentStruct) {
+        os_ << ", extends `" << Value<ReflectedType_Struct>(types_.at(s.super_id)).CanonicalName() << '`';
+      }
       if (!fields.empty()) {
-        os_ << "\n### `" << s.CanonicalName() << '`';
-        if (s.super_id != TypeID::CurrentStruct) {
-          os_ << ", extends `" << Value<ReflectedType_Struct>(types_.at(s.super_id)).CanonicalName() << '`';
-        }
         os_ << "\n| **Field** | **Type** | **Description** |\n| ---: | :--- | :--- |\n" << fields << '\n';
+      } else {
+        os_ << "\n_No own fields._\n";
       }
     }
   };  // struct LanguageSyntax<Language::Markdown>::FullSchemaPrinter


### PR DESCRIPTION
Example application: empty struct which is one of a variant options, e.g. an event payload, the name of the struct defines the event type, so that all the declared types need to be exposed (documented) in Markdown.
