### PR TITLE
Got rid of the `IterationMode` template arguments.

### DIFF
--- a/blocks/persistence/test.cc
+++ b/blocks/persistence/test.cc
@@ -83,8 +83,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200", Join(first_two, ","));
       std::vector<std::string> first_two_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+      for (const auto& e : impl.IterateUnsafe()) {
         first_two_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -104,8 +103,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 300", Join(all_three, ","));
       std::vector<std::string> all_three_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+      for (const auto& e : impl.IterateUnsafe()) {
         all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -122,8 +120,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
       std::vector<std::string> just_the_last_one_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(2)) {
+      for (const auto& e : impl.IterateUnsafe(2)) {
         just_the_last_one_unsafe.push_back(e);
       }
       EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unsafe, ","));
@@ -136,9 +133,7 @@ TEST(PersistenceLayer, Memory) {
       }
       EXPECT_EQ("meh", Join(just_the_last_one, ","));
       std::vector<std::string> just_the_last_one_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-               std::chrono::microseconds(300))) {
+      for (const auto& e : impl.IterateUnsafe(std::chrono::microseconds(300))) {
         just_the_last_one_unsafe.push_back(e);
       }
       EXPECT_EQ("{\"index\":2,\"us\":300}\t\"meh\"", Join(just_the_last_one_unsafe, ","));
@@ -220,17 +215,11 @@ TEST(PersistenceLayer, MemoryExceptions) {
     impl.Publish("2", std::chrono::microseconds(2));
     impl.Publish("3", std::chrono::microseconds(3));
     ASSERT_THROW(impl.Iterate(1, 0), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(
-        (impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(1, 0)),
-        current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW((impl.template IterateUnsafe(1, 0)), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 101), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(
-        (impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(100, 101)),
-        current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW((impl.IterateUnsafe(100, 101)), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 100), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(
-        (impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(100, 100)),
-        current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW((impl.IterateUnsafe(100, 100)), current::persistence::InvalidIterableRangeException);
   }
 }
 
@@ -249,8 +238,7 @@ TEST(PersistenceLayer, MemoryIteratorCanNotOutliveMemoryBlock) {
 
   {
     auto iterable = p->Iterate();
-    auto iterable_unsafe =
-        p->Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>();
+    auto iterable_unsafe = p->IterateUnsafe();
     EXPECT_TRUE(static_cast<bool>(iterable));
     EXPECT_TRUE(static_cast<bool>(iterable_unsafe));
     auto iterator = iterable.begin();
@@ -332,8 +320,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200", Join(first_two, ","));
       std::vector<std::string> first_two_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+      for (const auto& e : impl.IterateUnsafe()) {
         first_two_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -362,8 +349,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500", Join(all_three, ","));
       std::vector<std::string> all_three_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+      for (const auto& e : impl.IterateUnsafe()) {
         all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -400,8 +386,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500", Join(all_three, ","));
       std::vector<std::string> all_three_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+      for (const auto& e : impl.IterateUnsafe()) {
         all_three_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -428,8 +413,7 @@ TEST(PersistenceLayer, File) {
       }
       EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500,blah 3 999", Join(all_four, ","));
       std::vector<std::string> all_four_unsafe;
-      for (const auto& e :
-           impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+      for (const auto& e : impl.IterateUnsafe()) {
         all_four_unsafe.push_back(e);
       }
       EXPECT_EQ(
@@ -454,8 +438,7 @@ TEST(PersistenceLayer, File) {
     }
     EXPECT_EQ("foo 0 100,bar 1 200,meh 2 500,blah 3 999", Join(all_four, ","));
     std::vector<std::string> all_four_unsafe;
-    for (const auto& e :
-         impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+    for (const auto& e : impl.IterateUnsafe()) {
       all_four_unsafe.push_back(e);
     }
     EXPECT_EQ(
@@ -644,16 +627,11 @@ TEST(PersistenceLayer, FileExceptions) {
     current::time::SetNow(std::chrono::microseconds(3));
     impl.Publish("3");
     ASSERT_THROW(impl.Iterate(1, 0), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW((impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(1, 0)),
-                 current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW((impl.IterateUnsafe(1, 0)), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 101), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(
-        (impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(100, 101)),
-        current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW((impl.IterateUnsafe(100, 101)), current::persistence::InvalidIterableRangeException);
     ASSERT_THROW(impl.Iterate(100, 100), current::persistence::InvalidIterableRangeException);
-    ASSERT_THROW(
-        (impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(100, 100)),
-        current::persistence::InvalidIterableRangeException);
+    ASSERT_THROW((impl.IterateUnsafe(100, 100)), current::persistence::InvalidIterableRangeException);
   }
 }
 
@@ -730,8 +708,7 @@ TEST(PersistenceLayer, FileSafeVsUnsafeIterators) {
 
   const auto GetUnsafeIterationResult = [&]() -> std::string {
     std::string combined_result;
-    for (const auto& e :
-         impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>()) {
+    for (const auto& e : impl.IterateUnsafe()) {
       combined_result += e + '\n';
     }
     return combined_result;
@@ -766,14 +743,10 @@ TEST(PersistenceLayer, FileSafeVsUnsafeIterators) {
     EXPECT_THROW(*impl.Iterate(1, 2).begin(), current::ss::InconsistentIndexException);
     EXPECT_THROW(*impl.Iterate().begin(), current::ss::InconsistentIndexException);
     EXPECT_THROW(*(++impl.Iterate().begin()), current::ss::InconsistentIndexException);
-    EXPECT_NO_THROW(
-        (*impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(0, 1).begin()));
-    EXPECT_NO_THROW(
-        (*impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(1, 2).begin()));
-    EXPECT_NO_THROW(
-        (*impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>().begin()));
-    EXPECT_NO_THROW(
-        (*(++impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>().begin())));
+    EXPECT_NO_THROW((*impl.IterateUnsafe(0, 1).begin()));
+    EXPECT_NO_THROW((*impl.IterateUnsafe(1, 2).begin()));
+    EXPECT_NO_THROW((*impl.IterateUnsafe().begin()));
+    EXPECT_NO_THROW((*(++impl.IterateUnsafe().begin())));
     EXPECT_EQ(
         "{\"index\":1,\"us\":200}\t{\"s\":\"bar\"}\n"
         "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"}\n"
@@ -790,10 +763,8 @@ TEST(PersistenceLayer, FileSafeVsUnsafeIterators) {
     // Check that "safe" iterators throw the MalformedEntryException while "unsafe" ones don't.
     EXPECT_THROW(*(++(impl.Iterate().begin())), current::persistence::MalformedEntryException);
     EXPECT_THROW(*impl.Iterate(1, 2).begin(), current::persistence::MalformedEntryException);
-    EXPECT_NO_THROW(
-        (*impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(1, 2).begin()));
-    EXPECT_NO_THROW(
-        (*(++impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>().begin())));
+    EXPECT_NO_THROW((*impl.IterateUnsafe(1, 2).begin()));
+    EXPECT_NO_THROW((*(++impl.IterateUnsafe().begin())));
     EXPECT_EQ(
         "{\"index\":0,\"us\":100}\t{\"s\":\"foo\"}\n"
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
@@ -814,8 +785,7 @@ TEST(PersistenceLayer, FileSafeVsUnsafeIterators) {
     // Check that "safe" iterators throw the InvalidJSONException while "unsafe" ones don't.
     EXPECT_THROW(*impl.Iterate(0, 1).begin(), current::serialization::json::InvalidJSONException);
     EXPECT_THROW(*impl.Iterate().begin(), current::serialization::json::InvalidJSONException);
-    EXPECT_NO_THROW(
-        (*impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(0, 1).begin()));
+    EXPECT_NO_THROW((*impl.IterateUnsafe(0, 1).begin()));
     EXPECT_EQ(
         "BBBBBBBBBBBBBBBBBBBB\t{\"s\":\"foo\"}\n"
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
@@ -835,8 +805,7 @@ TEST(PersistenceLayer, FileSafeVsUnsafeIterators) {
 
     // Check that "safe" iterators throw the InvalidJSONException while "unsafe" ones don't.
     EXPECT_THROW(*impl.Iterate(2, 3).begin(), current::serialization::json::InvalidJSONException);
-    EXPECT_NO_THROW(
-        (*impl.Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(2, 3).begin()));
+    EXPECT_NO_THROW((*impl.IterateUnsafe(2, 3).begin()));
     EXPECT_EQ(
         "BBBBBBBBBBBBBBBBBBBB\t{\"s\":\"foo\"}\n"
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
@@ -872,21 +841,17 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
     EXPECT_EQ(0ull, (*impl.Iterate(0, 1).begin()).idx_ts.index);
     EXPECT_EQ(0ll, (*impl.Iterate(0, 1).begin()).idx_ts.us.count());
     EXPECT_EQ("0000000 aaa", (*impl.Iterate(0, 1).begin()).entry.s);
-    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}",
-              (*impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-                         0, 1).begin()));
+    EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}", (*impl.template IterateUnsafe(0, 1).begin()));
     EXPECT_EQ(10ull, (*impl.Iterate(10, 11).begin()).idx_ts.index);
     EXPECT_EQ(10000ll, (*impl.Iterate(10, 11).begin()).idx_ts.us.count());
     EXPECT_EQ("0000010 kkkkkk", (*impl.Iterate(10, 11).begin()).entry.s);
     EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}",
-              (*impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-                         10, 11).begin()));
+              (*impl.template IterateUnsafe(10, 11).begin()));
     EXPECT_EQ(100ull, (*impl.Iterate(100, 101).begin()).idx_ts.index);
     EXPECT_EQ(100000ll, (*impl.Iterate(100, 101).begin()).idx_ts.us.count());
     EXPECT_EQ("0000100 wwwww", (*impl.Iterate(100, 101).begin()).entry.s);
     EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}",
-              (*impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-                         100, 101).begin()));
+              (*impl.template IterateUnsafe(100, 101).begin()));
   }
   {
     // By timestamp.
@@ -894,20 +859,17 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
     EXPECT_EQ(0ll, (*impl.Iterate(us_t(0), us_t(1000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000000 aaa", (*impl.Iterate(us_t(0), us_t(1000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":0,\"us\":0}\t{\"s\":\"0000000 aaa\"}",
-              (*impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-                         us_t(0), us_t(1000)).begin()));
+              (*impl.template IterateUnsafe(us_t(0), us_t(1000)).begin()));
     EXPECT_EQ(10ull, (*impl.Iterate(us_t(10000), us_t(11000)).begin()).idx_ts.index);
     EXPECT_EQ(10000ll, (*impl.Iterate(us_t(10000), us_t(11000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000010 kkkkkk", (*impl.Iterate(us_t(10000), us_t(11000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":10,\"us\":10000}\t{\"s\":\"0000010 kkkkkk\"}",
-              (*impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-                         us_t(10000), us_t(11000)).begin()));
+              (*impl.template IterateUnsafe(us_t(10000), us_t(11000)).begin()));
     EXPECT_EQ(100ull, (*impl.Iterate(us_t(100000), us_t(101000)).begin()).idx_ts.index);
     EXPECT_EQ(100000ll, (*impl.Iterate(us_t(100000), us_t(101000)).begin()).idx_ts.us.count());
     EXPECT_EQ("0000100 wwwww", (*impl.Iterate(us_t(100000), us_t(101000)).begin()).entry.s);
     EXPECT_EQ("{\"index\":100,\"us\":100000}\t{\"s\":\"0000100 wwwww\"}",
-              (*impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(
-                         us_t(100000), us_t(101000)).begin()));
+              (*impl.template IterateUnsafe(us_t(100000), us_t(101000)).begin()));
   }
 
   // Perftest the creation of a large number of iterators.
@@ -916,9 +878,7 @@ void IteratorPerformanceTest(IMPL& impl, bool publish = true) {
   for (int i = 0; i < N; ++i) {
     const auto cit = impl.Iterate(i, i + 1).begin();
     const auto& e = *cit;
-    const auto cit_unsafe =
-        impl.template Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>(i, i + 1)
-            .begin();
+    const auto cit_unsafe = impl.template IterateUnsafe(i, i + 1).begin();
     const auto& e_unsafe = *cit_unsafe;
     EXPECT_EQ(JSON(e.idx_ts), JSON((*impl.Iterate(us_t(i * 1000), us_t((i + 1) * 1000)).begin()).idx_ts));
     EXPECT_EQ(static_cast<uint64_t>(i), e.idx_ts.index);
@@ -978,8 +938,7 @@ TEST(PersistenceLayer, FileIteratorCanNotOutliveFile) {
 
   {
     auto iterable = p->Iterate();
-    auto iterable_unsafe =
-        p->Iterate<current::locks::MutexLockStatus::NeedToLock, current::ss::IterationMode::Unsafe>();
+    auto iterable_unsafe = p->IterateUnsafe();
     EXPECT_TRUE(static_cast<bool>(iterable));
     EXPECT_TRUE(static_cast<bool>(iterable_unsafe));
     auto iterator = iterable.begin();

--- a/blocks/ss/persister.h
+++ b/blocks/ss/persister.h
@@ -116,16 +116,17 @@ class EntryPersister : public GenericEntryPersister<ENTRY>, public IMPL {
   }
 
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
-  IterableRangeUnsafe IterateUnsafe(uint64_t begin = static_cast<uint64_t>(0), uint64_t end = static_cast<size_t>(-1)) const {
+  IterableRangeUnsafe IterateUnsafe(uint64_t begin = static_cast<uint64_t>(0),
+                                    uint64_t end = static_cast<size_t>(-1)) const {
     return IMPL::template PersisterIterateUnsafe<MLS>(begin, end);
   }
 
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
   IterableRange Iterate(std::chrono::microseconds from,
-                            std::chrono::microseconds till = std::chrono::microseconds(-1)) const {
+                        std::chrono::microseconds till = std::chrono::microseconds(-1)) const {
     return IMPL::template PersisterIterate<MLS>(from, till);
   }
-  
+
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock>
   IterableRangeUnsafe IterateUnsafe(std::chrono::microseconds from,
                                     std::chrono::microseconds till = std::chrono::microseconds(-1)) const {


### PR DESCRIPTION
Iterate<MLS, IM> -> Iterate\<MLS> + IterateUnsafe\<MLS>
PersisterIterateImpl<MLS, IM> -> PersisterIterate\<MLS> + PersisterIterateUnsafe\<MLS>