### PR TITLE
scripts/individual-tests.sh: Exclude filter for the batch test run.

### DIFF
--- a/scripts/individual-tests.sh
+++ b/scripts/individual-tests.sh
@@ -8,8 +8,7 @@ FAILURES=""
 
 for i in $(find . -name test.cc | sort -g) ; do
   DIR=$(dirname $i)
-  echo -e -n "\n\033[0m\033[1mDir\033[0m: \033[36m"
-  echo $DIR
+  echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m${DIR}\033[0m"
   cd $DIR
   if ! make -s test ; then
     FAILURES="$FAILURES\n- $DIR"

--- a/scripts/individual-tests.sh
+++ b/scripts/individual-tests.sh
@@ -6,14 +6,21 @@ set -u -e
 
 FAILURES=""
 
+# A space-separated list of relative paths to exclude from the test run. Example: "./Blocks/HTTP ./Blocks/MMQ".
+EXCLUDE=("")
+
 for i in $(find . -name test.cc | sort -g) ; do
   DIR=$(dirname $i)
   echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m${DIR}\033[0m"
-  cd $DIR
-  if ! make -s test ; then
-    FAILURES="$FAILURES\n- $DIR"
+  if [[ " ${EXCLUDE[@]} " =~ " $DIR " ]]; then
+    echo "Excluded.";
+  else
+    cd $DIR
+    if ! make -s test ; then
+      FAILURES="$FAILURES\n- $DIR"
+    fi
+    cd - >/dev/null
   fi
-  cd - >/dev/null
 done
 
 if [ "$FAILURES" = "" ] ; then


### PR DESCRIPTION
- Useful when tracking the tests which may implicitly affect each other.

_Includes https://github.com/C5T/Current/pull/765 to avoid merge conflicts on adjacent lines._
