### PR TITLE
CORS refactoring.

### DIFF
--- a/blocks/http/chunked_demo.cc
+++ b/blocks/http/chunked_demo.cc
@@ -159,8 +159,8 @@ int main() {
                   r(layout,
                     // "layout",  <--  @dkorolev, remove this source file entirely, as it's obsolete.
                     HTTPResponseCode.OK,
-                    "application/json; charset=utf-8",
-                    Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
+                    Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}),
+                    "application/json; charset=utf-8");
                 });
   HTTP(FLAGS_port)
       .Register("/meta",
@@ -168,8 +168,8 @@ int main() {
                   r(ExampleMeta(),
                     // "meta",  <--  @dkorolev, remove this source file entirely, as it's obsolete.
                     HTTPResponseCode.OK,
-                    "application/json; charset=utf-8",
-                    Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}));
+                    Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}),
+                    "application/json; charset=utf-8");
                 });
   HTTP(FLAGS_port)
       .Register("/data",
@@ -179,8 +179,8 @@ int main() {
                     try {
                       auto response = r.connection.SendChunkedHTTPResponse(
                           HTTPResponseCode.OK,
-                          "application/json; charset=utf-8",
-                          {{"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"}});
+                          {{"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"}},
+                          "application/json; charset=utf-8");
                       std::string data;
                       const double begin = static_cast<double>(Now().count());
                       const double t = atof(r.url.query["t"].c_str());

--- a/blocks/http/docu/server/docu_03httpserver_03_test.cc
+++ b/blocks/http/docu/server/docu_03httpserver_03_test.cc
@@ -40,8 +40,8 @@ const auto port = FLAGS_docu_net_server_port_03;
   const auto scope = HTTP(port).Register("/found", [](Request r) {
     r("Yes.",
       HTTPResponseCode.Accepted,
-      current::net::constants::kDefaultHTMLContentType,
-      current::net::http::Headers().Set("custom", "header").Set("another", "one"));
+      current::net::http::Headers().Set("custom", "header").Set("another", "one"),
+      current::net::constants::kDefaultHTMLContentType);
   });
 EXPECT_EQ("Yes.", HTTP(GET(Printf("http://localhost:%d/found", port))).body);
 }

--- a/blocks/http/impl/posix_server.h
+++ b/blocks/http/impl/posix_server.h
@@ -129,12 +129,13 @@ struct StaticFileServer {
         // (`static` is a directory, not a file).
         // 2) Respond with the content if we're serving a file and don't have a trailing slash. Example:
         // `/static/index.html`, `/static/file.png`.
-        r.connection.SendHTTPResponse(content, HTTPResponseCode.OK, content_type);
+        r.connection.SendHTTPResponse(content, HTTPResponseCode.OK, net::http::Headers(), content_type);
       } else if (!serves_directory && r.url_path_had_trailing_slash) {
         // Respond with HTTP 404 Not Found if we're serving a file and have a trailing slash. Example:
         // `/static/index.html/`.
         r.connection.SendHTTPResponse(current::net::DefaultNotFoundMessage(),
                                       HTTPResponseCode.NotFound,
+                                      current::net::http::Headers(),
                                       current::net::constants::kDefaultHTMLContentType);
       } else {
         // Redirect to add trailing slash to the directory URL. Example: `/static` -> `/static/`.
@@ -143,12 +144,13 @@ struct StaticFileServer {
         // See RFC1808, `Resolving Relative URLs`, `Step 6`: https://www.ietf.org/rfc/rfc1808.txt
         r.connection.SendHTTPResponse("",
                                       HTTPResponseCode.Found,
-                                      content_type,
-                                      current::net::http::Headers({{"Location", trailing_slash_redirect_url}}));
+                                      current::net::http::Headers({{"Location", trailing_slash_redirect_url}}),
+                                      content_type);
       }
     } else {
       r.connection.SendHTTPResponse(current::net::DefaultMethodNotAllowedMessage(),
                                     HTTPResponseCode.MethodNotAllowed,
+                                    current::net::http::Headers(),
                                     current::net::constants::kDefaultHTMLContentType);
     }
   }
@@ -442,6 +444,7 @@ class HTTPServerPOSIX final {
         } else {
           connection->SendHTTPResponse(current::net::DefaultNotFoundMessage(),
                                        HTTPResponseCode.NotFound,
+                                       current::net::http::Headers(),
                                        current::net::constants::kDefaultHTMLContentType);
         }
       } catch (const current::net::ChunkSizeNotAValidHEXValue&) {

--- a/blocks/http/request.h
+++ b/blocks/http/request.h
@@ -116,12 +116,12 @@ struct Request final {
   template <uint64_t CACHE_SIZE = CURRENT_BRICKS_HTTP_DEFAULT_CHUNK_CACHE_SIZE>
   current::net::HTTPServerConnection::ChunkedResponseSender<CACHE_SIZE> SendChunkedResponse(
       net::HTTPResponseCodeValue code = HTTPResponseCode.OK,
-      const std::string& content_type = net::constants::kDefaultJSONContentType,
-      const net::http::Headers& extra_headers = net::http::Headers::DefaultJSONHeaders()) {
+      const net::http::Headers& headers = net::http::Headers(),
+      const std::string& content_type = net::constants::kDefaultJSONContentType) {
     if (!unique_connection) {
       CURRENT_THROW(net::AttemptedToSendHTTPResponseMoreThanOnce());
     }
-    return connection.SendChunkedHTTPResponse<CACHE_SIZE>(code, content_type, extra_headers);
+    return connection.SendChunkedHTTPResponse<CACHE_SIZE>(code, headers, content_type);
   }
 
   Request(const Request&) = delete;

--- a/blocks/http/response.h
+++ b/blocks/http/response.h
@@ -51,7 +51,6 @@ struct FillResponseHelper<true> {
     return object;
   }
   static std::string DefaultContentType() { return net::constants::kDefaultContentType; }
-  static void SetAccessControlAllowOriginHeaderIfJSON(net::http::Headers&) {}
 };
 
 template <>
@@ -65,10 +64,6 @@ struct FillResponseHelper<false> {
     return "{\"" + object_name + "\":" + JSON(std::forward<T>(object)) + "}\n";
   }
   static std::string DefaultContentType() { return net::constants::kDefaultJSONContentType; }
-  static void SetAccessControlAllowOriginHeaderIfJSON(net::http::Headers& headers) {
-    headers.Set(net::constants::kHTTPAccessControlAllowOriginHeaderName,
-                net::constants::kHTTPAccessControlAllowOriginHeaderValue);
-  }
 };
 }  // namespace impl
 
@@ -79,6 +74,7 @@ struct Response final : IHasDoRespondViaHTTP {
   net::HTTPResponseCodeValue code;
   std::string content_type;
   net::http::Headers headers;
+  bool cors_header = true;
 
   Response() : body(""), code(HTTPResponseCode.OK), content_type(net::constants::kDefaultContentType) {}
 
@@ -125,7 +121,6 @@ struct Response final : IHasDoRespondViaHTTP {
     this->body = G::AsString(std::forward<T>(object));
     this->code = code;
     this->content_type = G::DefaultContentType();
-    G::SetAccessControlAllowOriginHeaderIfJSON(this->headers);
   }
 
   template <typename T>
@@ -134,7 +129,6 @@ struct Response final : IHasDoRespondViaHTTP {
     this->body = G::AsString(std::forward<T>(object), object_name);
     this->code = code;
     this->content_type = G::DefaultContentType();
-    G::SetAccessControlAllowOriginHeaderIfJSON(this->headers);
   }
 
   template <typename T>
@@ -144,7 +138,6 @@ struct Response final : IHasDoRespondViaHTTP {
     this->code = code;
     this->content_type = G::DefaultContentType();
     this->headers = headers;
-    G::SetAccessControlAllowOriginHeaderIfJSON(this->headers);
   }
 
   template <typename T>
@@ -157,7 +150,6 @@ struct Response final : IHasDoRespondViaHTTP {
     this->code = code;
     this->content_type = G::DefaultContentType();
     this->headers = headers;
-    G::SetAccessControlAllowOriginHeaderIfJSON(this->headers);
   }
 
   template <typename T>
@@ -170,7 +162,6 @@ struct Response final : IHasDoRespondViaHTTP {
     this->code = code;
     this->content_type = content_type;
     this->headers = headers;
-    G::SetAccessControlAllowOriginHeaderIfJSON(this->headers);
   }
 
   template <typename T>
@@ -184,7 +175,6 @@ struct Response final : IHasDoRespondViaHTTP {
     this->code = code;
     this->content_type = content_type;
     this->headers = headers;
-    G::SetAccessControlAllowOriginHeaderIfJSON(this->headers);
   }
 
   Response& Body(const std::string& s) {
@@ -248,9 +238,25 @@ struct Response final : IHasDoRespondViaHTTP {
     return *this;
   }
 
+  Response& NoCORS() {
+    cors_header = false;
+    return *this;
+  }
+
+  Response& ReinsertCORS() {
+    cors_header = true;
+    return *this;
+  }
+
   void DoRespondViaHTTP(Request r) const override {
     if (initialized) {
-      r(body, code, content_type, headers);
+      if (cors_header) {
+        auto mutable_headers = headers;
+        mutable_headers.SetCORSHeader();
+        r(body, code, mutable_headers, content_type);
+      } else {
+        r(body, code, headers, content_type);
+      }
     }
     // Else, a 500 "INTERNAL SERVER ERROR" will be returned, since `Request`
     // has not been served upon destructing at the exit from this method.

--- a/blocks/http/response.h
+++ b/blocks/http/response.h
@@ -238,12 +238,12 @@ struct Response final : IHasDoRespondViaHTTP {
     return *this;
   }
 
-  Response& NoCORS() {
+  Response& DisableCORS() {
     cors_header = false;
     return *this;
   }
 
-  Response& ReinsertCORS() {
+  Response& EnableCORS() {
     cors_header = true;
     return *this;
   }

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -1753,7 +1753,7 @@ TEST(HTTPAPI, JSONDoesHaveCORSHeaderByDefault) {
   }
   {
     const auto scope = HTTP(FLAGS_net_api_test_port).Register("/json2", [](Request r) {
-      r(Response(SerializableObject()).NoCORS());
+      r(Response(SerializableObject()).DisableCORS());
     });
 
     const auto response = HTTP(GET(Printf("http://localhost:%d/json2", FLAGS_net_api_test_port)));
@@ -1763,7 +1763,7 @@ TEST(HTTPAPI, JSONDoesHaveCORSHeaderByDefault) {
   }
   {
     const auto scope = HTTP(FLAGS_net_api_test_port).Register("/json3", [](Request r) {
-      r(Response(SerializableObject()).NoCORS() .ReinsertCORS());
+      r(Response(SerializableObject()).DisableCORS().EnableCORS());
     });
 
     const auto response = HTTP(GET(Printf("http://localhost:%d/json3", FLAGS_net_api_test_port)));

--- a/bricks/net/http/constants.h
+++ b/bricks/net/http/constants.h
@@ -50,8 +50,13 @@ constexpr char kTransferEncodingHeaderKey[] = "Transfer-Encoding";
 constexpr char kTransferEncodingChunkedValue[] = "chunked";
 constexpr char kHTTPMethodOverrideHeaderKey[] = "X-HTTP-Method-Override";
 
-constexpr char kHTTPAccessControlAllowOriginHeaderName[] = "Access-Control-Allow-Origin";
-constexpr char kHTTPAccessControlAllowOriginHeaderValue[] = "*";
+// By default:
+// * HTTP responses that use `struct Response` will have the CORS header set.
+//   It can be unset with `.NoCORS()`. There is also `ReinsertCORS()` to add it back.
+// * HTTP responses that use `Request::operator()` will not have the CORS header set.
+//   Use `Headers.{Set,Remove}CORSHeader()` to manually insert or remove it.
+constexpr char kCORSHeaderName[] = "Access-Control-Allow-Origin";
+constexpr char kCORSHeaderValue[] = "*";
 
 #ifndef CURRENT_MAX_HTTP_PAYLOAD
 constexpr size_t kMaxHTTPPayloadSizeInBytes = 1024 * 1024 * 16;

--- a/bricks/net/http/constants.h
+++ b/bricks/net/http/constants.h
@@ -52,7 +52,7 @@ constexpr char kHTTPMethodOverrideHeaderKey[] = "X-HTTP-Method-Override";
 
 // By default:
 // * HTTP responses that use `struct Response` will have the CORS header set.
-//   It can be unset with `.NoCORS()`. There is also `ReinsertCORS()` to add it back.
+//   It can be unset with `.DisableCORS()`. There is also `EnableCORS()` to add it back.
 // * HTTP responses that use `Request::operator()` will not have the CORS header set.
 //   Use `Headers.{Set,Remove}CORSHeader()` to manually insert or remove it.
 constexpr char kCORSHeaderName[] = "Access-Control-Allow-Origin";

--- a/bricks/net/http/headers/headers.h
+++ b/bricks/net/http/headers/headers.h
@@ -280,7 +280,7 @@ struct Headers final {
   }
 
   // The mutable version of `Header& operator[]` is also exposed, and it creates the header if it did not exist.
-  // Returns a header with const `.header` and mutable `.value` mutable.
+  // Returns a header with const `.header` and mutable `.value`.
   // Capitalization-wise, treats various spellings of the same header as one header, retains the name first seen.
   Header& operator[](const std::string& header) {
     Header::ThrowIfHeaderIsCookie(header);

--- a/bricks/net/http/headers/headers.h
+++ b/bricks/net/http/headers/headers.h
@@ -196,7 +196,7 @@ struct Headers final {
                   [this](const std::pair<std::string, std::string>& h) { Set(h.first, h.second); });
   }
 
-  // Can `Set()` / `Get()` / `Has()` headers.
+  // An instance of `Headers` can `Set()` / `Get()` / `Has()` / `Remove()` headers.
   Headers& Set(const std::string& header, const std::string& value) {
     Header::ThrowIfHeaderIsCookie(header);
     // Discard empty headers.
@@ -264,7 +264,8 @@ struct Headers final {
     }
   }
 
-  // Can `operator[] const` headers. Returns the `Header`, with `.header` and `.value`.
+  // An instance of `Headers` can be accessed via `operator[] const`.
+  // Returns the `Header`, with `.header` and `.value`.
   // Capitalization-wise, treats various spellings of the same header as one header, retains the name first seen.
   const Header& operator[](const std::string& header) const {
     Header::ThrowIfHeaderIsCookie(header);
@@ -278,13 +279,14 @@ struct Headers final {
     }
   }
 
-  // Can `Header& operator[]`. Creates the header if it does not exist. Its `.header` is const, `.value` mutable.
+  // The mutable version of `Header& operator[]` is also exposed, and it creates the header if it did not exist.
+  // Returns a header with const `.header` and mutable `.value` mutable.
   // Capitalization-wise, treats various spellings of the same header as one header, retains the name first seen.
   Header& operator[](const std::string& header) {
     Header::ThrowIfHeaderIsCookie(header);
     std::unique_ptr<Header>& placeholder = map[header];
     if (!placeholder) {
-      // Create new `Header` under this `header`.
+      // Create a new `Header` with the name `header` under this placeholder.
       placeholder = std::make_unique<Header>(header);
       list.emplace_back(header, placeholder.get());
     }

--- a/bricks/net/http/headers/headers.h
+++ b/bricks/net/http/headers/headers.h
@@ -196,11 +196,6 @@ struct Headers final {
                   [this](const std::pair<std::string, std::string>& h) { Set(h.first, h.second); });
   }
 
-  inline static Headers DefaultJSONHeaders() {
-    return Headers(
-        {{constants::kHTTPAccessControlAllowOriginHeaderName, constants::kHTTPAccessControlAllowOriginHeaderValue}});
-  }
-
   // Can `Set()` / `Get()` / `Has()` headers.
   Headers& Set(const std::string& header, const std::string& value) {
     Header::ThrowIfHeaderIsCookie(header);
@@ -226,7 +221,17 @@ struct Headers final {
 
   Headers& Remove(const std::string& header) {
     Header::ThrowIfHeaderIsCookie(header);
-    map.erase(header);
+    const auto cit = map.find(header);
+    if (cit != map.end()) {
+      map.erase(cit);
+      headers_list_t updated_list;
+      for (const auto& e : list) {
+        if (e.first != header) {
+          updated_list.emplace_back(std::move(e));
+        }
+      }
+      list = std::move(updated_list);
+    }
     return *this;
   }
 
@@ -260,8 +265,7 @@ struct Headers final {
   }
 
   // Can `operator[] const` headers. Returns the `Header`, with `.header` and `.value`.
-  // Capitalization-wise, treats various spellings of the same header as one header, retains the name first
-  // seen.
+  // Capitalization-wise, treats various spellings of the same header as one header, retains the name first seen.
   const Header& operator[](const std::string& header) const {
     Header::ThrowIfHeaderIsCookie(header);
     const auto rhs = map.find(header);
@@ -274,10 +278,8 @@ struct Headers final {
     }
   }
 
-  // Can `Header& operator[]`. Creates the header if it does not exist. Its `.header` is const, `.value`
-  // mutable.
-  // Capitalization-wise, treats various spellings of the same header as one header, retains the name first
-  // seen.
+  // Can `Header& operator[]`. Creates the header if it does not exist. Its `.header` is const, `.value` mutable.
+  // Capitalization-wise, treats various spellings of the same header as one header, retains the name first seen.
   Header& operator[](const std::string& header) {
     Header::ThrowIfHeaderIsCookie(header);
     std::unique_ptr<Header>& placeholder = map[header];
@@ -329,9 +331,14 @@ struct Headers final {
     }
   }
 
-  void SetAccessControlOriginHeader() {
-    Set(net::constants::kHTTPAccessControlAllowOriginHeaderName,
-        net::constants::kHTTPAccessControlAllowOriginHeaderValue);
+  Headers& SetCORSHeader() {
+    Set(constants::kCORSHeaderName, constants::kCORSHeaderValue);
+    return *this;
+  }
+
+  Headers& RemoveCORSHeader() {
+    Remove(net::constants::kCORSHeaderName);
+    return *this;
   }
 
   // An externally facing `SetCookie()`, to be used mostly while constructing the `Response`.

--- a/karl/claire.h
+++ b/karl/claire.h
@@ -511,6 +511,7 @@ class GenericClaire final : private DummyClaireNotifiable {
       // LCOV_EXCL_START
       r(current::net::DefaultMethodNotAllowedMessage(),
         HTTPResponseCode.MethodNotAllowed,
+        net::http::Headers(),
         net::constants::kDefaultHTMLContentType);
       // LCOV_EXCL_STOP
     }

--- a/karl/karl.h
+++ b/karl/karl.h
@@ -434,6 +434,7 @@ class GenericKarl final : private KarlStorage<STORAGE_TYPE>,
     if (r.method != "GET" && r.method != "POST" && r.method != "DELETE") {
       r(current::net::DefaultMethodNotAllowedMessage(),
         HTTPResponseCode.MethodNotAllowed,
+        net::http::Headers(),
         net::constants::kDefaultHTMLContentType);
       return;
     }
@@ -696,6 +697,7 @@ class GenericKarl final : private KarlStorage<STORAGE_TYPE>,
       // TODO(dkorolev) + TODO(mzhurovich): JSON headers magic.
       r(JSON<JSONFormat::Minimalistic>(KarlUpStatus()) + '\n',
         HTTPResponseCode.OK,
+        current::net::http::Headers(),
         current::net::constants::kDefaultJSONContentType);
     }
   }
@@ -743,6 +745,7 @@ class GenericKarl final : private KarlStorage<STORAGE_TYPE>,
         r(JSON<JSONFormat::Minimalistic>(
               SnapshotOfKeepalive<runtime_status_variant_t>(e.idx_ts.us - current::time::Now(), e.entry.keepalive)),
           HTTPResponseCode.OK,
+          current::net::http::Headers(),
           current::net::constants::kDefaultJSONContentType);
       } else {
         auto tmp = e.entry.keepalive;
@@ -750,6 +753,7 @@ class GenericKarl final : private KarlStorage<STORAGE_TYPE>,
         r(JSON<JSONFormat::Minimalistic>(
               SnapshotOfKeepalive<runtime_status_variant_t>(e.idx_ts.us - current::time::Now(), tmp)),
           HTTPResponseCode.OK,
+          current::net::http::Headers(),
           current::net::constants::kDefaultJSONContentType);
       }
     } else {

--- a/stream/pubsub.h
+++ b/stream/pubsub.h
@@ -244,11 +244,11 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
         output_started_(false),
         http_response_(http_request_.SendChunkedResponse(
             HTTPResponseCode.OK,
-            current::net::constants::kDefaultJSONContentType,
             current::net::http::Headers({
                 {kStreamHeaderCurrentSubscriptionId, subscription_id},
                 {kStreamHeaderCurrentStreamSize, current::ToString(impl_->persister.Size())},
-            }))) {
+            }),
+            current::net::constants::kDefaultJSONContentType)) {
     if (params_.recent.count() > 0) {
       serving_ = false;  // Start in 'non-serving' mode when `recent` is set.
       from_timestamp_ = r.timestamp - params_.recent;

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -514,8 +514,8 @@ class Stream final {
       const std::string body = (r.method == "GET") ? size_str + '\n' : "";
       r(body,
         HTTPResponseCode.OK,
-        current::net::constants::kDefaultContentType,
-        current::net::http::Headers({{kStreamHeaderCurrentStreamSize, size_str}}));
+        current::net::http::Headers({{kStreamHeaderCurrentStreamSize, size_str}}),
+        current::net::constants::kDefaultContentType);
       return;
     }
 

--- a/stream/test.cc
+++ b/stream/test.cc
@@ -1309,8 +1309,8 @@ TEST(Stream, ParseArbitrarilySplitChunks) {
                         const auto index = current::FromString<uint64_t>(r.url.query["i"]);
                         auto response = r.connection.SendChunkedHTTPResponse(
                             HTTPResponseCode.OK,
-                            "text/plain",
-                            current::net::http::Headers({{"X-Current-Stream-Subscription-Id", subscription_id}}));
+                            current::net::http::Headers({{"X-Current-Stream-Subscription-Id", subscription_id}}),
+                            "text/plain");
                         if (index == 0u) {
                           for (const auto& chunk : stream_golden_data_chunks) {
                             response.Send(chunk);


### PR DESCRIPTION
After https://github.com/C5T/Current/pull/805, just one commit: https://github.com/C5T/Current/commit/b5a9a9ba0eda24b57e37695d66be5a5a558fe924

I took the liberty to flip the order of headers and content type, as headers are clearly more important :-)

CC @grixa