### PR TITLE
Supported "unsafe" iterators in the persisters.

### DIFF
--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -310,12 +310,13 @@ class FilePersister {
       return result;
     }
 
-    void operator++() {
+    Iterator& operator++() {
       if (!valid_) {
         CURRENT_THROW(
             PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
       }
       ++i_;
+      return *this;
     }
     bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
     bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
@@ -375,13 +376,14 @@ class FilePersister {
       return current_entry_;
     }
 
-    void operator++() {
+    IteratorUnsafe& operator++() {
       if (!valid_) {
         CURRENT_THROW(
             PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
       }
       ++i_;
       current_entry_.clear();
+      return *this;
     }
     bool operator==(const IteratorUnsafe& rhs) const { return i_ == rhs.i_; }
     bool operator!=(const IteratorUnsafe& rhs) const { return !operator==(rhs); }

--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -332,10 +332,10 @@ class FilePersister {
   class IteratorUnchecked final {
    public:
     IteratorUnchecked() = delete;
-    IteratorUnchecked(const Iterator&) = delete;
-    IteratorUnchecked(Iterator&&) = default;
-    IteratorUnchecked& operator=(const Iterator&) = delete;
-    IteratorUnchecked& operator=(Iterator&&) = default;
+    IteratorUnchecked(const IteratorUnchecked&) = delete;
+    IteratorUnchecked(IteratorUnchecked&&) = default;
+    IteratorUnchecked& operator=(const IteratorUnchecked&) = delete;
+    IteratorUnchecked& operator=(IteratorUnchecked&&) = default;
 
     IteratorUnchecked(ScopeOwned<FilePersisterImpl>& file_persister_impl,
                       const std::string& filename,
@@ -392,8 +392,8 @@ class FilePersister {
     bool valid_ = true;
     std::unique_ptr<std::ifstream> fi_;
     uint64_t i_;
-    std::string current_entry_;
-    std::streampos current_offset_;
+    mutable std::string current_entry_;
+    mutable std::streampos current_offset_;
   };
 
   template <typename ITERATOR>

--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -270,15 +270,7 @@ class FilePersister {
         : file_persister_impl_(file_persister_impl, [this]() { valid_ = false; }), i_(i) {
       if (!filename.empty()) {
         fi_ = std::make_unique<std::ifstream>(filename);
-        // This `if` condition is only here to test performance with vs. without the `seekg`.
-        // The high performance version jumps to the desired entry right away,
-        // The poor performance one scans the file from the very beginning for each new iterator created.
-        if (true) {
-          cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, offset, index_at_offset);
-        } else {
-          // Inefficient, scan the file from the very beginning.
-          cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, 0, 0);
-        }
+        cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, offset, index_at_offset);
       }
     }
 

--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -249,117 +249,185 @@ class FilePersister {
                          const std::string& filename)
       : file_persister_impl_(mutex_ref, namespace_name, filename) {}
 
-  class IterableRange {
+  class Iterator final {
    public:
-    explicit IterableRange(ScopeOwned<FilePersisterImpl>& file_persister_impl,
-                           uint64_t begin,
-                           uint64_t end,
-                           std::streampos begin_offset)
-        : file_persister_impl_(file_persister_impl, [this]() { valid_ = false; }),
-          begin_(begin),
-          end_(end),
-          begin_offset_(begin_offset) {}
-
     struct Entry {
       idxts_t idx_ts;
       ENTRY entry;
     };
 
-    class Iterator final {
-     public:
-      Iterator() = delete;
-      Iterator(const Iterator&) = delete;
-      Iterator(Iterator&&) = default;
-      Iterator& operator=(const Iterator&) = delete;
-      Iterator& operator=(Iterator&&) = default;
+    Iterator() = delete;
+    Iterator(const Iterator&) = delete;
+    Iterator(Iterator&&) = default;
+    Iterator& operator=(const Iterator&) = delete;
+    Iterator& operator=(Iterator&&) = default;
 
-      Iterator(ScopeOwned<FilePersisterImpl>& file_persister_impl,
-               const std::string& filename,
-               uint64_t i,
-               std::streampos offset,
-               uint64_t index_at_offset)
-          : file_persister_impl_(file_persister_impl, [this]() { valid_ = false; }), i_(i) {
-        if (!filename.empty()) {
-          fi_ = std::make_unique<std::ifstream>(filename);
-          // This `if` condition is only here to test performance with vs. without the `seekg`.
-          // The high performance version jumps to the desired entry right away,
-          // The poor performance one scans the file from the very beginning for each new iterator created.
-          if (true) {
-            cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, offset, index_at_offset);
-          } else {
-            // Inefficient, scan the file from the very beginning.
-            cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, 0, 0);
-          }
+    Iterator(ScopeOwned<FilePersisterImpl>& file_persister_impl,
+             const std::string& filename,
+             uint64_t i,
+             std::streampos offset,
+             uint64_t index_at_offset)
+        : file_persister_impl_(file_persister_impl, [this]() { valid_ = false; }), i_(i) {
+      if (!filename.empty()) {
+        fi_ = std::make_unique<std::ifstream>(filename);
+        // This `if` condition is only here to test performance with vs. without the `seekg`.
+        // The high performance version jumps to the desired entry right away,
+        // The poor performance one scans the file from the very beginning for each new iterator created.
+        if (true) {
+          cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, offset, index_at_offset);
+        } else {
+          // Inefficient, scan the file from the very beginning.
+          cit_ = std::make_unique<IteratorOverFileOfPersistedEntries<ENTRY>>(*fi_, 0, 0);
         }
-      }
-
-      // `operator*` relies on the fact each entry will be requested at most once.
-      // The range-based for-loop works fine. -- D.K.
-      Entry operator*() const {
-        if (!valid_) {
-          CURRENT_THROW(PersistenceFileNoLongerAvailable(
-              file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
-        }
-        Entry result;
-        bool found = false;
-        while (!found) {
-          if (!(cit_->ProcessNextEntry(
-                  [this, &found, &result](const idxts_t& cursor, const char* json) {
-                    if (cursor.index == i_) {
-                      found = true;
-                      result.idx_ts = cursor;
-                      result.entry = ParseJSON<ENTRY>(json);
-                    } else if (cursor.index > i_) {                                     // LCOV_EXCL_LINE
-                      CURRENT_THROW(ss::InconsistentIndexException(i_, cursor.index));  // LCOV_EXCL_LINE
-                    }
-                  },
-                  [](const std::string&) {}))) {
-            // End of file. Should never happen as long as the user only iterates over valid ranges.
-            CURRENT_THROW(current::Exception());  // LCOV_EXCL_LINE
-          }
-        }
-        return result;
-      }
-
-      void operator++() {
-        if (!valid_) {
-          CURRENT_THROW(PersistenceFileNoLongerAvailable(
-              file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
-        }
-        ++i_;
-      }
-      bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
-      bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
-      operator bool() const { return valid_; }
-
-     private:
-      ScopeOwnedBySomeoneElse<FilePersisterImpl> file_persister_impl_;
-      bool valid_ = true;
-      std::unique_ptr<std::ifstream> fi_;
-      std::unique_ptr<IteratorOverFileOfPersistedEntries<ENTRY>> cit_;
-      uint64_t i_;
-    };
-
-    Iterator begin() const {
-      if (!valid_) {
-        CURRENT_THROW(
-            PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
-      }
-      if (begin_ == end_) {
-        return Iterator(file_persister_impl_, "", 0, 0, 0);  // No need in accessing the file for a null iterator.
-      } else {
-        return Iterator(file_persister_impl_, file_persister_impl_->filename, begin_, begin_offset_, begin_);
       }
     }
-    Iterator end() const {
+
+    // `operator*` relies on the fact each entry will be requested at most once.
+    // The range-based for-loop works fine. -- D.K.
+    Entry operator*() const {
+      if (!valid_) {
+        CURRENT_THROW(
+            PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
+      }
+      Entry result;
+      bool found = false;
+      while (!found) {
+        if (!(cit_->ProcessNextEntry(
+                [this, &found, &result](const idxts_t& cursor, const char* json) {
+                  if (cursor.index == i_) {
+                    found = true;
+                    result.idx_ts = cursor;
+                    result.entry = ParseJSON<ENTRY>(json);
+                  } else if (cursor.index > i_) {                                     // LCOV_EXCL_LINE
+                    CURRENT_THROW(ss::InconsistentIndexException(i_, cursor.index));  // LCOV_EXCL_LINE
+                  }
+                },
+                [](const std::string&) {}))) {
+          // End of file. Should never happen as long as the user only iterates over valid ranges.
+          CURRENT_THROW(current::Exception());  // LCOV_EXCL_LINE
+        }
+      }
+      return result;
+    }
+
+    void operator++() {
+      if (!valid_) {
+        CURRENT_THROW(
+            PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
+      }
+      ++i_;
+    }
+    bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
+    bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
+    operator bool() const { return valid_; }
+
+   private:
+    ScopeOwnedBySomeoneElse<FilePersisterImpl> file_persister_impl_;
+    bool valid_ = true;
+    std::unique_ptr<std::ifstream> fi_;
+    std::unique_ptr<IteratorOverFileOfPersistedEntries<ENTRY>> cit_;
+    uint64_t i_;
+  };
+
+  class IteratorUnchecked final {
+   public:
+    IteratorUnchecked() = delete;
+    IteratorUnchecked(const Iterator&) = delete;
+    IteratorUnchecked(Iterator&&) = default;
+    IteratorUnchecked& operator=(const Iterator&) = delete;
+    IteratorUnchecked& operator=(Iterator&&) = default;
+
+    IteratorUnchecked(ScopeOwned<FilePersisterImpl>& file_persister_impl,
+                      const std::string& filename,
+                      uint64_t i,
+                      std::streampos offset,
+                      uint64_t)
+        : file_persister_impl_(file_persister_impl, [this]() { valid_ = false; }), i_(i), current_offset_(offset) {
+      if (!filename.empty()) {
+        fi_ = std::make_unique<std::ifstream>(filename);
+        CURRENT_ASSERT(!fi_->bad());
+        if (offset) {
+          fi_->seekg(offset, std::ios_base::beg);
+        }
+      }
+    }
+
+    // `operator*` relies on the fact each entry will be requested at most once.
+    // The range-based for-loop works fine. -- D.K.
+    std::string operator*() const {
+      if (!valid_) {
+        CURRENT_THROW(
+            PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
+      }
+      if (current_entry_.empty()) {
+        const auto offset = file_persister_impl_->offset[i_];
+        if (offset != current_offset_) {
+          fi_->seekg(offset, std::ios_base::beg);
+          current_offset_ = offset;
+        }
+        if (std::getline(*fi_, current_entry_)) {
+          CURRENT_ASSERT(current_entry_[0] != constants::kDirectiveMarker);
+        } else {
+          // End of file. Should never happen as long as the user only iterates over valid ranges.
+          CURRENT_THROW(current::Exception());  // LCOV_EXCL_LINE
+        }
+      }
+      return current_entry_;
+    }
+
+    void operator++() {
+      if (!valid_) {
+        CURRENT_THROW(
+            PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
+      }
+      ++i_;
+      current_entry_.clear();
+    }
+    bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
+    bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
+    operator bool() const { return valid_; }
+
+   private:
+    ScopeOwnedBySomeoneElse<FilePersisterImpl> file_persister_impl_;
+    bool valid_ = true;
+    std::unique_ptr<std::ifstream> fi_;
+    uint64_t i_;
+    std::string current_entry_;
+    std::streampos current_offset_;
+  };
+
+  template <typename ITERATOR>
+  class IterableRangeImpl {
+   public:
+    explicit IterableRangeImpl(ScopeOwned<FilePersisterImpl>& file_persister_impl,
+                               uint64_t begin,
+                               uint64_t end,
+                               std::streampos begin_offset)
+        : file_persister_impl_(file_persister_impl, [this]() { valid_ = false; }),
+          begin_(begin),
+          end_(end),
+          begin_offset_(begin_offset) {}
+
+    ITERATOR begin() const {
       if (!valid_) {
         CURRENT_THROW(
             PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
       }
       if (begin_ == end_) {
-        return Iterator(file_persister_impl_, "", 0, 0, 0);  // No need in accessing the file for a null iterator.
+        return ITERATOR(file_persister_impl_, "", 0, 0, 0);  // No need in accessing the file for a null iterator.
       } else {
-        return Iterator(
+        return ITERATOR(file_persister_impl_, file_persister_impl_->filename, begin_, begin_offset_, begin_);
+      }
+    }
+    ITERATOR end() const {
+      if (!valid_) {
+        CURRENT_THROW(
+            PersistenceFileNoLongerAvailable(file_persister_impl_.ObjectAccessorDespitePossiblyDestructing().filename));
+      }
+      if (begin_ == end_) {
+        return ITERATOR(file_persister_impl_, "", 0, 0, 0);  // No need in accessing the file for a null iterator.
+      } else {
+        return ITERATOR(
             file_persister_impl_, "", end_, 0, 0);  // No need in accessing the file for a no-op `end` iterator.
       }
     }
@@ -373,6 +441,9 @@ class FilePersister {
     const uint64_t end_;
     const std::streampos begin_offset_;
   };
+
+  using IterableRange = IterableRangeImpl<Iterator>;
+  using IterableRangeUnchecked = IterableRangeImpl<IteratorUnchecked>;
 
   template <current::locks::MutexLockStatus MLS, typename E, typename US>
   idxts_t DoPublish(E&& entry, const US us) {
@@ -510,6 +581,40 @@ class FilePersister {
       return Iterate(index_range.first, index_range.second);
     } else {  // No entries found in the given range.
       return IterableRange(file_persister_impl_, 0, 0, 0);
+    }
+  }
+
+  IterableRangeUnchecked IterateUnchecked(uint64_t begin_index, uint64_t end_index) const {
+    const uint64_t current_size = file_persister_impl_->end.load().next_index;
+    if (end_index == static_cast<uint64_t>(-1)) {
+      end_index = current_size;
+    }
+    if (end_index > current_size) {
+      CURRENT_THROW(InvalidIterableRangeException());
+    }
+    if (begin_index == end_index) {
+      return IterableRangeUnchecked(
+          file_persister_impl_, 0, 0, 0);  // OK, even for an empty persister, where 0 is an invalid index.
+    }
+    if (end_index < begin_index) {
+      CURRENT_THROW(InvalidIterableRangeException());
+    }
+    std::lock_guard<std::mutex> lock(file_persister_impl_->mutex_ref);
+    CURRENT_ASSERT(file_persister_impl_->offset.size() >=
+                   current_size);  // "Greater" is OK, `Iterate()` is multithreaded. -- D.K.
+    return IterableRangeUnchecked(
+        file_persister_impl_, begin_index, end_index, file_persister_impl_->offset[begin_index]);
+  }
+
+  IterableRangeUnchecked IterateUnchecked(std::chrono::microseconds from, std::chrono::microseconds till) const {
+    if (till.count() > 0 && till < from) {
+      CURRENT_THROW(InvalidIterableRangeException());
+    }
+    const auto index_range = IndexRangeByTimestampRange(from, till);
+    if (index_range.first != static_cast<uint64_t>(-1)) {
+      return IterateUnchecked(index_range.first, index_range.second);
+    } else {  // No entries found in the given range.
+      return IterableRangeUnchecked(file_persister_impl_, 0, 0, 0);
     }
   }
 

--- a/Blocks/Persistence/file.h
+++ b/Blocks/Persistence/file.h
@@ -383,8 +383,8 @@ class FilePersister {
       ++i_;
       current_entry_.clear();
     }
-    bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
-    bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
+    bool operator==(const IteratorUnchecked& rhs) const { return i_ == rhs.i_; }
+    bool operator!=(const IteratorUnchecked& rhs) const { return !operator==(rhs); }
     operator bool() const { return valid_; }
 
    private:

--- a/Blocks/Persistence/memory.h
+++ b/Blocks/Persistence/memory.h
@@ -85,11 +85,12 @@ class MemoryPersister {
       std::lock_guard<std::mutex> lock(container_->mutex_ref);
       return Entry(i_, container_->entries[i_]);
     }
-    void operator++() {
+    Iterator& operator++() {
       if (!valid_) {
         CURRENT_THROW(PersistenceMemoryBlockNoLongerAvailable());
       }
       ++i_;
+      return *this;
     }
     bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
     bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
@@ -114,11 +115,12 @@ class MemoryPersister {
       const auto& entry = container_->entries[i_];
       return JSON(idxts_t(i_, entry.first)) + '\t' + JSON(entry.second);
     }
-    void operator++() {
+    IteratorUnsafe& operator++() {
       if (!valid_) {
         CURRENT_THROW(PersistenceMemoryBlockNoLongerAvailable());
       }
       ++i_;
+      return *this;
     }
     bool operator==(const IteratorUnsafe& rhs) const { return i_ == rhs.i_; }
     bool operator!=(const IteratorUnsafe& rhs) const { return !operator==(rhs); }

--- a/Blocks/Persistence/memory.h
+++ b/Blocks/Persistence/memory.h
@@ -106,15 +106,6 @@ class MemoryPersister {
     IteratorUnchecked(ScopeOwned<Container>& container, uint64_t i)
         : container_(container, [this]() { valid_ = false; }), i_(i) {}
 
-    struct Entry {
-      const idxts_t idx_ts;
-      const ENTRY& entry;
-
-      Entry() = delete;
-      Entry(uint64_t index, const std::pair<std::chrono::microseconds, ENTRY>& input)
-          : idx_ts(index, input.first), entry(input.second) {}
-    };
-
     std::string operator*() const {
       if (!valid_) {
         CURRENT_THROW(PersistenceMemoryBlockNoLongerAvailable());
@@ -129,8 +120,8 @@ class MemoryPersister {
       }
       ++i_;
     }
-    bool operator==(const Iterator& rhs) const { return i_ == rhs.i_; }
-    bool operator!=(const Iterator& rhs) const { return !operator==(rhs); }
+    bool operator==(const IteratorUnchecked& rhs) const { return i_ == rhs.i_; }
+    bool operator!=(const IteratorUnchecked& rhs) const { return !operator==(rhs); }
     operator bool() const { return valid_; }
 
    private:

--- a/Blocks/Persistence/test.cc
+++ b/Blocks/Persistence/test.cc
@@ -82,7 +82,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200", Join(first_two, ","));
       std::vector<std::string> first_two_unsafe;
-      for (const auto& e : impl.IterateUnsafe()) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
         first_two_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -102,7 +102,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 300", Join(all_three, ","));
       std::vector<std::string> all_three_unsafe;
-      for (const auto& e : impl.IterateUnsafe()) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
         all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -119,7 +119,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
       std::vector<std::string> just_the_last_one_unsafe;
-      for (const auto& e : impl.IterateUnsafe(2)) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>(2)) {
         just_the_last_one_unsafe.push_back(e);
       }
       EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unsafe, ","));
@@ -132,7 +132,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
       std::vector<std::string> just_the_last_one_unsafe;
-      for (const auto& e : impl.IterateUnsafe(std::chrono::microseconds(300))) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>(std::chrono::microseconds(300))) {
         just_the_last_one_unsafe.push_back(e);
       }
       EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unsafe, ","));
@@ -214,11 +214,14 @@ TEST(PersistenceLayer, MemoryExceptions) {
     impl.Publish("2", std::chrono::microseconds(2));
     impl.Publish("3", std::chrono::microseconds(3));
     ASSERT_THROW(impl.Iterate(1, 0), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnsafe(1, 0), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.Iterate<current::ss::IterationMode::Unsafe>(1, 0),
+                 current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 101), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnsafe(100, 101), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.Iterate<current::ss::IterationMode::Unsafe>(100, 101),
+                 current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 100), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnsafe(100, 100), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.Iterate<current::ss::IterationMode::Unsafe>(100, 100),
+                 current::persistence::InvalidIterableRangeException);
   }
 }
 
@@ -237,7 +240,7 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
 
   {
     auto iterable = p->Iterate();
-    auto iterable_unsafe = p->IterateUnsafe();
+    auto iterable_unsafe = p->Iterate<current::ss::IterationMode::Unsafe>();
     EXPECT_TRUE(static_cast<bool>(iterable));
     EXPECT_TRUE(static_cast<bool>(iterable_unsafe));
     auto iterator = iterable.begin();
@@ -323,7 +326,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200", Join(first_two, ","));
       std::vector<std::string> first_two_unsafe;
-      for (const auto& e : impl.IterateUnsafe()) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
         first_two_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -352,7 +355,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500", Join(all_three, ","));
       std::vector<std::string> all_three_unsafe;
-      for (const auto& e : impl.IterateUnsafe()) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
         all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -389,7 +392,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500", Join(all_three, ","));
       std::vector<std::string> all_three_unsafe;
-      for (const auto& e : impl.IterateUnsafe()) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
         all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -416,7 +419,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500,blah 3 999", Join(all_four, ","));
       std::vector<std::string> all_four_unsafe;
-      for (const auto& e : impl.IterateUnsafe()) {
+      for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
         all_four_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -441,7 +444,7 @@ TEST(PersistenceLayer, File) {
     }
     EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500,blah 3 999", Join(all_four, ","));
     std::vector<std::string> all_four_unsafe;
-    for (const auto& e : impl.IterateUnsafe()) {
+    for (const auto& e : impl.Iterate<current::ss::IterationMode::Unsafe>()) {
       all_four_unsafe.push_back(e);
     }
     EXPECT_EQ(
@@ -630,11 +633,14 @@ TEST(PersistenceLayer, FileExceptions) {
     current::time::SetNow(std::chrono::microseconds(3));
     impl.Publish("3");
     ASSERT_THROW(impl.Iterate(1, 0), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnsafe(1, 0), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.Iterate<current::ss::IterationMode::Unsafe>(1, 0),
+                 current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 101), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnsafe(100, 101), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.Iterate<current::ss::IterationMode::Unsafe>(100, 101),
+                 current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 100), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnsafe(100, 100), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.Iterate<current::ss::IterationMode::Unsafe>(100, 100),
+                 current::persistence::InvalidIterableRangeException);
   }
 }
 
@@ -705,32 +711,36 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
     EXPECT_EQ(0ull, (*impl.Iterate(0, 1).begin()).idx_ts.index);
     EXPECT_EQ(0ll, (*impl.Iterate(0, 1).begin()).idx_ts.us.count());
     EXPECT_EQ("0000000 aaa", (*impl.Iterate(0, 1).begin()).entry.s);
-    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.IterateUnsafe(0, 1).begin()));
+    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}",
+              (*impl.template Iterate<current::ss::IterationMode::Unsafe>(0, 1).begin()));
     EXPECT_EQ(10ull, (*impl.Iterate(10, 11).begin()).idx_ts.index);
     EXPECT_EQ(10000ll, (*impl.Iterate(10, 11).begin()).idx_ts.us.count());
     EXPECT_EQ("0000010 kkkkkk", (*impl.Iterate(10, 11).begin()).entry.s);
-    EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}", (*impl.IterateUnsafe(10, 11).begin()));
+    EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}",
+              (*impl.template Iterate<current::ss::IterationMode::Unsafe>(10, 11).begin()));
     EXPECT_EQ(100ull, (*impl.Iterate(100, 101).begin()).idx_ts.index);
     EXPECT_EQ(100000ll, (*impl.Iterate(100, 101).begin()).idx_ts.us.count());
     EXPECT_EQ("0000100 wwwww", (*impl.Iterate(100, 101).begin()).entry.s);
-    EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}", (*impl.IterateUnsafe(100, 101).begin()));
+    EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}",
+              (*impl.template Iterate<current::ss::IterationMode::Unsafe>(100, 101).begin()));
   }
   {
     // By timestamp.
     EXPECT_EQ(0ull, (*impl.Iterate(us_t(0), us_t(1000)).begin()).idx_ts.index);
     EXPECT_EQ(0ll, (*impl.Iterate(us_t(0), us_t(1000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000000 aaa", (*impl.Iterate(us_t(0), us_t(1000)).begin()).entry.s);
-    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.IterateUnsafe(us_t(0), us_t(1000)).begin()));
+    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}",
+              (*impl.template Iterate<current::ss::IterationMode::Unsafe>(us_t(0), us_t(1000)).begin()));
     EXPECT_EQ(10ull, (*impl.Iterate(us_t(10000), us_t(11000)).begin()).idx_ts.index);
     EXPECT_EQ(10000ll, (*impl.Iterate(us_t(10000), us_t(11000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000010 kkkkkk", (*impl.Iterate(us_t(10000), us_t(11000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}",
-              (*impl.IterateUnsafe(us_t(10000), us_t(11000)).begin()));
+              (*impl.template Iterate<current::ss::IterationMode::Unsafe>(us_t(10000), us_t(11000)).begin()));
     EXPECT_EQ(100ull, (*impl.Iterate(us_t(100000), us_t(101000)).begin()).idx_ts.index);
     EXPECT_EQ(100000ll, (*impl.Iterate(us_t(100000), us_t(101000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000100 wwwww", (*impl.Iterate(us_t(100000), us_t(101000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}",
-              (*impl.IterateUnsafe(us_t(100000), us_t(101000)).begin()));
+              (*impl.template Iterate<current::ss::IterationMode::Unsafe>(us_t(100000), us_t(101000)).begin()));
   }
 
   // Perftest the creation of a large number of iterators.
@@ -739,7 +749,7 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
   for (int i = 0; i < N; ++i) {
     const auto cit = impl.Iterate(i, i + 1).begin();
     const auto& e = *cit;
-    const auto cit_unsafe = impl.IterateUnsafe(i, i + 1).begin();
+    const auto cit_unsafe = impl.template Iterate<current::ss::IterationMode::Unsafe>(i, i + 1).begin();
     const auto& e_unsafe = *cit_unsafe;
     EXPECT_EQ(JSON(e.idx_ts), JSON((*impl.Iterate(us_t(i * 1000), us_t((i + 1) * 1000)).begin()).idx_ts));
     EXPECT_EQ(static_cast<uint64_t>(i), e.idx_ts.index);
@@ -799,7 +809,7 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
 
   {
     auto iterable = p->Iterate();
-    auto iterable_unsafe = p->IterateUnsafe();
+    auto iterable_unsafe = p->Iterate<current::ss::IterationMode::Unsafe>();
     EXPECT_TRUE(static_cast<bool>(iterable));
     EXPECT_TRUE(static_cast<bool>(iterable_unsafe));
     auto iterator = iterable.begin();

--- a/Blocks/Persistence/test.cc
+++ b/Blocks/Persistence/test.cc
@@ -81,14 +81,14 @@ TEST(PersistenceLayer, Memory) {
             "%s %d %d", e.entry.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
       }
       EXPECT_EQ("foo 0 100,bar 1 200", Join(first_two, ","));
-      std::vector<std::string> first_two_unchecked;
-      for (const auto& e : impl.IterateUnchecked()) {
-        first_two_unchecked.push_back(e);
+      std::vector<std::string> first_two_unsafe;
+      for (const auto& e : impl.IterateUnsafe()) {
+        first_two_unsafe.push_back(e);
       }
       EXPECT_EQ(
           "{\"index\":0,\"us\":100}\t\"foo\","
           "{\"index\":1,\"us\":200}\t\"bar\"",
-          Join(first_two_unchecked, ","));
+          Join(first_two_unsafe, ","));
     }
 
     impl.Publish("meh");
@@ -101,15 +101,15 @@ TEST(PersistenceLayer, Memory) {
             "%s %d %d", e.entry.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 300", Join(all_three, ","));
-      std::vector<std::string> all_three_unchecked;
-      for (const auto& e : impl.IterateUnchecked()) {
-        all_three_unchecked.push_back(e);
+      std::vector<std::string> all_three_unsafe;
+      for (const auto& e : impl.IterateUnsafe()) {
+        all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
           "{\"index\":0,\"us\":100}\t\"foo\","
           "{\"index\":1,\"us\":200}\t\"bar\","
           "{\"index\":2,\"us\":300}\t\"meh\"",
-          Join(all_three_unchecked, ","));
+          Join(all_three_unsafe, ","));
     }
 
     {
@@ -118,11 +118,11 @@ TEST(PersistenceLayer, Memory) {
         just_the_last_one.push_back(e.entry);
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
-      std::vector<std::string> just_the_last_one_unchecked;
-      for (const auto& e : impl.IterateUnchecked(2)) {
-        just_the_last_one_unchecked.push_back(e);
+      std::vector<std::string> just_the_last_one_unsafe;
+      for (const auto& e : impl.IterateUnsafe(2)) {
+        just_the_last_one_unsafe.push_back(e);
       }
-      EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unchecked, ","));
+      EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unsafe, ","));
     }
 
     {
@@ -131,11 +131,11 @@ TEST(PersistenceLayer, Memory) {
         just_the_last_one.push_back(e.entry);
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
-      std::vector<std::string> just_the_last_one_unchecked;
-      for (const auto& e : impl.IterateUnchecked(std::chrono::microseconds(300))) {
-        just_the_last_one_unchecked.push_back(e);
+      std::vector<std::string> just_the_last_one_unsafe;
+      for (const auto& e : impl.IterateUnsafe(std::chrono::microseconds(300))) {
+        just_the_last_one_unsafe.push_back(e);
       }
-      EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unchecked, ","));
+      EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unsafe, ","));
     }
   }
 
@@ -214,11 +214,11 @@ TEST(PersistenceLayer, MemoryExceptions) {
     impl.Publish("2", std::chrono::microseconds(2));
     impl.Publish("3", std::chrono::microseconds(3));
     ASSERT_THROW(impl.Iterate(1, 0), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnchecked(1, 0), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.IterateUnsafe(1, 0), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 101), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnchecked(100, 101), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.IterateUnsafe(100, 101), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 100), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnchecked(100, 100), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.IterateUnsafe(100, 100), current::persistence::InvalidIterableRangeException);
   }
 }
 
@@ -237,15 +237,15 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
 
   {
     auto iterable = p->Iterate();
-    auto iterable_unchecked = p->IterateUnchecked();
+    auto iterable_unsafe = p->IterateUnsafe();
     EXPECT_TRUE(static_cast<bool>(iterable));
-    EXPECT_TRUE(static_cast<bool>(iterable_unchecked));
+    EXPECT_TRUE(static_cast<bool>(iterable_unsafe));
     auto iterator = iterable.begin();
-    auto iterator_unchecked = iterable_unchecked.begin();
+    auto iterator_unsafe = iterable_unsafe.begin();
     EXPECT_TRUE(static_cast<bool>(iterator));
-    EXPECT_TRUE(static_cast<bool>(iterator_unchecked));
+    EXPECT_TRUE(static_cast<bool>(iterator_unsafe));
     EXPECT_EQ("1", (*iterator).entry);
-    EXPECT_EQ("{\"index\":0,\"us\":1}\t\"1\"", *iterator_unchecked);
+    EXPECT_EQ("{\"index\":0,\"us\":1}\t\"1\"", *iterator_unsafe);
 
     t = std::thread([&p]() {
       // Release the persister. Well, begin to, as this "call" would block until the iterators are done.
@@ -257,7 +257,7 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
       std::mutex mutex;
       while (true) {
         std::lock_guard<std::mutex> lock(mutex);
-        if (!iterator && !iterator_unchecked) {
+        if (!iterator && !iterator_unsafe) {
           break;
         }
         std::this_thread::yield();
@@ -266,15 +266,15 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
 
     ASSERT_THROW(*iterator, current::persistence::PersistenceMemoryBlockNoLongerAvailable);
     ASSERT_THROW(++iterator, current::persistence::PersistenceMemoryBlockNoLongerAvailable);
-    ASSERT_THROW(*iterator_unchecked, current::persistence::PersistenceMemoryBlockNoLongerAvailable);
-    ASSERT_THROW(++iterator_unchecked, current::persistence::PersistenceMemoryBlockNoLongerAvailable);
+    ASSERT_THROW(*iterator_unsafe, current::persistence::PersistenceMemoryBlockNoLongerAvailable);
+    ASSERT_THROW(++iterator_unsafe, current::persistence::PersistenceMemoryBlockNoLongerAvailable);
 
     // Spin lock, and w/o a mutex it would hang with `NDEBUG=1`.
     {
       std::mutex mutex;
       while (true) {
         std::lock_guard<std::mutex> lock(mutex);
-        if (!iterable && !iterable_unchecked) {
+        if (!iterable && !iterable_unsafe) {
           break;
         }
         std::this_thread::yield();
@@ -283,8 +283,8 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
 
     ASSERT_THROW(iterable.begin(), current::persistence::PersistenceMemoryBlockNoLongerAvailable);
     ASSERT_THROW(iterable.end(), current::persistence::PersistenceMemoryBlockNoLongerAvailable);
-    ASSERT_THROW(iterable_unchecked.begin(), current::persistence::PersistenceMemoryBlockNoLongerAvailable);
-    ASSERT_THROW(iterable_unchecked.end(), current::persistence::PersistenceMemoryBlockNoLongerAvailable);
+    ASSERT_THROW(iterable_unsafe.begin(), current::persistence::PersistenceMemoryBlockNoLongerAvailable);
+    ASSERT_THROW(iterable_unsafe.end(), current::persistence::PersistenceMemoryBlockNoLongerAvailable);
   }
 
   t.join();
@@ -322,14 +322,14 @@ TEST(PersistenceLayer, File) {
             "%s %d %d", e.entry.s.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
       }
       EXPECT_EQ("foo 0 100,bar 1 200", Join(first_two, ","));
-      std::vector<std::string> first_two_unchecked;
-      for (const auto& e : impl.IterateUnchecked()) {
-        first_two_unchecked.push_back(e);
+      std::vector<std::string> first_two_unsafe;
+      for (const auto& e : impl.IterateUnsafe()) {
+        first_two_unsafe.push_back(e);
       }
       EXPECT_EQ(
           "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"},"
           "{\"index\":1,\"us\":200}\t{\"s\":\"bar\"}",
-          Join(first_two_unchecked, ","));
+          Join(first_two_unsafe, ","));
     }
 
     current::time::SetNow(std::chrono::microseconds(500));
@@ -351,15 +351,15 @@ TEST(PersistenceLayer, File) {
             "%s %d %d", e.entry.s.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500", Join(all_three, ","));
-      std::vector<std::string> all_three_unchecked;
-      for (const auto& e : impl.IterateUnchecked()) {
-        all_three_unchecked.push_back(e);
+      std::vector<std::string> all_three_unsafe;
+      for (const auto& e : impl.IterateUnsafe()) {
+        all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
           "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"},"
           "{\"index\":1,\"us\":200}\t{\"s\":\"bar\"},"
           "{\"index\":2,\"us\":500}\t{\"s\":\"meh\"}",
-          Join(all_three_unchecked, ","));
+          Join(all_three_unsafe, ","));
     }
   }
 
@@ -388,15 +388,15 @@ TEST(PersistenceLayer, File) {
             "%s %d %d", e.entry.s.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500", Join(all_three, ","));
-      std::vector<std::string> all_three_unchecked;
-      for (const auto& e : impl.IterateUnchecked()) {
-        all_three_unchecked.push_back(e);
+      std::vector<std::string> all_three_unsafe;
+      for (const auto& e : impl.IterateUnsafe()) {
+        all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
           "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"},"
           "{\"index\":1,\"us\":200}\t{\"s\":\"bar\"},"
           "{\"index\":2,\"us\":500}\t{\"s\":\"meh\"}",
-          Join(all_three_unchecked, ","));
+          Join(all_three_unsafe, ","));
     }
 
     current::time::SetNow(std::chrono::microseconds(998));
@@ -415,16 +415,16 @@ TEST(PersistenceLayer, File) {
             "%s %d %d", e.entry.s.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500,blah 3 999", Join(all_four, ","));
-      std::vector<std::string> all_four_unchecked;
-      for (const auto& e : impl.IterateUnchecked()) {
-        all_four_unchecked.push_back(e);
+      std::vector<std::string> all_four_unsafe;
+      for (const auto& e : impl.IterateUnsafe()) {
+        all_four_unsafe.push_back(e);
       }
       EXPECT_EQ(
           "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"},"
           "{\"index\":1,\"us\":200}\t{\"s\":\"bar\"},"
           "{\"index\":2,\"us\":500}\t{\"s\":\"meh\"},"
           "{\"index\":3,\"us\":999}\t{\"s\":\"blah\"}",
-          Join(all_four_unchecked, ","));
+          Join(all_four_unsafe, ","));
     }
   }
 
@@ -440,16 +440,16 @@ TEST(PersistenceLayer, File) {
           "%s %d %d", e.entry.s.c_str(), static_cast<int>(e.idx_ts.index), static_cast<int>(e.idx_ts.us.count())));
     }
     EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500,blah 3 999", Join(all_four, ","));
-    std::vector<std::string> all_four_unchecked;
-    for (const auto& e : impl.IterateUnchecked()) {
-      all_four_unchecked.push_back(e);
+    std::vector<std::string> all_four_unsafe;
+    for (const auto& e : impl.IterateUnsafe()) {
+      all_four_unsafe.push_back(e);
     }
     EXPECT_EQ(
         "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"},"
         "{\"index\":1,\"us\":200}\t{\"s\":\"bar\"},"
         "{\"index\":2,\"us\":500}\t{\"s\":\"meh\"},"
         "{\"index\":3,\"us\":999}\t{\"s\":\"blah\"}",
-        Join(all_four_unchecked, ","));
+        Join(all_four_unsafe, ","));
   }
 }
 
@@ -630,11 +630,11 @@ TEST(PersistenceLayer, FileExceptions) {
     current::time::SetNow(std::chrono::microseconds(3));
     impl.Publish("3");
     ASSERT_THROW(impl.Iterate(1, 0), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnchecked(1, 0), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.IterateUnsafe(1, 0), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 101), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnchecked(100, 101), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.IterateUnsafe(100, 101), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 100), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(impl.IterateUnchecked(100, 100), current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW(impl.IterateUnsafe(100, 100), current::persistence::InvalidIterableRangeException);
   }
 }
 
@@ -705,32 +705,32 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
     EXPECT_EQ(0ull, (*impl.Iterate(0, 1).begin()).idx_ts.index);
     EXPECT_EQ(0ll, (*impl.Iterate(0, 1).begin()).idx_ts.us.count());
     EXPECT_EQ("0000000 aaa", (*impl.Iterate(0, 1).begin()).entry.s);
-    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.IterateUnchecked(0, 1).begin()));
+    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.IterateUnsafe(0, 1).begin()));
     EXPECT_EQ(10ull, (*impl.Iterate(10, 11).begin()).idx_ts.index);
     EXPECT_EQ(10000ll, (*impl.Iterate(10, 11).begin()).idx_ts.us.count());
     EXPECT_EQ("0000010 kkkkkk", (*impl.Iterate(10, 11).begin()).entry.s);
-    EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}", (*impl.IterateUnchecked(10, 11).begin()));
+    EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}", (*impl.IterateUnsafe(10, 11).begin()));
     EXPECT_EQ(100ull, (*impl.Iterate(100, 101).begin()).idx_ts.index);
     EXPECT_EQ(100000ll, (*impl.Iterate(100, 101).begin()).idx_ts.us.count());
     EXPECT_EQ("0000100 wwwww", (*impl.Iterate(100, 101).begin()).entry.s);
-    EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}", (*impl.IterateUnchecked(100, 101).begin()));
+    EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}", (*impl.IterateUnsafe(100, 101).begin()));
   }
   {
     // By timestamp.
     EXPECT_EQ(0ull, (*impl.Iterate(us_t(0), us_t(1000)).begin()).idx_ts.index);
     EXPECT_EQ(0ll, (*impl.Iterate(us_t(0), us_t(1000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000000 aaa", (*impl.Iterate(us_t(0), us_t(1000)).begin()).entry.s);
-    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.IterateUnchecked(us_t(0), us_t(1000)).begin()));
+    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.IterateUnsafe(us_t(0), us_t(1000)).begin()));
     EXPECT_EQ(10ull, (*impl.Iterate(us_t(10000), us_t(11000)).begin()).idx_ts.index);
     EXPECT_EQ(10000ll, (*impl.Iterate(us_t(10000), us_t(11000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000010 kkkkkk", (*impl.Iterate(us_t(10000), us_t(11000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}",
-              (*impl.IterateUnchecked(us_t(10000), us_t(11000)).begin()));
+              (*impl.IterateUnsafe(us_t(10000), us_t(11000)).begin()));
     EXPECT_EQ(100ull, (*impl.Iterate(us_t(100000), us_t(101000)).begin()).idx_ts.index);
     EXPECT_EQ(100000ll, (*impl.Iterate(us_t(100000), us_t(101000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000100 wwwww", (*impl.Iterate(us_t(100000), us_t(101000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}",
-              (*impl.IterateUnchecked(us_t(100000), us_t(101000)).begin()));
+              (*impl.IterateUnsafe(us_t(100000), us_t(101000)).begin()));
   }
 
   // Perftest the creation of a large number of iterators.
@@ -739,15 +739,15 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
   for (int i = 0; i < N; ++i) {
     const auto cit = impl.Iterate(i, i + 1).begin();
     const auto& e = *cit;
-    const auto cit_unchecked = impl.IterateUnchecked(i, i + 1).begin();
-    const auto& e_unchecked = *cit_unchecked;
+    const auto cit_unsafe = impl.IterateUnsafe(i, i + 1).begin();
+    const auto& e_unsafe = *cit_unsafe;
     EXPECT_EQ(JSON(e.idx_ts), JSON((*impl.Iterate(us_t(i * 1000), us_t((i + 1) * 1000)).begin()).idx_ts));
     EXPECT_EQ(static_cast<uint64_t>(i), e.idx_ts.index);
     EXPECT_EQ(static_cast<int64_t>(i * 1000), e.idx_ts.us.count());
     EXPECT_EQ(LargeTestStorableString(i).s, e.entry.s);
     EXPECT_EQ(JSON((*impl.Iterate(us_t(i * 1000), us_t((i + 1) * 1000)).begin()).idx_ts) + '\t' +
                   JSON(LargeTestStorableString(i)),
-              e_unchecked);
+              e_unsafe);
   }
 }
 
@@ -799,15 +799,15 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
 
   {
     auto iterable = p->Iterate();
-    auto iterable_unchecked = p->IterateUnchecked();
+    auto iterable_unsafe = p->IterateUnsafe();
     EXPECT_TRUE(static_cast<bool>(iterable));
-    EXPECT_TRUE(static_cast<bool>(iterable_unchecked));
+    EXPECT_TRUE(static_cast<bool>(iterable_unsafe));
     auto iterator = iterable.begin();
-    auto iterator_unchecked = iterable_unchecked.begin();
+    auto iterator_unsafe = iterable_unsafe.begin();
     EXPECT_TRUE(static_cast<bool>(iterator));
-    EXPECT_TRUE(static_cast<bool>(iterator_unchecked));
+    EXPECT_TRUE(static_cast<bool>(iterator_unsafe));
     EXPECT_EQ("1", (*iterator).entry);
-    EXPECT_EQ("{\"index\":0,\"us\":1}\t\"1\"", *iterator_unchecked);
+    EXPECT_EQ("{\"index\":0,\"us\":1}\t\"1\"", *iterator_unsafe);
 
     t = std::thread([&p]() {
       // Release the persister. Well, begin to, as this "call" would block until the iterators are done.
@@ -819,7 +819,7 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
       std::mutex aux_mutex;
       while (true) {
         std::lock_guard<std::mutex> lock(aux_mutex);
-        if (!iterator && !iterator_unchecked) {
+        if (!iterator && !iterator_unsafe) {
           break;
         }
         std::this_thread::yield();
@@ -828,15 +828,15 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
 
     ASSERT_THROW(*iterator, current::persistence::PersistenceFileNoLongerAvailable);
     ASSERT_THROW(++iterator, current::persistence::PersistenceFileNoLongerAvailable);
-    ASSERT_THROW(*iterator_unchecked, current::persistence::PersistenceFileNoLongerAvailable);
-    ASSERT_THROW(++iterator_unchecked, current::persistence::PersistenceFileNoLongerAvailable);
+    ASSERT_THROW(*iterator_unsafe, current::persistence::PersistenceFileNoLongerAvailable);
+    ASSERT_THROW(++iterator_unsafe, current::persistence::PersistenceFileNoLongerAvailable);
 
     // Spin lock, and w/o a mutex it would hang with `NDEBUG=1`.
     {
       std::mutex aux_mutex;
       while (true) {
         std::lock_guard<std::mutex> lock(aux_mutex);
-        if (!iterable && !iterable_unchecked) {
+        if (!iterable && !iterable_unsafe) {
           break;
         }
         std::this_thread::yield();
@@ -845,8 +845,8 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
 
     ASSERT_THROW(iterable.begin(), current::persistence::PersistenceFileNoLongerAvailable);
     ASSERT_THROW(iterable.end(), current::persistence::PersistenceFileNoLongerAvailable);
-    ASSERT_THROW(iterable_unchecked.begin(), current::persistence::PersistenceFileNoLongerAvailable);
-    ASSERT_THROW(iterable_unchecked.end(), current::persistence::PersistenceFileNoLongerAvailable);
+    ASSERT_THROW(iterable_unsafe.begin(), current::persistence::PersistenceFileNoLongerAvailable);
+    ASSERT_THROW(iterable_unsafe.end(), current::persistence::PersistenceFileNoLongerAvailable);
   }
 
   t.join();

--- a/Blocks/Persistence/test.cc
+++ b/Blocks/Persistence/test.cc
@@ -101,6 +101,11 @@ TEST(PersistenceLayer, Memory) {
         just_the_last_one.push_back(e.entry);
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
+      std::vector<std::string> just_the_last_one_unchecked;
+      for (const auto& e : impl.IterateUnchecked(2)) {
+        just_the_last_one_unchecked.push_back(e);
+      }
+      EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unchecked, ","));
     }
 
     {
@@ -109,6 +114,11 @@ TEST(PersistenceLayer, Memory) {
         just_the_last_one.push_back(e.entry);
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
+      std::vector<std::string> just_the_last_one_unchecked;
+      for (const auto& e : impl.IterateUnchecked(std::chrono::microseconds(300))) {
+        just_the_last_one_unchecked.push_back(e);
+      }
+      EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unchecked, ","));
     }
   }
 

--- a/Blocks/SS/persister.h
+++ b/Blocks/SS/persister.h
@@ -108,8 +108,12 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
     return IMPL::Iterate(from, std::chrono::microseconds(-1));
   }
   IterableRange Iterate() const { return IMPL::Iterate(0, static_cast<uint64_t>(-1)); }
-  IterableRangeUnchecked IterateUnchecked(uint64_t begin, uint64_t end) const { return IMPL::Iterate(begin, end); }
-  IterableRangeUnchecked IterateUnchecked(uint64_t begin) const { return IMPL::Iterate(begin, static_cast<uint64_t>(-1)); }
+  IterableRangeUnchecked IterateUnchecked(uint64_t begin, uint64_t end) const {
+    return IMPL::IterateUnchecked(begin, end);
+  }
+  IterableRangeUnchecked IterateUnchecked(uint64_t begin) const {
+    return IMPL::IterateUnchecked(begin, static_cast<uint64_t>(-1));
+  }
   IterableRangeUnchecked IterateUnchecked(std::chrono::microseconds from, std::chrono::microseconds till) const {
     return IMPL::IterateUnchecked(from, till);
   }

--- a/Blocks/SS/persister.h
+++ b/Blocks/SS/persister.h
@@ -96,7 +96,7 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
     return IMPL::IndexRangeByTimestampRange(from, till);
   }
   using IterableRange = typename IMPL::IterableRange;
-  using IterableRangeUnchecked = typename IMPL::IterableRangeUnchecked;
+  using IterableRangeUnsafe = typename IMPL::IterableRangeUnsafe;
 
   // NOTE: `IMPL::Iterate()` may throw.
   IterableRange Iterate(uint64_t begin, uint64_t end) const { return IMPL::Iterate(begin, end); }
@@ -108,19 +108,19 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
     return IMPL::Iterate(from, std::chrono::microseconds(-1));
   }
   IterableRange Iterate() const { return IMPL::Iterate(0, static_cast<uint64_t>(-1)); }
-  IterableRangeUnchecked IterateUnchecked(uint64_t begin, uint64_t end) const {
-    return IMPL::IterateUnchecked(begin, end);
+  IterableRangeUnsafe IterateUnsafe(uint64_t begin, uint64_t end) const {
+    return IMPL::IterateUnsafe(begin, end);
   }
-  IterableRangeUnchecked IterateUnchecked(uint64_t begin) const {
-    return IMPL::IterateUnchecked(begin, static_cast<uint64_t>(-1));
+  IterableRangeUnsafe IterateUnsafe(uint64_t begin) const {
+    return IMPL::IterateUnsafe(begin, static_cast<uint64_t>(-1));
   }
-  IterableRangeUnchecked IterateUnchecked(std::chrono::microseconds from, std::chrono::microseconds till) const {
-    return IMPL::IterateUnchecked(from, till);
+  IterableRangeUnsafe IterateUnsafe(std::chrono::microseconds from, std::chrono::microseconds till) const {
+    return IMPL::IterateUnsafe(from, till);
   }
-  IterableRangeUnchecked IterateUnchecked(std::chrono::microseconds from) const {
-    return IMPL::IterateUnchecked(from, std::chrono::microseconds(-1));
+  IterableRangeUnsafe IterateUnsafe(std::chrono::microseconds from) const {
+    return IMPL::IterateUnsafe(from, std::chrono::microseconds(-1));
   }
-  IterableRangeUnchecked IterateUnchecked() const { return IMPL::IterateUnchecked(0, static_cast<uint64_t>(-1)); }
+  IterableRangeUnsafe IterateUnsafe() const { return IMPL::IterateUnsafe(0, static_cast<uint64_t>(-1)); }
 };
 
 // For `static_assert`-s.

--- a/Blocks/SS/persister.h
+++ b/Blocks/SS/persister.h
@@ -96,6 +96,7 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
     return IMPL::IndexRangeByTimestampRange(from, till);
   }
   using IterableRange = typename IMPL::IterableRange;
+  using IterableRangeUnchecked = typename IMPL::IterableRangeUnchecked;
 
   // NOTE: `IMPL::Iterate()` may throw.
   IterableRange Iterate(uint64_t begin, uint64_t end) const { return IMPL::Iterate(begin, end); }
@@ -107,6 +108,15 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
     return IMPL::Iterate(from, std::chrono::microseconds(-1));
   }
   IterableRange Iterate() const { return IMPL::Iterate(0, static_cast<uint64_t>(-1)); }
+  IterableRangeUnchecked IterateUnchecked(uint64_t begin, uint64_t end) const { return IMPL::Iterate(begin, end); }
+  IterableRangeUnchecked IterateUnchecked(uint64_t begin) const { return IMPL::Iterate(begin, static_cast<uint64_t>(-1)); }
+  IterableRangeUnchecked IterateUnchecked(std::chrono::microseconds from, std::chrono::microseconds till) const {
+    return IMPL::IterateUnchecked(from, till);
+  }
+  IterableRangeUnchecked IterateUnchecked(std::chrono::microseconds from) const {
+    return IMPL::IterateUnchecked(from, std::chrono::microseconds(-1));
+  }
+  IterableRangeUnchecked IterateUnchecked() const { return IMPL::IterateUnchecked(0, static_cast<uint64_t>(-1)); }
 };
 
 // For `static_assert`-s.

--- a/Blocks/SS/persister.h
+++ b/Blocks/SS/persister.h
@@ -34,6 +34,8 @@ SOFTWARE.
 namespace current {
 namespace ss {
 
+enum class IterationMode : bool { Safe = true, Unsafe = false };
+
 struct GenericPersister {};
 
 template <typename ENTRY>
@@ -95,32 +97,25 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
                                                            std::chrono::microseconds till) const {
     return IMPL::IndexRangeByTimestampRange(from, till);
   }
-  using IterableRange = typename IMPL::IterableRange;
-  using IterableRangeUnsafe = typename IMPL::IterableRangeUnsafe;
+
+  template <IterationMode IM>
+  using IterableRange = typename IMPL::template IterableRange<IM>;
 
   // NOTE: `IMPL::Iterate()` may throw.
-  IterableRange Iterate(uint64_t begin, uint64_t end) const { return IMPL::Iterate(begin, end); }
-  IterableRange Iterate(uint64_t begin) const { return IMPL::Iterate(begin, static_cast<uint64_t>(-1)); }
-  IterableRange Iterate(std::chrono::microseconds from, std::chrono::microseconds till) const {
-    return IMPL::Iterate(from, till);
+  template <IterationMode IM = IterationMode::Safe>
+  IterableRange<IM> Iterate(uint64_t begin, uint64_t end) const { return IMPL::template Iterate<IM>(begin, end); }
+  template <IterationMode IM = IterationMode::Safe>
+  IterableRange<IM> Iterate(uint64_t begin) const { return IMPL::template Iterate<IM>(begin, static_cast<uint64_t>(-1)); }
+  template <IterationMode IM = IterationMode::Safe>
+  IterableRange<IM> Iterate(std::chrono::microseconds from, std::chrono::microseconds till) const {
+    return IMPL::template Iterate<IM>(from, till);
   }
-  IterableRange Iterate(std::chrono::microseconds from) const {
-    return IMPL::Iterate(from, std::chrono::microseconds(-1));
+  template <IterationMode IM = IterationMode::Safe>
+  IterableRange<IM> Iterate(std::chrono::microseconds from) const {
+    return IMPL::template Iterate<IM>(from, std::chrono::microseconds(-1));
   }
-  IterableRange Iterate() const { return IMPL::Iterate(0, static_cast<uint64_t>(-1)); }
-  IterableRangeUnsafe IterateUnsafe(uint64_t begin, uint64_t end) const {
-    return IMPL::IterateUnsafe(begin, end);
-  }
-  IterableRangeUnsafe IterateUnsafe(uint64_t begin) const {
-    return IMPL::IterateUnsafe(begin, static_cast<uint64_t>(-1));
-  }
-  IterableRangeUnsafe IterateUnsafe(std::chrono::microseconds from, std::chrono::microseconds till) const {
-    return IMPL::IterateUnsafe(from, till);
-  }
-  IterableRangeUnsafe IterateUnsafe(std::chrono::microseconds from) const {
-    return IMPL::IterateUnsafe(from, std::chrono::microseconds(-1));
-  }
-  IterableRangeUnsafe IterateUnsafe() const { return IMPL::IterateUnsafe(0, static_cast<uint64_t>(-1)); }
+  template <IterationMode IM = IterationMode::Safe>
+  IterableRange<IM> Iterate() const { return IMPL::template Iterate<IM>(0, static_cast<uint64_t>(-1)); }
 };
 
 // For `static_assert`-s.


### PR DESCRIPTION
Iterate the data in the file persister in an "unsafe" way
Questions:
1. Do we need fake "unsafe" iterators for the `MemoryPersister`? Or is it better just leave them unimplemented?
2. If we would use `Chunk` instead of `std::string` as the result of the `operator*` and store last few lines of the file inside the iterator cache, how could we guarantee that the specific `Chunk` doesn't outlive the iterator which produce it?