### PR TITLE
scripts/individual-tests.sh: Close the terminal color tag before starting a slow operation.

### DIFF
--- a/scripts/individual-tests.sh
+++ b/scripts/individual-tests.sh
@@ -8,8 +8,7 @@ FAILURES=""
 
 for i in $(find . -name test.cc | sort -g) ; do
   DIR=$(dirname $i)
-  echo -e -n "\n\033[0m\033[1mDir\033[0m: \033[36m"
-  echo $DIR
+  echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m${DIR}\033[0m"
   cd $DIR
   if ! make -s test ; then
     FAILURES="$FAILURES\n- $DIR"


### PR DESCRIPTION
- Ensure the terminal color is reset before starting a slow operation which may be interrupted (e.g. with Ctrl+C SIGINT).
- Output a colored line in one command, not in three.

#### Before
<img width="591" alt="screen shot 2017-07-13 at 3 18 40 am" src="https://user-images.githubusercontent.com/498274/28161913-2dbc5500-677a-11e7-8fbd-23e33c18f1d0.png">

#### After
<img width="559" alt="screen shot 2017-07-13 at 3 19 30 am" src="https://user-images.githubusercontent.com/498274/28161920-36882f88-677a-11e7-838c-706116225c1f.png">
