### PR TITLE
TypeSystem: Fix missing include for std::function failing compilation on Arch Linux.

### DIFF
--- a/TypeSystem/Schema/schema.h
+++ b/TypeSystem/Schema/schema.h
@@ -31,6 +31,7 @@ SOFTWARE.
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <functional>
 
 #include "json_schema_format.h"
 


### PR DESCRIPTION
Discovered by @d-oliveros on Arch Linux where the newer C++ (GCC 7.1.1? clang 4?) was installed out-of-the-box. Downgrading clang to 3.8 to compile Current-based code was required, but not enough: the error about namespace `std` missing `function` was reported from files using `TypeSystem/Schema/schema.h`.
