### PR TITLE
Several minor tweaks.

### DIFF
--- a/blocks/http/chunked_demo.cc
+++ b/blocks/http/chunked_demo.cc
@@ -157,7 +157,7 @@ int main() {
                   LayoutItem row;
                   layout.col.push_back(row);
                   r(layout,
-                    "layout",
+                    // "layout",  <--  @dkorolev, remove this source file entirely, as it's obsolete.
                     HTTPResponseCode.OK,
                     "application/json; charset=utf-8",
                     Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
@@ -166,7 +166,7 @@ int main() {
       .Register("/meta",
                 [](Request r) {
                   r(ExampleMeta(),
-                    "meta",
+                    // "meta",  <--  @dkorolev, remove this source file entirely, as it's obsolete.
                     HTTPResponseCode.OK,
                     "application/json; charset=utf-8",
                     Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));

--- a/blocks/http/request.h
+++ b/blocks/http/request.h
@@ -39,16 +39,10 @@ namespace http {
 
 struct Request;
 
-template <typename T>
-constexpr static bool HasRespondViaHTTP(char) {
-  return false;
-}
-
-template <typename T>
-constexpr static auto HasRespondViaHTTP(int)
-    -> decltype(std::declval<T>().RespondViaHTTP(std::declval<struct Request>()), bool()) {
-  return true;
-}
+struct IHasDoRespondViaHTTP {
+  virtual ~IHasDoRespondViaHTTP() = default;
+  virtual void DoRespondViaHTTP(Request r) const = 0;
+};
 
 // The only parameter to be passed to HTTP handlers.
 struct Request final {
@@ -100,22 +94,23 @@ struct Request final {
         body(http_data.Body()),
         timestamp(rhs.timestamp) {}
 
-  // Support objects with user-defined HTTP response handlers.
-  template <typename T>
-  inline typename std::enable_if<HasRespondViaHTTP<current::decay<T>>(0)>::type operator()(T&& that_dude_over_there) {
+  // A shortcut to allow `[](Request r) { r("OK"); }` instead of `r.connection.SendHTTPResponse("OK")`.
+  template <typename T, typename... TS>
+  ENABLE_IF<!std::is_base_of<IHasDoRespondViaHTTP, current::decay<T>>::value>
+  operator()(T&& arg, TS&&... args) {
     if (!unique_connection) {
       CURRENT_THROW(net::AttemptedToSendHTTPResponseMoreThanOnce());
     }
-    that_dude_over_there.RespondViaHTTP(std::move(*this));
+    connection.SendHTTPResponse(std::forward<T>(arg), std::forward<TS>(args)...);
   }
 
-  // A shortcut to allow `[](Request r) { r("OK"); }` instead of `r.connection.SendHTTPResponse("OK")`.
-  template <typename... TS>
-  void operator()(TS&&... params) {
+  // Support `Response`, as well as custom objects with user-defined HTTP response handlers.
+  template <class T>
+  ENABLE_IF<std::is_base_of<IHasDoRespondViaHTTP, current::decay<T>>::value> operator()(T&& response) {
     if (!unique_connection) {
       CURRENT_THROW(net::AttemptedToSendHTTPResponseMoreThanOnce());
     }
-    connection.SendHTTPResponse(std::forward<TS>(params)...);
+    response.DoRespondViaHTTP(std::move(*this));
   }
 
   template <uint64_t CACHE_SIZE = CURRENT_BRICKS_HTTP_DEFAULT_CHUNK_CACHE_SIZE>

--- a/blocks/http/response.h
+++ b/blocks/http/response.h
@@ -72,7 +72,7 @@ struct FillResponseHelper<false> {
 };
 }  // namespace impl
 
-struct Response {
+struct Response final : IHasDoRespondViaHTTP {
   bool initialized = false;
 
   std::string body;
@@ -248,7 +248,7 @@ struct Response {
     return *this;
   }
 
-  void RespondViaHTTP(Request r) const {
+  void DoRespondViaHTTP(Request r) const override {
     if (initialized) {
       r(body, code, content_type, headers);
     }
@@ -284,8 +284,6 @@ inline Response GenerateResponseFromMaybeSerializableObject(
       T,
       current::serialization::json::IsJSONSerializable<T>::value>::DoIt(value, code);
 }
-
-static_assert(HasRespondViaHTTP<Response>(0), "");
 
 }  // namespace http
 }  // namespace current

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -375,7 +375,9 @@ TEST(HTTPAPI, RespondsWithObject) {
                          .Register("/responds_with_object",
                                    [](Request r) {
                                      r(HTTPAPITestObject(),
+#if 0
                                        "test_object",
+#endif
                                        HTTPResponseCode.OK,
                                        "application/json",
                                        Headers({{"foo", "bar"}}));
@@ -383,7 +385,11 @@ TEST(HTTPAPI, RespondsWithObject) {
   const string url = Printf("http://localhost:%d/responds_with_object", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(200, static_cast<int>(response.code));
+#if 0
   EXPECT_EQ("{\"test_object\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n", response.body);
+#else
+  EXPECT_EQ("{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}\n", response.body);
+#endif
   EXPECT_EQ(url, response.url);
   EXPECT_EQ(1u, HTTP(FLAGS_net_api_test_port).PathHandlersCount());
 }

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -926,10 +926,16 @@ TEST(HTTPAPI, RespondWithStringAsConstCharPtrViaRequestDirectly) {
 }
 
 CURRENT_STRUCT(SerializableObject) {
-  CURRENT_FIELD(x, int, 42);
+  CURRENT_FIELD(x, int32_t, 42);
   CURRENT_FIELD(s, std::string, "foo");
-  std::string AsString() const { return Printf("%d:%s", x, s.c_str()); }
+  std::string AsString() const { return Printf("%d:%s", static_cast<int>(x), s.c_str()); }
 };
+
+CURRENT_STRUCT(AnotherSerializableObject) {
+  CURRENT_FIELD(z, uint32_t, 42u);
+};
+
+CURRENT_VARIANT(SerializableVariant, SerializableObject, AnotherSerializableObject);
 
 #if !defined(CURRENT_APPLE) || defined(CURRENT_APPLE_HTTP_CLIENT_POSIX)
 // Disabled for Apple - native code doesn't throw exceptions -- M.Z.
@@ -1567,6 +1573,21 @@ TEST(HTTPAPI, ResponseSmokeTest) {
           .Register("/response9",
                     [send_response](Request r) {
                       send_response(Response(), std::move(r));  // Will result in a 500 "INTERNAL SERVER ERROR".
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response10",
+                    [send_response](Request r) {
+                      SerializableVariant v;
+                      v.template Construct<SerializableObject>();
+                      r(v);
+                    }) +
+      HTTP(FLAGS_net_api_test_port)
+          .Register("/response11",
+                    [send_response](Request r) {
+                      // Test both a direct response (`Request::operator()`) and a response via `Respose`.
+                      SerializableVariant v;
+                      v.template Construct<SerializableObject>();
+                      send_response(v, std::move(r));
                     });
 
   const auto response1 = HTTP(GET(Printf("http://localhost:%d/response1", FLAGS_net_api_test_port)));
@@ -1604,6 +1625,14 @@ TEST(HTTPAPI, ResponseSmokeTest) {
   const auto response9 = HTTP(GET(Printf("http://localhost:%d/response9", FLAGS_net_api_test_port)));
   EXPECT_EQ(500, static_cast<int>(response9.code));
   EXPECT_EQ("<h1>INTERNAL SERVER ERROR</h1>\n", response9.body);
+
+  const auto response10 = HTTP(GET(Printf("http://localhost:%d/response10", FLAGS_net_api_test_port)));
+  EXPECT_EQ(200, static_cast<int>(response10.code));
+  EXPECT_EQ("{\"SerializableObject\":{\"x\":42,\"s\":\"foo\"},\"\":\"T9201749777787913665\"}\n", response10.body);
+
+  const auto response11 = HTTP(GET(Printf("http://localhost:%d/response11", FLAGS_net_api_test_port)));
+  EXPECT_EQ(200, static_cast<int>(response11.code));
+  EXPECT_EQ("{\"SerializableObject\":{\"x\":42,\"s\":\"foo\"},\"\":\"T9201749777787913665\"}\n", response11.body);
 
   {
     Response response;

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -375,9 +375,6 @@ TEST(HTTPAPI, RespondsWithObject) {
                          .Register("/responds_with_object",
                                    [](Request r) {
                                      r(HTTPAPITestObject(),
-#if 0
-                                       "test_object",
-#endif
                                        HTTPResponseCode.OK,
                                        "application/json",
                                        Headers({{"foo", "bar"}}));
@@ -385,11 +382,7 @@ TEST(HTTPAPI, RespondsWithObject) {
   const string url = Printf("http://localhost:%d/responds_with_object", FLAGS_net_api_test_port);
   const auto response = HTTP(GET(url));
   EXPECT_EQ(200, static_cast<int>(response.code));
-#if 0
-  EXPECT_EQ("{\"test_object\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n", response.body);
-#else
   EXPECT_EQ("{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}\n", response.body);
-#endif
   EXPECT_EQ(url, response.url);
   EXPECT_EQ(1u, HTTP(FLAGS_net_api_test_port).PathHandlersCount());
 }

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -387,8 +387,8 @@ TEST(HTTPAPI, RespondsWithObject) {
   EXPECT_EQ(1u, HTTP(FLAGS_net_api_test_port).PathHandlersCount());
 }
 
-struct GoodStuff {
-  void RespondViaHTTP(Request r) const {
+struct GoodStuff : IHasDoRespondViaHTTP {
+  void DoRespondViaHTTP(Request r) const override {
     r("Good stuff.", HTTPResponseCode(762));  // https://github.com/joho/7XX-rfc
   }
 };

--- a/blocks/http/types.h
+++ b/blocks/http/types.h
@@ -121,9 +121,10 @@ struct FillBody<REQUEST, true> {
 template <typename REQUEST>
 struct FillBody<REQUEST, false> {
   template <typename T>
-  static typename std::enable_if<IS_CURRENT_STRUCT(current::decay<T>)>::type Fill(REQUEST& request,
-                                                                                  T&& object,
-                                                                                  const std::string& content_type) {
+  static typename std::enable_if<IS_CURRENT_STRUCT_OR_VARIANT(current::decay<T>)>::type Fill(
+      REQUEST& request,
+      T&& object,
+      const std::string& content_type) {
     request.body = JSON(std::forward<T>(object));
     request.content_type = !content_type.empty() ? content_type : net::constants::kDefaultJSONContentType;
   }

--- a/bricks/net/http/headers/headers.h
+++ b/bricks/net/http/headers/headers.h
@@ -224,6 +224,12 @@ struct Headers final {
     return *this;
   }
 
+  Headers& Clear(const std::string& header) {
+    Header::ThrowIfHeaderIsCookie(header);
+    map.erase(header);
+    return *this;
+  }
+
   bool Has(const std::string& header) const {
     Header::ThrowIfHeaderIsCookie(header);
     return map.find(header) != map.end();

--- a/bricks/net/http/headers/headers.h
+++ b/bricks/net/http/headers/headers.h
@@ -224,7 +224,7 @@ struct Headers final {
     return *this;
   }
 
-  Headers& Clear(const std::string& header) {
+  Headers& Remove(const std::string& header) {
     Header::ThrowIfHeaderIsCookie(header);
     map.erase(header);
     return *this;

--- a/bricks/net/http/headers/test.cc
+++ b/bricks/net/http/headers/test.cc
@@ -69,6 +69,10 @@ TEST(HTTPHeadersTest, Smoke) {
   EXPECT_EQ("2", headers.GetOrDefault("bar", "nope"));
   EXPECT_EQ("1", headers.Get("foo"));
   EXPECT_EQ("2", headers.Get("bar"));
+
+  headers.Clear("foo");
+  EXPECT_EQ("nope", headers.GetOrDefault("foo", "nope"));
+  EXPECT_EQ("2", headers.GetOrDefault("bar", "nope"));
 }
 
 TEST(HTTPHeadersTest, Initialization) {

--- a/bricks/net/http/headers/test.cc
+++ b/bricks/net/http/headers/test.cc
@@ -70,7 +70,7 @@ TEST(HTTPHeadersTest, Smoke) {
   EXPECT_EQ("1", headers.Get("foo"));
   EXPECT_EQ("2", headers.Get("bar"));
 
-  headers.Clear("foo");
+  headers.Remove("foo");
   EXPECT_EQ("nope", headers.GetOrDefault("foo", "nope"));
   EXPECT_EQ("2", headers.GetOrDefault("bar", "nope"));
 }

--- a/bricks/net/http/impl/server.h
+++ b/bricks/net/http/impl/server.h
@@ -179,22 +179,6 @@ struct HTTPResponder {
     const std::string s = JSON(std::forward<T>(object)) + '\n';
     SendHTTPResponseImpl(connection, s.begin(), s.end(), code, content_type, extra_headers);
   }
-
-#if 0
-  // JSON objects under custom names removed by @dkorolev in January 2018.
-  template <class T>
-  static ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> SendHTTPResponse(
-      Connection& connection,
-      T&& object,
-      const std::string& name,
-      HTTPResponseCodeValue code = HTTPResponseCode.OK,
-      const std::string& content_type = constants::kDefaultJSONContentType,
-      const http::Headers& extra_headers = http::Headers::DefaultJSONHeaders()) {
-    // TODO(dkorolev): We should probably make this not only correct but also efficient.
-    const std::string s = "{\"" + name + "\":" + JSON(std::forward<T>(object)) + "}\n";
-    SendHTTPResponseImpl(connection, s.begin(), s.end(), code, content_type, extra_headers);
-  }
-#endif  // #if 0
 };
 
 // HTTPDefaultHelper handles headers and chunked transfers.
@@ -665,14 +649,6 @@ class GenericHTTPServerConnection final : public HTTPResponder {
       inline ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> Send(T&& object, ChunkFlush flush) {
         SendImpl(JSON(std::forward<T>(object)) + '\n', flush);
       }
-
-#if 0
-      // JSON objects under custom names removed by @dkorolev in January 2018.
-      template <class T, typename S>
-      inline ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> Send(T&& object, S&& name, ChunkFlush flush) {
-        SendImpl(std::string("{\"") + name + "\":" + JSON(std::forward<T>(object)) + "}\n", flush);
-      }
-#endif  // #if 0
 
       Connection& connection_;
       bool can_no_longer_write_ = false;

--- a/bricks/net/http/impl/server.h
+++ b/bricks/net/http/impl/server.h
@@ -180,8 +180,8 @@ struct HTTPResponder {
     SendHTTPResponseImpl(connection, s.begin(), s.end(), code, content_type, extra_headers);
   }
 
-  // Support `CURRENT_STRUCT`-s wrapper under a user-defined name.
-  // (For backwards compatibility only, really. -- D.K.)
+#if 0
+  // JSON objects under custom names removed by @dkorolev in January 2018.
   template <class T>
   static ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> SendHTTPResponse(
       Connection& connection,
@@ -194,6 +194,7 @@ struct HTTPResponder {
     const std::string s = "{\"" + name + "\":" + JSON(std::forward<T>(object)) + "}\n";
     SendHTTPResponseImpl(connection, s.begin(), s.end(), code, content_type, extra_headers);
   }
+#endif  // #if 0
 };
 
 // HTTPDefaultHelper handles headers and chunked transfers.
@@ -664,10 +665,14 @@ class GenericHTTPServerConnection final : public HTTPResponder {
       inline ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> Send(T&& object, ChunkFlush flush) {
         SendImpl(JSON(std::forward<T>(object)) + '\n', flush);
       }
+
+#if 0
+      // JSON objects under custom names removed by @dkorolev in January 2018.
       template <class T, typename S>
       inline ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> Send(T&& object, S&& name, ChunkFlush flush) {
         SendImpl(std::string("{\"") + name + "\":" + JSON(std::forward<T>(object)) + "}\n", flush);
       }
+#endif  // #if 0
 
       Connection& connection_;
       bool can_no_longer_write_ = false;

--- a/bricks/net/http/impl/server.h
+++ b/bricks/net/http/impl/server.h
@@ -167,9 +167,9 @@ struct HTTPResponder {
     SendHTTPResponseImpl(connection, string.begin(), string.end(), code, content_type, extra_headers);
   }
 
-  // Support `CURRENT_STRUCT`-s.
+  // Support `CURRENT_STRUCT`-s and `CURRENT_VARIANT`-s.
   template <class T>
-  static ENABLE_IF<IS_CURRENT_STRUCT(current::decay<T>)> SendHTTPResponse(
+  static ENABLE_IF<IS_CURRENT_STRUCT_OR_VARIANT(current::decay<T>)> SendHTTPResponse(
       Connection& connection,
       T&& object,
       HTTPResponseCodeValue code = HTTPResponseCode.OK,

--- a/bricks/net/http/test.cc
+++ b/bricks/net/http/test.cc
@@ -183,6 +183,8 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
   t.join();
 }
 
+#if 0
+// The "named objects" functionality is removed by @dkorolev in January 2018.
 TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
   std::thread t([](Socket s) {
     HTTPServerConnection c(s.Accept());
@@ -205,6 +207,7 @@ TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
       connection);
   t.join();
 }
+#endif  // #if 0
 
 TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
   std::thread t([](Socket s) {
@@ -215,7 +218,9 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
     r.Send("onetwothree");
     r.Send(std::vector<char>({'f', 'o', 'o'}));
     r.Send(HTTPTestObject());
+#if 0
     r.Send(HTTPTestObject(), "epic_chunk");
+#endif
   }, Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
   connection.BlockingWrite("GET /chunked HTTP/1.1\r\n", true);
@@ -234,8 +239,10 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
       "foo\r\n"
       "2C\r\n"
       "{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}\n\r\n"
+#if 0
       "3B\r\n"
       "{\"epic_chunk\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n\r\n"
+#endif
       "0\r\n",
       connection);
   t.join();

--- a/bricks/net/http/test.cc
+++ b/bricks/net/http/test.cc
@@ -183,32 +183,6 @@ TEST(PosixHTTPServerTest, SmokeWithObject) {
   t.join();
 }
 
-#if 0
-// The "named objects" functionality is removed by @dkorolev in January 2018.
-TEST(PosixHTTPServerTest, SmokeWithNamedObject) {
-  std::thread t([](Socket s) {
-    HTTPServerConnection c(s.Accept());
-    EXPECT_EQ("GET", c.HTTPRequest().Method());
-    EXPECT_EQ("/test_named_object", c.HTTPRequest().RawPath());
-    c.SendHTTPResponse(HTTPTestObject(), "epic_object");
-  }, Socket(FLAGS_net_http_test_port));
-  Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
-  connection.BlockingWrite("GET /test_named_object HTTP/1.1\r\n", true);
-  connection.BlockingWrite("Host: localhost\r\n", true);
-  connection.BlockingWrite("\r\n", false);
-  ExpectToReceive(
-      "HTTP/1.1 200 OK\r\n"
-      "Content-Type: application/json; charset=utf-8\r\n"
-      "Connection: close\r\n"
-      "Access-Control-Allow-Origin: *\r\n"
-      "Content-Length: 60\r\n"
-      "\r\n"
-      "{\"epic_object\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n",
-      connection);
-  t.join();
-}
-#endif  // #if 0
-
 TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
   std::thread t([](Socket s) {
     HTTPServerConnection c(s.Accept());
@@ -218,9 +192,6 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
     r.Send("onetwothree");
     r.Send(std::vector<char>({'f', 'o', 'o'}));
     r.Send(HTTPTestObject());
-#if 0
-    r.Send(HTTPTestObject(), "epic_chunk");
-#endif
   }, Socket(FLAGS_net_http_test_port));
   Connection connection(ClientSocket("localhost", FLAGS_net_http_test_port));
   connection.BlockingWrite("GET /chunked HTTP/1.1\r\n", true);
@@ -239,10 +210,6 @@ TEST(PosixHTTPServerTest, SmokeChunkedResponse) {
       "foo\r\n"
       "2C\r\n"
       "{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}\n\r\n"
-#if 0
-      "3B\r\n"
-      "{\"epic_chunk\":{\"number\":42,\"text\":\"text\",\"array\":[1,2,3]}}\n\r\n"
-#endif
       "0\r\n",
       connection);
   t.join();

--- a/storage/container/dictionary.h
+++ b/storage/container/dictionary.h
@@ -52,6 +52,7 @@ class GenericDictionary {
 
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }
+  bool Has(sfinae::CF<key_t> x) const { return map_.find(x) != map_.end(); }
 
   ImmutableOptional<T> operator[](sfinae::CF<key_t> key) const {
     const auto iterator = map_.find(key);

--- a/storage/container/many_to_many.h
+++ b/storage/container/many_to_many.h
@@ -66,6 +66,13 @@ class GenericManyToMany {
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }
 
+  bool Has(sfinae::CF<key_t> key) const {
+    return map_.find(key) != map_.end();
+  }
+  bool Has(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const {
+    return map_.find(key_t(row, col)) != map_.end();
+  }
+
   void Add(const T& object) {
     const auto now = current::time::Now();
     const auto row = sfinae::GetRow(object);

--- a/storage/container/one_to_many.h
+++ b/storage/container/one_to_many.h
@@ -65,6 +65,13 @@ class GenericOneToMany {
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }
 
+  bool Has(sfinae::CF<key_t> key) const {
+    return map_.find(key) != map_.end();
+  }
+  bool Has(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const {
+    return map_.find(key_t(row, col)) != map_.end();
+  }
+
   // Adds specified object and overwrites existing one if it has the same row and col.
   // Removes all other existing objects with the same col.
   void Add(const T& object) {

--- a/storage/test.cc
+++ b/storage/test.cc
@@ -193,7 +193,15 @@ TEST(TransactionalStorage, SmokeTest) {
         EXPECT_TRUE(fields.umany_to_umany.Cols().Empty());
         EXPECT_EQ(0u, fields.umany_to_umany.Rows().Size());
         EXPECT_EQ(0u, fields.umany_to_umany.Cols().Size());
+        EXPECT_FALSE(fields.umany_to_umany.Has(1, "one"));
+        EXPECT_FALSE(fields.umany_to_umany.Has(std::make_pair(1, "one")));
         fields.umany_to_umany.Add(Cell{1, "one", 1});
+        EXPECT_TRUE(fields.umany_to_umany.Has(1, "one"));
+        EXPECT_TRUE(fields.umany_to_umany.Has(std::make_pair(1, "one")));
+        EXPECT_FALSE(fields.umany_to_umany.Has(101, "one"));
+        EXPECT_FALSE(fields.umany_to_umany.Has(1, "some one"));
+        EXPECT_FALSE(fields.umany_to_umany.Has(std::make_pair(101, "one")));
+        EXPECT_FALSE(fields.umany_to_umany.Has(std::make_pair(1, "some one")));
         fields.umany_to_umany.Add(Cell{2, "two", 2});
         fields.umany_to_umany.Add(Cell{2, "too", 3});
         EXPECT_FALSE(fields.umany_to_umany.Empty());

--- a/storage/test.cc
+++ b/storage/test.cc
@@ -276,6 +276,10 @@ TEST(TransactionalStorage, SmokeTest) {
         EXPECT_TRUE(fields.uone_to_umany.Cols().Empty());
         EXPECT_EQ(0u, fields.uone_to_umany.Rows().Size());
         EXPECT_EQ(0u, fields.uone_to_umany.Cols().Size());
+
+        EXPECT_FALSE(fields.uone_to_umany.Has(1, "one"));
+        EXPECT_FALSE(fields.uone_to_umany.Has(std::make_pair(1, "one")));
+
         fields.uone_to_umany.Add(Cell{1, "one", 1});   // Adds {1,one=1 }
         fields.uone_to_umany.Add(Cell{2, "two", 5});   // Adds {2,two=5 }
         fields.uone_to_umany.Add(Cell{2, "two", 4});   // Adds {2,two=4 }, overwrites {2,two=5}
@@ -283,6 +287,14 @@ TEST(TransactionalStorage, SmokeTest) {
         fields.uone_to_umany.Add(Cell{2, "fiv", 10});  // Adds {2,fiv=10}, removes {1,fiv=5}
         fields.uone_to_umany.Add(Cell{3, "six", 18});  // Adds {3,six=18}
         fields.uone_to_umany.Add(Cell{1, "six", 6});   // Adds {1,six=6 }, removes {3,six=18}
+
+        EXPECT_TRUE(fields.uone_to_umany.Has(1, "one"));
+        EXPECT_TRUE(fields.uone_to_umany.Has(std::make_pair(1, "one")));
+        EXPECT_FALSE(fields.uone_to_umany.Has(1, "fiv"));  // Implicitly removed above.
+        EXPECT_FALSE(fields.uone_to_umany.Has(3, "six"));  // Implicitly removed above.
+        EXPECT_FALSE(fields.uone_to_umany.Has(std::make_pair(1, "fiv")));
+        EXPECT_FALSE(fields.uone_to_umany.Has(std::make_pair(3, "six")));
+
         EXPECT_FALSE(fields.uone_to_umany.Empty());
         EXPECT_EQ(4u, fields.uone_to_umany.Size());
         EXPECT_FALSE(fields.uone_to_umany.Rows().Empty());

--- a/storage/test.cc
+++ b/storage/test.cc
@@ -148,7 +148,9 @@ TEST(TransactionalStorage, SmokeTest) {
     // Fill a `Dictionary` container.
     {
       const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+        EXPECT_FALSE(fields.d.Has("one"));
         fields.d.Add(Record{"one", 1});
+        EXPECT_TRUE(fields.d.Has("one"));
 
         {
           size_t count = 0u;
@@ -174,7 +176,9 @@ TEST(TransactionalStorage, SmokeTest) {
         EXPECT_EQ(2, Value(fields.d["two"]).rhs);
 
         fields.d.Add(Record{"three", 3});
+        EXPECT_TRUE(fields.d.Has("three"));
         fields.d.Erase("three");
+        EXPECT_FALSE(fields.d.Has("three"));
       }).Go();
 
       EXPECT_TRUE(WasCommitted(result));

--- a/typesystem/serialization/json.h
+++ b/typesystem/serialization/json.h
@@ -29,6 +29,7 @@ SOFTWARE.
 #include "serialization.h"
 
 #include "json/enum.h"
+#include "json/immutable_optional.h"
 #include "json/map.h"
 #include "json/optional.h"
 #include "json/pair.h"

--- a/typesystem/serialization/json/immutable_optional.h
+++ b/typesystem/serialization/json/immutable_optional.h
@@ -1,0 +1,152 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+          (c) 2016 Maxim Zhurovich <zhurovich@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// A shamelessly copy-pasted `optional.h` with `Optional<>` replaced by `ImmutableOptional<>`. -- D.K.
+
+#ifndef CURRENT_TYPE_SYSTEM_SERIALIZATION_JSON_IMMUTABLE_OPTIONAL_H
+#define CURRENT_TYPE_SYSTEM_SERIALIZATION_JSON_IMMUTABLE_OPTIONAL_H
+
+#include <type_traits>
+
+#include "primitives.h"
+
+#include "../../optional.h"
+
+namespace current {
+namespace serialization {
+
+template <class JSON_FORMAT, typename T>
+struct SerializeImpl<json::JSONStringifier<JSON_FORMAT>, ImmutableOptional<T>> {
+  static void DoSerialize(json::JSONStringifier<JSON_FORMAT>& json_stringifier, const ImmutableOptional<T>& value) {
+    if (Exists(value)) {
+      Serialize(json_stringifier, Value(value));
+    } else {
+      // Current's default JSON parser would accept a missing field as well for no value,
+      // but output it as `null` nonetheless, for clarity.
+      json_stringifier.Current().SetNull();
+    }
+  }
+};
+
+template <typename T>
+struct SerializeImpl<json::JSONStringifier<json::JSONFormat::Minimalistic>, ImmutableOptional<T>> {
+  static void DoSerialize(json::JSONStringifier<json::JSONFormat::Minimalistic>& json_stringifier,
+                          const ImmutableOptional<T>& value) {
+    if (Exists(value)) {
+      Serialize(json_stringifier, Value(value));
+    } else {
+      json_stringifier.MarkAsAbsentValue();
+    }
+  }
+};
+
+// In F#, `'T option` is an alias for `ImmutableOptional<'T>`, which, in its turn, is a DU / Variant
+// type with the signature `ImmutableOptional<'T> = | Some 'T | None`.
+// Thus, yeah, for a non-null `ImmutableOptional` in F#, we need "Case" and "Fields".
+template <typename T>
+struct SerializeImpl<json::JSONStringifier<json::JSONFormat::NewtonsoftFSharp>, ImmutableOptional<T>> {
+  static void DoSerialize(json::JSONStringifier<json::JSONFormat::NewtonsoftFSharp>& json_stringifier,
+                          const ImmutableOptional<T>& value) {
+    if (Exists(value)) {
+      rapidjson::Value ultimate_destination;
+      json_stringifier.Inner(&ultimate_destination, Value(value));
+      rapidjson::Value array_of_one_element_containing_value;
+      array_of_one_element_containing_value.SetArray();
+      array_of_one_element_containing_value.PushBack(std::move(ultimate_destination.Move()),
+                                                     json_stringifier.Allocator());
+      json_stringifier.Current().SetObject();
+      json_stringifier.Current().AddMember("Case", "Some", json_stringifier.Allocator());
+      json_stringifier.Current().AddMember(
+          "Fields", std::move(array_of_one_element_containing_value.Move()), json_stringifier.Allocator());
+    } else {
+      json_stringifier.MarkAsAbsentValue();
+    }
+  }
+};
+
+template <class JSON_FORMAT, typename T>
+struct DeserializeImpl<json::JSONParser<JSON_FORMAT>, ImmutableOptional<T>> {
+  static void DoDeserialize(json::JSONParser<JSON_FORMAT>& json_parser, ImmutableOptional<T>& destination) {
+    if (json_parser && !json_parser.Current().IsNull()) {
+      destination = T();
+      Deserialize(json_parser, Value(destination));
+    } else {
+      if (!json::JSONPatchMode<JSON_FORMAT>::value || json_parser) {
+        // Nullify `destination` if at least one of two following conditions is true:
+        // 1) The input JSON contains an explicit `null` (the `json_parser` check), OR
+        // 2) The logic invoked is `ParseJSON`, not `PatchObjectWithJSON`.
+        // Effectively, always nullify the destination in `ParseJSON`, mode, and, when in `PatchObjectWithJSON`
+        // mode, take no action if the key is missing, yet treat the input `null` as explicit nullification.
+        destination = nullptr;
+      }
+    }
+  }
+};
+
+template <typename T>
+struct DeserializeImpl<json::JSONParser<JSONFormat::NewtonsoftFSharp>, ImmutableOptional<T>> {
+  static void DoDeserialize(json::JSONParser<JSONFormat::NewtonsoftFSharp>& json_parser,
+                            ImmutableOptional<T>& destination) {
+    if (!json_parser || json_parser.Current().IsNull()) {
+      destination = nullptr;
+    } else {
+      bool ok = false;
+      if (json_parser.Current().IsObject() && json_parser.Current().HasMember("Case")) {
+        const auto& case_field = json_parser.Current()["Case"];
+        if (case_field.IsString()) {
+          const char* case_field_value = case_field.GetString();
+          if (!strcmp(case_field_value, "None")) {
+            // Unnecessary, but to be safe. -- D.K.
+            destination = nullptr;
+            ok = true;
+          } else if (!strcmp(case_field_value, "Some") && json_parser.Current().HasMember("Fields")) {
+            auto& fields_field = json_parser.Current()["Fields"];
+            if (fields_field.IsArray() && fields_field.Size() == 1u) {
+              destination = T();
+              json_parser.Inner(&fields_field[0u], Value(destination));
+              ok = true;
+            }
+          }
+        }
+      }
+      if (!ok) {
+        CURRENT_THROW(JSONSchemaException("optional as `null` or `{\"Case\":\"Some\",\"Fields\":[value]}`",
+                                          json_parser));
+      }
+    }
+  }
+};
+
+namespace json {
+template <typename T>
+struct IsJSONSerializable<ImmutableOptional<T>> {
+  constexpr static bool value = IsJSONSerializable<T>::value;
+};
+}  // namespace json
+
+}  // namespace current::serialization
+}  // namespace current
+
+#endif  // CURRENT_TYPE_SYSTEM_SERIALIZATION_JSON_IMMUTABLE_OPTIONAL_H

--- a/typesystem/test.cc
+++ b/typesystem/test.cc
@@ -1487,3 +1487,19 @@ TEST(TypeSystemTest, DISABLED_NestedVariants)
     EXPECT_EQ(3u, Value<Bar>(Value<Variant<Bar, Baz>>(v)).j);
   }
 }
+
+TEST(TypeSystemTest, InplaceVariantConstruction) {
+  using namespace struct_definition_test;
+
+  Variant<Foo, Bar> v;
+
+  v.template Construct<Foo>(101u);
+  ASSERT_TRUE(Exists<Foo>(v));
+  ASSERT_FALSE(Exists<Bar>(v));
+  EXPECT_EQ(101u, Value<Foo>(v).i);
+
+  v.template Construct<Bar>(202u);
+  ASSERT_TRUE(Exists<Bar>(v));
+  ASSERT_FALSE(Exists<Foo>(v));
+  EXPECT_EQ(202u, Value<Bar>(v).j);
+}

--- a/typesystem/variant.h
+++ b/typesystem/variant.h
@@ -212,6 +212,15 @@ struct VariantImpl<NAME, TypeListImpl<TYPES...>> : IHasUncheckedMoveFromUniquePt
     object_ = std::move(input);
   }
 
+#ifdef VARIANT_CHECKS_AT_RUNTIME_INSTEAD_OF_COMPILE_TIME
+  template <typename T, typename... ARGS>
+#else
+  template <typename T, typename... ARGS, class ENABLE = std::enable_if_t<TypeListContains<typelist_t, T>::value>>
+#endif  // VARIANT_CHECKS_AT_RUNTIME_INSTEAD_OF_COMPILE_TIME
+  T& Construct(ARGS&&... args) {
+    object_ = std::make_unique<T>(std::forward<ARGS>(args)...);
+    return *dynamic_cast<T*>(object_.get());
+  }
   operator bool() const { return object_ ? true : false; }
 
   template <typename F>


### PR DESCRIPTION
Hi @mzhurovich, @grixa,

A couple minor tweaks on the way to:

1. Refactoring class `Response` to support JSON format selection (otherwise the user has to manually set the origin header for each `JSON<JSONFormat::Minimalistic>`, which sucks, and
2. The journaled file system and its applications.

On the bright side, `RespondViaHTTP` is now not SFINAE-powered.

Thanks,
Dima