### PR TITLE
Unsafe stream subscription

### DIFF
--- a/blocks/ss/pubsub.h
+++ b/blocks/ss/pubsub.h
@@ -126,8 +126,8 @@ class EntrySubscriber : public GenericEntrySubscriber<ENTRY>, public IMPL {
   virtual ~EntrySubscriber() {}
 
   EntryResponse operator()(const ENTRY& e, idxts_t current, idxts_t last) { return IMPL::operator()(e, current, last); }
-  EntryResponse operator()(const std::string& entry_json, uint64_t current_index, uint64_t last_index) {
-    return IMPL::operator()(entry_json, current_index, last_index);
+  EntryResponse operator()(const std::string& entry_json, uint64_t current_index, idxts_t last) {
+    return IMPL::operator()(entry_json, current_index, last);
   }
   EntryResponse operator()(ENTRY&& e, idxts_t current, idxts_t last) {
     return IMPL::operator()(std::move(e), current, last);

--- a/blocks/ss/pubsub.h
+++ b/blocks/ss/pubsub.h
@@ -126,6 +126,9 @@ class EntrySubscriber : public GenericEntrySubscriber<ENTRY>, public IMPL {
   virtual ~EntrySubscriber() {}
 
   EntryResponse operator()(const ENTRY& e, idxts_t current, idxts_t last) { return IMPL::operator()(e, current, last); }
+  EntryResponse operator()(const std::string& entry_json, uint64_t current_index, uint64_t last_index) {
+    return IMPL::operator()(entry_json, current_index, last_index);
+  }
   EntryResponse operator()(ENTRY&& e, idxts_t current, idxts_t last) {
     return IMPL::operator()(std::move(e), current, last);
   }

--- a/blocks/ss/pubsub.h
+++ b/blocks/ss/pubsub.h
@@ -70,6 +70,11 @@ class EntryPublisher : public GenericEntryPublisher<ENTRY>, public IMPL {
   }
 
   template <MutexLockStatus MLS = MutexLockStatus::NeedToLock>
+  idxts_t PublishUnsafe(const std::string& entry_json) {
+    return IMPL::template PublisherPublishUnsafeImpl<MLS>(entry_json);
+  }
+
+  template <MutexLockStatus MLS = MutexLockStatus::NeedToLock>
   void UpdateHead() {
     IMPL::template PublisherUpdateHeadImpl<MLS>(current::time::DefaultTimeArgument());
   }

--- a/examples/benchmark/replication/replication_client.cc
+++ b/examples/benchmark/replication/replication_client.cc
@@ -67,9 +67,11 @@ void Replicate(ARGS&&... args) {
   {
     std::cerr << "Subscribing to the stream ..." << std::flush;
     const std::chrono::milliseconds print_delay(500);
-	  const auto subscriber_scope = FLAGS_use_safe_replication
-		? (current::stream::SubscriberScope)remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription)
-		: (current::stream::SubscriberScope)remote_stream.SubscribeUnsafe(*replicator, 0, FLAGS_use_checked_subscription);
+    const auto subscriber_scope =
+        FLAGS_use_safe_replication
+            ? (current::stream::SubscriberScope)remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription)
+            : (current::stream::SubscriberScope)remote_stream.SubscribeUnsafe(
+                  *replicator, 0, FLAGS_use_checked_subscription);
     std::cerr << "\b\b\bOK" << std::endl;
     auto next_print_time = start_time + print_delay;
     while (replicated_stream->Data()->Size() < records_to_replicate) {

--- a/examples/benchmark/replication/replication_client.cc
+++ b/examples/benchmark/replication/replication_client.cc
@@ -67,11 +67,11 @@ void Replicate(ARGS&&... args) {
   {
     std::cerr << "Subscribing to the stream ..." << std::flush;
     const std::chrono::milliseconds print_delay(500);
-    const auto subscriber_scope =
-        FLAGS_use_safe_replication
-            ? (current::stream::SubscriberScope)remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription)
-            : (current::stream::SubscriberScope)remote_stream.SubscribeUnsafe(
-                  *replicator, 0, FLAGS_use_checked_subscription);
+    const auto subscriber_scope = FLAGS_use_safe_replication
+                                      ? static_cast<current::stream::SubscriberScope>(
+                                            remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription))
+                                      : static_cast<current::stream::SubscriberScope>(remote_stream.SubscribeUnsafe(
+                                            *replicator, 0, FLAGS_use_checked_subscription));
     std::cerr << "\b\b\bOK" << std::endl;
     auto next_print_time = start_time + print_delay;
     while (replicated_stream->Data()->Size() < records_to_replicate) {

--- a/examples/benchmark/replication/replication_client.cc
+++ b/examples/benchmark/replication/replication_client.cc
@@ -36,6 +36,7 @@ DEFINE_uint64(total_entries, 0, "If set, the maximum number of entries to replic
 DEFINE_double(seconds, 0, "If set, the maximum number of seconds to run the benchmark for.");
 DEFINE_bool(do_not_remove_replicated_data, false, "Set to not remove the data file.");
 DEFINE_bool(use_checked_subscription, false, "Set to use checked subscription for the replication");
+DEFINE_bool(use_safe_replication, false, "Set to use \"safe\" (checked) replication");
 
 inline std::chrono::microseconds FastNow() {
   return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch());
@@ -66,7 +67,9 @@ void Replicate(ARGS&&... args) {
   {
     std::cerr << "Subscribing to the stream ..." << std::flush;
     const std::chrono::milliseconds print_delay(500);
-    const auto subscriber_scope = remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription);
+	  const auto subscriber_scope = FLAGS_use_safe_replication
+		? (current::stream::SubscriberScope)remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription)
+		: (current::stream::SubscriberScope)remote_stream.SubscribeUnsafe(*replicator, 0, FLAGS_use_checked_subscription);
     std::cerr << "\b\b\bOK" << std::endl;
     auto next_print_time = start_time + print_delay;
     while (replicated_stream->Data()->Size() < records_to_replicate) {

--- a/examples/benchmark/replication/replication_client.cc
+++ b/examples/benchmark/replication/replication_client.cc
@@ -35,6 +35,7 @@ DEFINE_string(replicated_stream_data_filename,
 DEFINE_uint64(total_entries, 0, "If set, the maximum number of entries to replicate.");
 DEFINE_double(seconds, 0, "If set, the maximum number of seconds to run the benchmark for.");
 DEFINE_bool(do_not_remove_replicated_data, false, "Set to not remove the data file.");
+DEFINE_bool(use_checked_subscription, false, "Set to use checked subscription for the replication");
 
 inline std::chrono::microseconds FastNow() {
   return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch());
@@ -65,7 +66,7 @@ void Replicate(ARGS&&... args) {
   {
     std::cerr << "Subscribing to the stream ..." << std::flush;
     const std::chrono::milliseconds print_delay(500);
-    const auto subscriber_scope = remote_stream.Subscribe(*replicator);
+    const auto subscriber_scope = remote_stream.Subscribe(*replicator, 0, FLAGS_use_checked_subscription);
     std::cerr << "\b\b\bOK" << std::endl;
     auto next_print_time = start_time + print_delay;
     while (replicated_stream->Data()->Size() < records_to_replicate) {

--- a/stream/pubsub.h
+++ b/stream/pubsub.h
@@ -358,12 +358,12 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
       }
       if (serving_) {
         const std::string response_data = [this, &entry_json]() {
-            if (!params_.entries_only) {
-              return entry_json;
-            } else {
-              const auto tab_pos = entry_json.find('\t');
-              return tab_pos != std::string::npos ? entry_json.substr(tab_pos + 1) : entry_json;
-            }
+          if (!params_.entries_only) {
+            return entry_json;
+          } else {
+            const auto tab_pos = entry_json.find('\t');
+            return tab_pos != std::string::npos ? entry_json.substr(tab_pos + 1) : entry_json;
+          }
         }() + '\n';
         current_response_size_ += response_data.length();
         try {

--- a/stream/pubsub.h
+++ b/stream/pubsub.h
@@ -340,7 +340,7 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
     return result;
   }
 
-  ss::EntryResponse operator()(const std::string& entry_json, uint64_t current_index, uint64_t last_index) {
+  ss::EntryResponse operator()(const std::string& entry_json, uint64_t current_index, idxts_t last) {
     const ss::EntryResponse result = [&, this]() {
       if (time_to_terminate_) {
         return ss::EntryResponse::Done;
@@ -348,11 +348,11 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
       // TODO(dkorolev): Should we always extract the timestamp and throw an exception if there is a mismatch?
       if (!serving_) {
         if (current_index >= params_.i &&                                           // Respect `i`.
-            (params_.tail == 0u || (last_index - current_index) < params_.tail)) {  // Respect `tail`.
+            (params_.tail == 0u || (last.index - current_index) < params_.tail)) {  // Respect `tail`.
           serving_ = true;
         }
         // Reached the end, didn't started serving and should not wait.
-        if (!serving_ && current_index == last_index && params_.no_wait) {
+        if (!serving_ && current_index == last.index && params_.no_wait) {
           return ss::EntryResponse::Done;
         }
       }
@@ -391,7 +391,7 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
           }
         }
         // Respect `no_wait`.
-        if (current_index == last_index && params_.no_wait) {
+        if (current_index == last.index && params_.no_wait) {
           return ss::EntryResponse::Done;
         }
       }

--- a/stream/pubsub.h
+++ b/stream/pubsub.h
@@ -158,6 +158,8 @@ struct ParsedHTTPRequestParams {
   bool entries_only = false;
   // If set, wrap the entries into a large JSON array. Mostly to please JSON-beautifying browser extensions.
   bool array = false;
+  // If set, use "safe" iteration to check the entries before sending.
+  bool checked = false;
 };
 
 inline ParsedHTTPRequestParams ParsePubSubHTTPRequest(const Request& r) {
@@ -218,6 +220,9 @@ inline ParsedHTTPRequestParams ParsePubSubHTTPRequest(const Request& r) {
   if (r.url.query.has("array")) {
     result.array = true;
     result.entries_only = true;  // Obviously, `array` implies `entries_only`.
+  }
+  if (r.url.query.has("checked")) {
+    result.checked = true;
   }
 
   return result;
@@ -320,6 +325,65 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
         }
         // Respect `no_wait`.
         if (current.index == last.index && params_.no_wait) {
+          return ss::EntryResponse::Done;
+        }
+      }
+      return ss::EntryResponse::More;
+    }();
+    if (result == ss::EntryResponse::Done && params_.array) {
+      if (!output_started_) {
+        http_response_("[]\n");
+      } else {
+        http_response_("]\n");
+      }
+    }
+    return result;
+  }
+
+  ss::EntryResponse operator()(const std::string& entry_json, uint64_t current_index, uint64_t last_index) {
+    const ss::EntryResponse result = [&, this]() {
+      if (time_to_terminate_) {
+        return ss::EntryResponse::Done;
+      }
+      // TODO(dkorolev): Should we always extract the timestamp and throw an exception if there is a mismatch?
+      if (!serving_) {
+        if (current_index >= params_.i &&                                           // Respect `i`.
+            (params_.tail == 0u || (last_index - current_index) < params_.tail)) {  // Respect `tail`.
+          serving_ = true;
+        }
+        // Reached the end, didn't started serving and should not wait.
+        if (!serving_ && current_index == last_index && params_.no_wait) {
+          return ss::EntryResponse::Done;
+        }
+      }
+      if (serving_) {
+        current_response_size_ += entry_json.length() + 1; // `\n`
+        try {
+          if (params_.array) {
+            if (!output_started_) {
+              http_response_("[\n");
+              output_started_ = true;
+            } else {
+              http_response_(",\n");
+            }
+          }
+          http_response_(entry_json + '\n');
+        } catch (const current::net::NetworkException&) {  // LCOV_EXCL_LINE
+          return ss::EntryResponse::Done;                  // LCOV_EXCL_LINE
+        }
+        // Respect `stop_after_bytes`.
+        if (params_.stop_after_bytes && current_response_size_ >= params_.stop_after_bytes) {
+          return ss::EntryResponse::Done;
+        }
+        // Respect `n`.
+        if (n_) {
+          --n_;
+          if (!n_) {
+            return ss::EntryResponse::Done;
+          }
+        }
+        // Respect `no_wait`.
+        if (current_index == last_index && params_.no_wait) {
           return ss::EntryResponse::Done;
         }
       }

--- a/stream/replicator.h
+++ b/stream/replicator.h
@@ -157,8 +157,8 @@ class SubscribableRemoteStream final {
     }
 
     template <SubscriptionMode MODE>
-    ENABLE_IF<MODE == SubscriptionMode::Safe, void> PassEntriesToSubscriber(const std::vector<std::string>& lines,
-                                                                            size_t whole_entries_count) {
+    ENABLE_IF<MODE == SubscriptionMode::Safe> PassEntriesToSubscriber(const std::vector<std::string>& lines,
+                                                                      size_t whole_entries_count) {
       for (size_t i = 0; i < whole_entries_count; ++i) {
         const auto split = current::strings::Split(lines[i], '\t');
         const auto tsoptidx = ParseJSON<ts_optidx_t>(split[0]);
@@ -181,8 +181,8 @@ class SubscribableRemoteStream final {
     }
 
     template <SubscriptionMode MODE>
-    ENABLE_IF<MODE == SubscriptionMode::Unsafe, void> PassEntriesToSubscriber(const std::vector<std::string>& lines,
-                                                                              size_t whole_entries_count) {
+    ENABLE_IF<MODE == SubscriptionMode::Unsafe> PassEntriesToSubscriber(const std::vector<std::string>& lines,
+                                                                        size_t whole_entries_count) {
       for (size_t i = 0; i < whole_entries_count; ++i) {
         const auto tab_pos = lines[i].find('\t');
         if (tab_pos != std::string::npos) {

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -478,7 +478,7 @@ class Stream final {
                   return;
                 }
               }
-              if (subscriber_(e, index++, bare_impl.persister.LastPublishedIndexAndTimestamp().index) ==
+              if (subscriber_(e, index++, bare_impl.persister.LastPublishedIndexAndTimestamp()) ==
                   ss::EntryResponse::Done) {
                 return;
               }

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -478,7 +478,7 @@ class Stream final {
                   return;
                 }
               }
-              if (subscriber_(e, index++, bare_impl.persister.Size()) == ss::EntryResponse::Done) {
+              if (subscriber_(e, index++, bare_impl.persister.LastPublishedIndexAndTimestamp().index) == ss::EntryResponse::Done) {
                 return;
               }
             }

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -119,7 +119,7 @@ CURRENT_STRUCT(StreamSchemaFormatNotFoundError) {
 template <typename ENTRY>
 using DEFAULT_PERSISTENCE_LAYER = current::persistence::Memory<ENTRY>;
 
-enum class SubscriptionMode : int { Safe, Unsafe };
+enum class SubscriptionMode : int { Safe = 0, Unsafe = 1 };
 
 template <typename ENTRY, template <typename> class PERSISTENCE_LAYER = DEFAULT_PERSISTENCE_LAYER>
 class Stream final {
@@ -581,9 +581,10 @@ class Stream final {
         borrowed_impl->http_subscriptions[subscription_id].second = nullptr;
       };
       current::stream::SubscriberScope http_chunked_subscriber_scope =
-          request_params.checked
-              ? (current::stream::SubscriberScope)Subscribe(*http_chunked_subscriber, begin_idx, done_callback)
-              : (current::stream::SubscriberScope)SubscribeUnsafe(*http_chunked_subscriber, begin_idx, done_callback);
+          request_params.checked ? static_cast<current::stream::SubscriberScope>(
+                                       Subscribe(*http_chunked_subscriber, begin_idx, done_callback))
+                                 : static_cast<current::stream::SubscriberScope>(
+                                       SubscribeUnsafe(*http_chunked_subscriber, begin_idx, done_callback));
 
       {
         std::lock_guard<std::mutex> lock(borrowed_impl->http_subscriptions_mutex);

--- a/stream/stream_impl.h
+++ b/stream/stream_impl.h
@@ -142,6 +142,13 @@ class StreamPublisherImpl {
     return result;
   }
 
+  template <current::locks::MutexLockStatus MLS>
+  idxts_t PublisherPublishUnsafeImpl(const std::string& entry_json) {
+    const auto result = data_->persister.template PersisterPublishUnsafeImpl<MLS>(entry_json);
+    data_->notifier.NotifyAllOfExternalWaitableEvent();
+    return result;
+  }
+
   template <current::locks::MutexLockStatus MLS, typename TIMESTAMP>
   void PublisherUpdateHeadImpl(TIMESTAMP&& timestamp) {
     data_->persister.template PersisterUpdateHeadImpl<MLS>(std::forward<TIMESTAMP>(timestamp));

--- a/stream/test.cc
+++ b/stream/test.cc
@@ -353,6 +353,7 @@ struct RecordsCollectorImpl {
       : count_(0u), rows_(rows), entries_(entries) {}
 
   EntryResponse operator()(const RecordWithTimestamp& entry, idxts_t current, idxts_t) {
+	printf("Entry %s idxts %s\n", JSON(entry).c_str(), JSON(current).c_str());
     rows_.push_back(JSON(current) + '\t' + JSON(entry) + '\n');
     entries_.push_back(JSON(entry));
     ++count_;

--- a/stream/test.cc
+++ b/stream/test.cc
@@ -783,17 +783,22 @@ TEST(Stream, SubscribeToStreamViaHTTP) {
   EXPECT_EQ(s[1], HTTP(GET(base_url + "?tail=4&i=1&n=1&checked")).body);
   EXPECT_EQ(s[1], HTTP(GET(base_url + "?tail=4&i=1&n=1")).body);
 
-  // Test `period`. Works only in `checked` mode.
+  // Test `period`.
   // Start from the first entry with the `period` less than 100.
   EXPECT_EQ(s[0], HTTP(GET(base_url + "?period=99&checked")).body);
+  EXPECT_EQ(s[0], HTTP(GET(base_url + "?period=99")).body);
   // Start 1 us later than the first entry with the `period` less than 200.
   EXPECT_EQ(s[1] + s[2], HTTP(GET(base_url + "?since=101&period=199&checked")).body);
+  EXPECT_EQ(s[1] + s[2], HTTP(GET(base_url + "?since=101&period=199")).body);
   // Start 1 us later than the first entry with the `period` equal to 200.
   EXPECT_EQ(s[1] + s[2] + s[3], HTTP(GET(base_url + "?since=101&period=200&nowait&checked")).body);
+  EXPECT_EQ(s[1] + s[2] + s[3], HTTP(GET(base_url + "?since=101&period=200&nowait")).body);
   // Start 1 us later than the first entry with the `period` equal to 200 and limit to one entry.
   EXPECT_EQ(s[1], HTTP(GET(base_url + "?since=101&period=200&n=1&checked")).body);
+  EXPECT_EQ(s[1], HTTP(GET(base_url + "?since=101&period=200&n=1")).body);
   // Start from the third entry from the end with the `period` less than 100.
   EXPECT_EQ(s[1], HTTP(GET(base_url + "?tail=3&period=99&checked")).body);
+  EXPECT_EQ(s[1], HTTP(GET(base_url + "?tail=3&period=99")).body);
 
   // Test `?stop_after_bytes=...`'
   // Request exactly the size of the first entry.


### PR DESCRIPTION
- Unsafe subscription to a stream, remote and local. Used by default via HTTP (switches to the "safe" one by adding "checked" flag to the subscription URL).
- Unsafe stream replication (and as a part of it - unsafe publishing to the file persister).

The replication benchmark shows the following on my machine:
100000 entries, 1000 bytes length each:
```
// old logic, parse JSONs on both sides
.current/replication_client --use_safe_replication --use_checked_subscription 
Seconds	EPS	MBps
3.59469	27818.8	26.53
// "unsafe" subscription, but parse received values before writing them on the client side 
.current/replication_client --use_safe_replication 
Seconds	EPS	MBps
3.08612	32403.1	30.902
// "unsafe" logic on both sides (parse only idxts_t in the FilePersister)
.current/replication_client
Seconds	EPS	MBps
2.72819	36654.3	34.9563
```
1000000 entries, 100 bytes length each:
```
// old logic, parse JSONs on both sides
.current/replication_client --use_safe_replication --use_checked_subscription 
Seconds	EPS	MBps
18.6243	53693.4	5.1206
// "unsafe" subscription, but parse received values before writing them on the client side 
.current/replication_client --use_safe_replication 
Seconds	EPS	MBps
15.0389	66494.3	6.34139
// "unsafe" logic on both sides (parse only idxts_t in the FilePersister)
.current/replication_client
Seconds	EPS	MBps
13.9142	71868.8	6.85394
```
I have several concerns:
  1. Naming :) May be it would be better in case of subscription to call it "unchecked" rather than "unsafe".
  2. UpdateHead produce some troubles: it is transferred the same way for both subscription types and the receiver should check that there is no '\t' and then parse it. Haven't any ideas of better solution for now.
  3. Some subscription options, such as `period`, require to parse idxts_t part of an each line to extract the current entry timestamp value. As I understand, we can't use the fact that each timestamp is stored in the FilePersister, because it's an implementation detail, that could be changed any moment. So, these options make the "unchecked" subscription less effective. Should we prohibit them or produce some kind of warning?
  4. When we subscribe (in "checked" mode) to the stream with "spoiled" data, it doesn't throw an exception. It crashes instead (in fact it trows an exception, but in a separate thread), so the `EXPECT_THROW(spoiled_stream.Subscribe(...))` doesn't work. Because of that I can't demonstrate an actual comparison in the `UnsafeVsSafeSubscription` test. Is it OK?