### PR TITLE
Blocks/HTTP/request: Segmentation fault after responding twice with Response

### DIFF
--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -414,7 +414,7 @@ TEST(HTTPAPI, HandlesRespondTwiceWithResponse) {
                                      try {
                                        r(Response("FAIL", HTTPResponseCode(762)));
                                        result = "Error, second response did not throw.";
-                                      } catch (const current::net::AttemptedToSendHTTPResponseMoreThanOnce&) {
+                                     } catch (const current::net::AttemptedToSendHTTPResponseMoreThanOnce&) {
                                        result = "OK, second response did throw.";
                                      }
                                    });

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -410,8 +410,7 @@ TEST(HTTPAPI, HandlesRespondTwiceWithResponse) {
                          .Register("/respond_twice",
                                    [](Request r) {
                                      r(Response("OK", HTTPResponseCode.OK));
-                                     // FIXME: On this line, `Request r` is invalid after `std::move(*this)` in `Request#operator()`.
-                                     r(Response("FAIL", HTTPResponseCode(762)));  // https://github.com/joho/7XX-rfc
+                                     r(Response("FAIL", HTTPResponseCode(762)));
                                    });
   const string url = Printf("http://localhost:%d/respond_twice", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));

--- a/Blocks/HTTP/test.cc
+++ b/Blocks/HTTP/test.cc
@@ -406,17 +406,24 @@ TEST(HTTPAPI, HandlesRespondTwiceWithString) {
 }
 
 TEST(HTTPAPI, HandlesRespondTwiceWithResponse) {
+  std::string result = "";
   const auto scope = HTTP(FLAGS_net_api_test_port)
                          .Register("/respond_twice",
-                                   [](Request r) {
+                                   [&result](Request r) {
                                      r(Response("OK", HTTPResponseCode.OK));
-                                     r(Response("FAIL", HTTPResponseCode(762)));
+                                     try {
+                                       r(Response("FAIL", HTTPResponseCode(762)));
+                                       result = "Error, second response did not throw.";
+                                      } catch (const current::net::AttemptedToSendHTTPResponseMoreThanOnce&) {
+                                       result = "OK, second response did throw.";
+                                     }
                                    });
   const string url = Printf("http://localhost:%d/respond_twice", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_EQ("OK", response.body);
   EXPECT_EQ(url, response.url);
+  EXPECT_EQ("OK, second response did throw.", result);
 }
 
 #if !defined(CURRENT_APPLE) || defined(CURRENT_APPLE_HTTP_CLIENT_POSIX)


### PR DESCRIPTION
### DO NOT MERGE, NOW FAILING TESTS WITH SEGFAULT

```
[ RUN      ] HTTPAPI.HandlesRespondTwiceWithString
HTTP route failed in user code:
./../../Bricks/net/http/impl/server.h:572
AttemptedToSendHTTPResponseMoreThanOnce()
[       OK ] HTTPAPI.HandlesRespondTwiceWithString (1 ms)
[ RUN      ] HTTPAPI.HandlesRespondTwiceWithResponse
make: *** [test] Segmentation fault: 11
```

Refs https://github.com/C5T/Current/issues/796