### PR TITLE
`Patch` in storage's dictionaries.

### DIFF
--- a/port.h
+++ b/port.h
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+// #define CURRENT_STORAGE_PATCH_SUPPORT
+
 // Cross-platform portability header.
 //
 // Ensures that one and only one of CURRENT_{POSIX,APPLE,ANDROID} is defined.

--- a/port.h
+++ b/port.h
@@ -30,9 +30,6 @@ SOFTWARE.
 #ifndef CURRENT_PORT_H
 #define CURRENT_PORT_H
 
-// TODO(dkorolev): Needed by Nathan. Remove later.
-#include <cassert>
-
 #define NOMINMAX  // Tell Visual Studio to not mess with std::min() / std::max().
 
 #ifdef _MSC_VER

--- a/storage/base.h
+++ b/storage/base.h
@@ -136,11 +136,17 @@ struct FieldCounter {
 };
 
 // Helper class to get the corresponding persisted types for each of the storage fields.
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
 template <typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+#else
+template <typename UPDATE_EVENT, typename DELETE_EVENT>
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 struct FieldInfo {
   using update_event_t = UPDATE_EVENT;
   using delete_event_t = DELETE_EVENT;
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
   using patch_event_t = PATCH_EVENT_OR_VOID;
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 };
 
 // Persisted types list generator.
@@ -149,14 +155,24 @@ struct TypeListMapperImpl;
 
 template <typename FIELDS, int... NS>
 struct TypeListMapperImpl<FIELDS, current::variadic_indexes::indexes<NS...>> {
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
   using result = TypeList<typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::update_event_t...,
                           typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::delete_event_t...,
                           typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::patch_event_t...>;
+#else
+  using result = TypeList<typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::update_event_t...,
+                          typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::delete_event_t...>;
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 };
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
 template <typename FIELDS, int COUNT>
 using FieldsTypeList = current::metaprogramming::TypeListRemoveVoids<
     typename TypeListMapperImpl<FIELDS, current::variadic_indexes::generate_indexes<COUNT>>::result>;
+#else
+template <typename FIELDS, int COUNT>
+using FieldsTypeList = typename TypeListMapperImpl<FIELDS, current::variadic_indexes::generate_indexes<COUNT>>::result;
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 
 // `MutationJournal` keeps all the changes made during one transaction, as well as the way to rollback them.
 struct MutationJournal {

--- a/storage/container/dictionary.h
+++ b/storage/container/dictionary.h
@@ -37,7 +37,11 @@ namespace current {
 namespace storage {
 namespace container {
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID, template <typename...> class MAP>
+template <typename T,
+          typename UPDATE_EVENT,
+          typename DELETE_EVENT,
+          typename PATCH_EVENT_OR_VOID,
+          template <typename...> class MAP>
 class GenericDictionary {
  public:
   using entry_t = T;
@@ -124,9 +128,12 @@ class GenericDictionary {
     }
   }
 
-  // NOTE(dkorolev): The `patch_object` parameter should be passed by value, as otherwise it won't be valid during the possible rollback.
+  // NOTE(dkorolev): The `patch_object` parameter should be passed by value, 
+  // as otherwise it won't be valid during the possible rollback.
   template <typename E = entry_t>
-  typename std::enable_if<HasPatch<E>(), bool>::type Patch(sfinae::CF<key_t> key, const typename E::patch_object_t patch_object) {
+  typename std::enable_if<HasPatch<E>(), bool>::type Patch(
+      sfinae::CF<key_t> key,
+      const typename E::patch_object_t patch_object) {
     static_assert(std::is_same<E, entry_t>::value, "");
     const auto now = current::time::Now();
     const auto map_iterator = map_.find(key);
@@ -168,7 +175,9 @@ class GenericDictionary {
     map_.erase(e.key);
   }
   struct DummyStructForNonExistentPatch {};  // Essential, as can't form a reference to `void` even if disabled.
-  void operator()(const typename std::conditional<HasPatch<entry_t>(), PATCH_EVENT_OR_VOID, DummyStructForNonExistentPatch>::type& e) {
+  void operator()(const typename std::conditional<HasPatch<entry_t>(),
+                                                  PATCH_EVENT_OR_VOID,
+                                                  DummyStructForNonExistentPatch>::type& e) {
     auto it = map_.find(e.key);
     if (it != map_.end()) {
       last_modified_[e.key] = e.us;

--- a/storage/container/many_to_many.h
+++ b/storage/container/many_to_many.h
@@ -43,7 +43,9 @@ namespace container {
 template <typename T,
           typename UPDATE_EVENT,
           typename DELETE_EVENT,
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
           typename PATCH_EVENT_OR_VOID,
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericManyToMany {
@@ -256,6 +258,8 @@ class GenericManyToMany {
   MutationJournal& journal_;
 };
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+
 template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
 using UnorderedManyToUnorderedMany = GenericManyToMany<T, 
                                                        UPDATE_EVENT,
@@ -288,7 +292,25 @@ using OrderedManyToUnorderedMany = GenericManyToMany<T,
                                                      Ordered,
                                                      Unordered>;
 
+#else
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedManyToUnorderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedManyToOrderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedManyToOrderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Ordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedManyToUnorderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Unordered>;
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
+
 }  // namespace container
+
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
 
 template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
 struct StorageFieldTypeSelector<container::UnorderedManyToUnorderedMany<T, E1, E2, E3>> {
@@ -309,6 +331,30 @@ template <typename T, typename E1, typename E2, typename E3>  // Entry, update e
 struct StorageFieldTypeSelector<container::OrderedManyToUnorderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedManyToUnorderedMany"; }
 };
+
+#else
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedManyToUnorderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedManyToUnorderedMany"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedManyToOrderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedManyToOrderedMany"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedManyToOrderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedManyToOrderedMany"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedManyToUnorderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedManyToUnorderedMany"; }
+};
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 
 }  // namespace storage
 }  // namespace current

--- a/storage/container/many_to_many.h
+++ b/storage/container/many_to_many.h
@@ -43,6 +43,7 @@ namespace container {
 template <typename T,
           typename UPDATE_EVENT,
           typename DELETE_EVENT,
+          typename PATCH_EVENT_OR_VOID,
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericManyToMany {
@@ -255,37 +256,57 @@ class GenericManyToMany {
   MutationJournal& journal_;
 };
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using UnorderedManyToUnorderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using UnorderedManyToUnorderedMany = GenericManyToMany<T, 
+                                                       UPDATE_EVENT,
+                                                       DELETE_EVENT,
+                                                       PATCH_EVENT_OR_VOID,
+                                                       Unordered,
+                                                       Unordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using OrderedManyToOrderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using OrderedManyToOrderedMany = GenericManyToMany<T,
+                                                   UPDATE_EVENT,
+                                                   DELETE_EVENT,
+                                                   PATCH_EVENT_OR_VOID,
+                                                   Ordered,
+                                                   Ordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using UnorderedManyToOrderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using UnorderedManyToOrderedMany = GenericManyToMany<T,
+                                                     UPDATE_EVENT,
+                                                     DELETE_EVENT,
+                                                     PATCH_EVENT_OR_VOID,
+                                                     Unordered,
+                                                     Ordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using OrderedManyToUnorderedMany = GenericManyToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using OrderedManyToUnorderedMany = GenericManyToMany<T,
+                                                     UPDATE_EVENT,
+                                                     DELETE_EVENT,
+                                                     PATCH_EVENT_OR_VOID,
+                                                     Ordered,
+                                                     Unordered>;
 
 }  // namespace container
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::UnorderedManyToUnorderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
+struct StorageFieldTypeSelector<container::UnorderedManyToUnorderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedManyToUnorderedMany"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::OrderedManyToOrderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
+struct StorageFieldTypeSelector<container::OrderedManyToOrderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedManyToOrderedMany"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::UnorderedManyToOrderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
+struct StorageFieldTypeSelector<container::UnorderedManyToOrderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedManyToOrderedMany"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::OrderedManyToUnorderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
+struct StorageFieldTypeSelector<container::OrderedManyToUnorderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedManyToUnorderedMany"; }
 };
 

--- a/storage/container/one_to_many.h
+++ b/storage/container/one_to_many.h
@@ -43,6 +43,7 @@ namespace container {
 template <typename T,
           typename UPDATE_EVENT,
           typename DELETE_EVENT,
+          typename PATCH_EVENT, 
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericOneToMany {
@@ -293,37 +294,57 @@ class GenericOneToMany {
   MutationJournal& journal_;
 };
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using UnorderedOneToUnorderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using UnorderedOneToUnorderedMany = GenericOneToMany<T,
+                                                     UPDATE_EVENT,
+                                                     DELETE_EVENT,
+                                                     PATCH_EVENT_OR_VOID,
+                                                     Unordered,
+                                                     Unordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using OrderedOneToOrderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using OrderedOneToOrderedMany = GenericOneToMany<T,
+                                                 UPDATE_EVENT,
+                                                 DELETE_EVENT,
+                                                 PATCH_EVENT_OR_VOID,
+                                                 Ordered,
+                                                 Ordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using UnorderedOneToOrderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using UnorderedOneToOrderedMany = GenericOneToMany<T,
+                                                   UPDATE_EVENT,
+                                                   DELETE_EVENT,
+                                                   PATCH_EVENT_OR_VOID,
+                                                   Unordered,
+                                                   Ordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using OrderedOneToUnorderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using OrderedOneToUnorderedMany = GenericOneToMany<T,
+                                                   UPDATE_EVENT,
+                                                   DELETE_EVENT,
+                                                   PATCH_EVENT_OR_VOID,
+                                                   Ordered,
+                                                   Unordered>;
 
 }  // namespace container
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event.
+struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedOneToUnorderedMany"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::OrderedOneToOrderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event.
+struct StorageFieldTypeSelector<container::OrderedOneToOrderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToOrderedMany"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::UnorderedOneToOrderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event.
+struct StorageFieldTypeSelector<container::UnorderedOneToOrderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedOneToOrderedMany"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::OrderedOneToUnorderedMany<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event.
+struct StorageFieldTypeSelector<container::OrderedOneToUnorderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToUnorderedMany"; }
 };
 

--- a/storage/container/one_to_many.h
+++ b/storage/container/one_to_many.h
@@ -43,7 +43,9 @@ namespace container {
 template <typename T,
           typename UPDATE_EVENT,
           typename DELETE_EVENT,
-          typename PATCH_EVENT, 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+          typename PATCH_EVENT_OR_VOID,
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericOneToMany {
@@ -294,6 +296,8 @@ class GenericOneToMany {
   MutationJournal& journal_;
 };
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+
 template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
 using UnorderedOneToUnorderedMany = GenericOneToMany<T,
                                                      UPDATE_EVENT,
@@ -326,7 +330,25 @@ using OrderedOneToUnorderedMany = GenericOneToMany<T,
                                                    Ordered,
                                                    Unordered>;
 
+#else
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedOneToUnorderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedOneToOrderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedOneToOrderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Ordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedOneToUnorderedMany = GenericOneToMany<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Unordered>;
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
+
 }  // namespace container
+
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
 
 template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event.
 struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedMany<T, E1, E2, E3>> {
@@ -347,6 +369,30 @@ template <typename T, typename E1, typename E2, typename E3>  // Entry, update e
 struct StorageFieldTypeSelector<container::OrderedOneToUnorderedMany<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToUnorderedMany"; }
 };
+
+#else
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedOneToUnorderedMany"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedOneToOrderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedOneToOrderedMany"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedOneToOrderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedOneToOrderedMany"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedOneToUnorderedMany<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedOneToUnorderedMany"; }
+};
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 
 }  // namespace storage
 }  // namespace current

--- a/storage/container/one_to_one.h
+++ b/storage/container/one_to_one.h
@@ -42,7 +42,9 @@ namespace container {
 template <typename T,
           typename UPDATE_EVENT,
           typename DELETE_EVENT,
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
           typename PATCH_EVENT_OR_VOID,
+#endif // CURRENT_STORAGE_PATCH_SUPPORT
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericOneToOne {
@@ -287,6 +289,8 @@ class GenericOneToOne {
   MutationJournal& journal_;
 };
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+
 template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
 using UnorderedOneToUnorderedOne = GenericOneToOne<T,
                                                    UPDATE_EVENT,
@@ -319,27 +323,69 @@ using OrderedOneToUnorderedOne = GenericOneToOne<T,
                                                  Ordered,
                                                  Unordered>;
 
+#else
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedOneToUnorderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedOneToOrderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using UnorderedOneToOrderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Ordered>;
+
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
+using OrderedOneToUnorderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Unordered>;
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
+
 }  // namespace container
 
-template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
 struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedOneToUnorderedOne"; }
 };
 
-template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
 struct StorageFieldTypeSelector<container::OrderedOneToOrderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToOrderedOne"; }
 };
 
-template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
 struct StorageFieldTypeSelector<container::UnorderedOneToOrderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedOneToOrderedOne"; }
 };
 
-template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch event or void.
 struct StorageFieldTypeSelector<container::OrderedOneToUnorderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToUnorderedOne"; }
 };
+
+#else
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedOne<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedOneToUnorderedOne"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedOneToOrderedOne<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedOneToOrderedOne"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::UnorderedOneToOrderedOne<T, E1, E2>> {
+  static const char* HumanReadableName() { return "UnorderedOneToOrderedOne"; }
+};
+
+template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
+struct StorageFieldTypeSelector<container::OrderedOneToUnorderedOne<T, E1, E2>> {
+  static const char* HumanReadableName() { return "OrderedOneToUnorderedOne"; }
+};
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 
 }  // namespace storage
 }  // namespace current

--- a/storage/container/one_to_one.h
+++ b/storage/container/one_to_one.h
@@ -42,6 +42,7 @@ namespace container {
 template <typename T,
           typename UPDATE_EVENT,
           typename DELETE_EVENT,
+          typename PATCH_EVENT_OR_VOID,
           template <typename...> class ROW_MAP,
           template <typename...> class COL_MAP>
 class GenericOneToOne {
@@ -286,37 +287,57 @@ class GenericOneToOne {
   MutationJournal& journal_;
 };
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using UnorderedOneToUnorderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using UnorderedOneToUnorderedOne = GenericOneToOne<T,
+                                                   UPDATE_EVENT,
+                                                   DELETE_EVENT,
+                                                   PATCH_EVENT_OR_VOID,
+                                                   Unordered,
+                                                   Unordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using OrderedOneToOrderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using OrderedOneToOrderedOne = GenericOneToOne<T,
+                                               UPDATE_EVENT,
+                                               DELETE_EVENT,
+                                               PATCH_EVENT_OR_VOID,
+                                               Ordered,
+                                               Ordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using UnorderedOneToOrderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Unordered, Ordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using UnorderedOneToOrderedOne = GenericOneToOne<T,
+                                                 UPDATE_EVENT,
+                                                 DELETE_EVENT,
+                                                 PATCH_EVENT_OR_VOID,
+                                                 Unordered,
+                                                 Ordered>;
 
-template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT>
-using OrderedOneToUnorderedOne = GenericOneToOne<T, UPDATE_EVENT, DELETE_EVENT, Ordered, Unordered>;
+template <typename T, typename UPDATE_EVENT, typename DELETE_EVENT, typename PATCH_EVENT_OR_VOID>
+using OrderedOneToUnorderedOne = GenericOneToOne<T,
+                                                 UPDATE_EVENT,
+                                                 DELETE_EVENT,
+                                                 PATCH_EVENT_OR_VOID,
+                                                 Ordered,
+                                                 Unordered>;
 
 }  // namespace container
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedOne<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+struct StorageFieldTypeSelector<container::UnorderedOneToUnorderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedOneToUnorderedOne"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::OrderedOneToOrderedOne<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+struct StorageFieldTypeSelector<container::OrderedOneToOrderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToOrderedOne"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::UnorderedOneToOrderedOne<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+struct StorageFieldTypeSelector<container::UnorderedOneToOrderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "UnorderedOneToOrderedOne"; }
 };
 
-template <typename T, typename E1, typename E2>  // Entry, update event, delete event.
-struct StorageFieldTypeSelector<container::OrderedOneToUnorderedOne<T, E1, E2>> {
+template <typename T, typename E1, typename E2, typename E3>  // Entry, update event, delete event, patch even tor void.
+struct StorageFieldTypeSelector<container::OrderedOneToUnorderedOne<T, E1, E2, E3>> {
   static const char* HumanReadableName() { return "OrderedOneToUnorderedOne"; }
 };
 

--- a/storage/container/sfinae.h
+++ b/storage/container/sfinae.h
@@ -27,7 +27,10 @@ SOFTWARE.
 
 #include <utility>
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
 #include "../../typesystem/struct.h"
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
+
 #include "../../bricks/template/metaprogramming.h"
 
 namespace current {
@@ -245,6 +248,8 @@ void SetCol(ENTRY& entry, typename col_accessor_t<ENTRY>::cf_col_t col) {
   col_accessor_t<ENTRY>::SetCol(entry, col);
 }
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+
 CURRENT_STRUCT(DummyPatchObjectForNonPatchableEntries) {};
 
 template <bool, class>
@@ -259,6 +264,8 @@ struct patch_object_t_accessor<true, ENTRY> {
 
 template <typename ENTRY>
 using entry_patch_object_t = typename patch_object_t_accessor<HasPatch<ENTRY>(), ENTRY>::patch_object_t;
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 
 }  // namespace sfinae
 }  // namespace storage

--- a/storage/container/sfinae.h
+++ b/storage/container/sfinae.h
@@ -27,6 +27,7 @@ SOFTWARE.
 
 #include <utility>
 
+#include "../../typesystem/struct.h"
 #include "../../bricks/template/metaprogramming.h"
 
 namespace current {
@@ -243,6 +244,21 @@ template <typename ENTRY>
 void SetCol(ENTRY& entry, typename col_accessor_t<ENTRY>::cf_col_t col) {
   col_accessor_t<ENTRY>::SetCol(entry, col);
 }
+
+CURRENT_STRUCT(DummyPatchObjectForNonPatchableEntries) {};
+
+template <bool, class>
+struct patch_object_t_accessor {
+  using patch_object_t = DummyPatchObjectForNonPatchableEntries;
+};
+
+template <class ENTRY>
+struct patch_object_t_accessor<true, ENTRY> {
+  using patch_object_t = typename ENTRY::patch_object_t;
+};
+
+template <typename ENTRY>
+using entry_patch_object_t = typename patch_object_t_accessor<HasPatch<ENTRY>(), ENTRY>::patch_object_t;
 
 }  // namespace sfinae
 }  // namespace storage

--- a/storage/test.cc
+++ b/storage/test.cc
@@ -3546,12 +3546,6 @@ TEST(TransactionalStorage, PatchMutation) {
   }
 
   {
-    // Also, patch for all container types.
-    // Also, rollback of a patch.
-    // Also, where the patch type contains a variant.
-  }
-
-  {
     current::Owned<storage_t> following_storage = storage_t::CreateFollowingStorageAtopExistingStream(stream);
     EXPECT_FALSE(following_storage->IsMasterStorage());
     EXPECT_EQ(6u, following_storage->UnderlyingStream()->Data()->Size());

--- a/storage/test.cc
+++ b/storage/test.cc
@@ -3346,4 +3346,231 @@ TEST(TransactionalStorage, FollowingStorageFlipsToMaster) {
   }
 }
 
+namespace transactional_storage_test {
+
+CURRENT_STRUCT(NonPatchableX) {
+  CURRENT_FIELD(key, std::string);
+  CURRENT_FIELD(x, int32_t);
+  CURRENT_CONSTRUCTOR(NonPatchableX)(std::string key = "", int32_t x = 0) : key(std::move(key)), x(x) {}
+};
+
+CURRENT_STRUCT(PatchToY) {
+  CURRENT_FIELD(dy, int32_t, 0);
+  CURRENT_CONSTRUCTOR(PatchToY)(int32_t dy = 0) : dy(dy) {}
+
+  // To test the forwarding constructor.
+  CURRENT_CONSTRUCTOR(PatchToY)(int32_t dy1, int32_t dy2, int32_t dy3) : dy(dy1 + dy2 + dy3) {}
+};
+
+CURRENT_STRUCT(PatchableY) {
+  CURRENT_FIELD(key, std::string);
+  CURRENT_FIELD(y, int32_t);
+  CURRENT_CONSTRUCTOR(PatchableY)(std::string key = "", int32_t y = 0) : key(std::move(key)), y(y) {}
+  
+  using patch_object_t = PatchToY;
+  void PatchWith(const patch_object_t& patch) {
+    y += patch.dy;
+  }
+};
+
+CURRENT_STORAGE_FIELD_ENTRY(OrderedDictionary, NonPatchableX, NonPatchableXDictionary);
+CURRENT_STORAGE_FIELD_ENTRY(OrderedDictionary, PatchableY, PatchableYDictionary);
+
+CURRENT_STORAGE(PatchTestStorage) {
+  CURRENT_STORAGE_FIELD(x, NonPatchableXDictionary);
+  CURRENT_STORAGE_FIELD(y, PatchableYDictionary);
+};
+
+}  // namespace transactional_storage_test
+
+TEST(TransactionalStorage, PatchMutation) {
+  current::time::ResetToZero();
+
+  using namespace transactional_storage_test;
+  static_assert(!current::HasPatch<NonPatchableX>(), "");
+  static_assert(current::HasPatch<PatchableY>(), "");
+
+  using storage_t = PatchTestStorage<StreamInMemoryStreamPersister>;
+
+  static_assert(std::is_same<typename storage_t::transaction_t, typename storage_t::stream_t::entry_t>::value, "");
+  // clang-format off
+  EXPECT_STREQ("Transaction<Variant<NonPatchableXDictionaryUpdated, PatchableYDictionaryUpdated, NonPatchableXDictionaryDeleted, PatchableYDictionaryDeleted, PatchableYDictionaryPatched>>",
+               current::reflection::CurrentTypeName<typename storage_t::transaction_t>());
+  // clang-format on
+
+  EXPECT_EQ(2u, storage_t::FIELDS_COUNT);
+
+  current::Owned<typename storage_t::stream_t> stream = storage_t::stream_t::CreateStream();
+  current::Owned<storage_t> storage = storage_t::CreateMasterStorageAtopExistingStream(stream);
+
+  EXPECT_TRUE(storage->IsMasterStorage());
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      EXPECT_FALSE(fields.x.Has("a"));
+      fields.x.Add(NonPatchableX{"a", 1});
+      EXPECT_TRUE(fields.x.Has("a"));
+      EXPECT_TRUE(Exists(fields.x["a"]));
+      EXPECT_EQ(1, Value(fields.x["a"]).x);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(1), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      EXPECT_FALSE(fields.y.Has("b"));
+      fields.y.Add(PatchableY{"b", 2});
+      ASSERT_TRUE(fields.y.Has("b"));
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(2, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(2), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      EXPECT_TRUE(fields.y.Patch("b", PatchToY(+10)));
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(12, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(3), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadOnlyTransaction([](ImmutableFields<storage_t> fields) {
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(12, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+  }
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      EXPECT_TRUE(fields.y.Patch("b", +100));
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(112, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(4), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadOnlyTransaction([](ImmutableFields<storage_t> fields) {
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(112, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+  }
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      EXPECT_TRUE(fields.y.Patch("b", +333, +333, +334));
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(1112, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(5), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      const auto b = Value(fields.y["b"]);
+      EXPECT_TRUE(fields.y.Patch(b, PatchToY(+1)));
+      EXPECT_TRUE(fields.y.Patch(b, +2));
+      EXPECT_TRUE(fields.y.Patch(b, 0, -1, -2));
+      EXPECT_EQ(1112, Value(fields.y["b"]).y);
+
+      EXPECT_FALSE(fields.y.Patch("no such key", -1));
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(6), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadOnlyTransaction([](ImmutableFields<storage_t> fields) {
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(1112, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+  }
+
+  {
+    const auto result = storage->ReadWriteTransaction([](MutableFields<storage_t> fields) {
+      EXPECT_TRUE(fields.y.Patch("b", PatchToY(+1000000)));
+      CURRENT_STORAGE_THROW_ROLLBACK();
+    }).Go();
+    EXPECT_FALSE(WasCommitted(result));
+    EXPECT_EQ(static_cast<uint64_t>(6), stream->Data()->Size());
+  }
+
+  {
+    const auto result = storage->ReadOnlyTransaction([](ImmutableFields<storage_t> fields) {
+      ASSERT_TRUE(Exists(fields.y["b"]));
+      EXPECT_EQ(1112, Value(fields.y["b"]).y);
+    }).Go();
+
+    EXPECT_TRUE(WasCommitted(result));
+  }
+
+  {
+    std::vector<std::string> entries;
+    for (const auto& entry : stream->Data()->Iterate()) {
+      for (const auto& mutation : entry.entry.mutations) {
+        entries.push_back(JSON<JSONFormat::Minimalistic>(mutation));
+      }
+    }
+    ASSERT_EQ(8u, entries.size());
+    // clang-format off
+    EXPECT_EQ("{\"NonPatchableXDictionaryUpdated\":{\"us\":1,\"data\":{\"key\":\"a\",\"x\":1}}}", entries[0]);
+    EXPECT_EQ("{\"PatchableYDictionaryUpdated\":{\"us\":5,\"data\":{\"key\":\"b\",\"y\":2}}}", entries[1]);
+    EXPECT_EQ("{\"PatchableYDictionaryPatched\":{\"us\":9,\"key\":\"b\",\"patch\":{\"dy\":10}}}", entries[2]);
+    EXPECT_EQ("{\"PatchableYDictionaryPatched\":{\"us\":13,\"key\":\"b\",\"patch\":{\"dy\":100}}}", entries[3]);
+    EXPECT_EQ("{\"PatchableYDictionaryPatched\":{\"us\":17,\"key\":\"b\",\"patch\":{\"dy\":1000}}}", entries[4]);
+    EXPECT_EQ("{\"PatchableYDictionaryPatched\":{\"us\":21,\"key\":\"b\",\"patch\":{\"dy\":1}}}", entries[5]);
+    EXPECT_EQ("{\"PatchableYDictionaryPatched\":{\"us\":22,\"key\":\"b\",\"patch\":{\"dy\":2}}}", entries[6]);
+    EXPECT_EQ("{\"PatchableYDictionaryPatched\":{\"us\":23,\"key\":\"b\",\"patch\":{\"dy\":-3}}}", entries[7]);
+    // clang-format on
+  }
+
+  {
+    // Also, patch for all container types.
+    // Also, rollback of a patch.
+    // Also, where the patch type contains a variant.
+  }
+
+  {
+    current::Owned<storage_t> following_storage = storage_t::CreateFollowingStorageAtopExistingStream(stream);
+    EXPECT_FALSE(following_storage->IsMasterStorage());
+    EXPECT_EQ(6u, following_storage->UnderlyingStream()->Data()->Size());
+
+    while (following_storage->LastAppliedTimestamp() < storage->LastAppliedTimestamp()) {
+      std::this_thread::yield();
+    }
+
+    {
+      const auto result = following_storage->ReadOnlyTransaction([](ImmutableFields<storage_t> fields) {
+        ASSERT_TRUE(Exists(fields.x["a"]));
+        EXPECT_EQ(1, Value(fields.x["a"]).x);
+        ASSERT_TRUE(Exists(fields.y["b"]));
+        EXPECT_EQ(1112, Value(fields.y["b"]).y);
+      }).Go();
+
+      EXPECT_TRUE(WasCommitted(result));
+    }
+  }
+}
+
 #endif  // STORAGE_ONLY_RUN_RESTFUL_TESTS

--- a/storage/test.cc
+++ b/storage/test.cc
@@ -3346,6 +3346,8 @@ TEST(TransactionalStorage, FollowingStorageFlipsToMaster) {
   }
 }
 
+#ifdef CURRENT_STORAGE_PATCH_SUPPORT
+
 namespace transactional_storage_test {
 
 CURRENT_STRUCT(NonPatchableX) {
@@ -3566,5 +3568,7 @@ TEST(TransactionalStorage, PatchMutation) {
     }
   }
 }
+
+#endif  // CURRENT_STORAGE_PATCH_SUPPORT
 
 #endif  // STORAGE_ONLY_RUN_RESTFUL_TESTS

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -442,6 +442,19 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 
 namespace current {
 
+template <typename T>
+constexpr bool HasPatchObjectImpl(char) {
+  return false;
+}
+
+template <typename T>
+constexpr auto HasPatchObjectImpl(int) -> decltype(sizeof(typename T::patch_object_t), bool()) {
+  return true;
+}
+
+template <typename T>
+constexpr bool HasPatch() { return HasPatchObjectImpl<T>(0); }
+
 // TODO(dkorolev): Find a better place for this code. Must be included from the top-level `current.h`.
 
 template <class B, class D>

--- a/typesystem/test.cc
+++ b/typesystem/test.cc
@@ -1503,3 +1503,46 @@ TEST(TypeSystemTest, InplaceVariantConstruction) {
   ASSERT_FALSE(Exists<Foo>(v));
   EXPECT_EQ(202u, Value<Bar>(v).j);
 }
+
+namespace struct_definition_test {
+
+CURRENT_STRUCT(DoesNotSupportPatch) {
+  CURRENT_FIELD(x, int32_t, 0);
+};
+
+CURRENT_STRUCT(PatchToY) {
+  CURRENT_FIELD(dy, int32_t, 0);
+};
+
+CURRENT_STRUCT(DoesSupportPatch) {
+  CURRENT_FIELD(y, int32_t, 0);
+
+  using patch_object_t = PatchToY;
+  void PatchWith(const patch_object_t& patch) {
+    y += patch.dy;
+  }
+};
+
+}  // namespace struct_definition_test
+
+TEST(TypeSystemTest, Patch) {
+  using namespace struct_definition_test;
+
+  static_assert(!current::HasPatch<void>(), "");
+  static_assert(!current::HasPatch<int>(), "");
+  static_assert(!current::HasPatch<DoesNotSupportPatch>(), "");
+
+  static_assert(current::HasPatch<DoesSupportPatch>(), "");
+
+  DoesSupportPatch object;
+  EXPECT_EQ(0, object.y);
+
+  PatchToY delta_object;
+  delta_object.dy = 42;
+  object.PatchWith(delta_object);
+  EXPECT_EQ(42, object.y);
+
+  delta_object.dy = -10;
+  object.PatchWith(delta_object);
+  EXPECT_EQ(32, object.y);
+}

--- a/typesystem/typename.h
+++ b/typesystem/typename.h
@@ -72,6 +72,13 @@ struct CurrentTypeNameCaller {
   }
 };
 
+template <NameFormat NF>
+struct CurrentTypeNameCaller<NF, CurrentSuper> {
+  static const char* CallGetCurrentTypeName() {
+    return "CurrentSuper";
+  }
+};
+
 template <NameFormat NF, typename T>
 struct JoinTypeNames;
 


### PR DESCRIPTION
Hi @mzhurovich, @grixa,

Я тут немного психанул, and implemented basic `patch` functionality for storage's dictionaries.

(There are only the placeholders for the matrix containers, but no implementation yet).

Basically, a `CURRENT_STRUCT` can be made patchable if it defines the `using patch_object_t = ...` type (another `CURRENT_STRUCT`, of course), and the `.PatchWith(const patch_object_t&)` method within itself.

There's `HasPatch<T>()`, which is `constexpr`, and will return true for false.

Now, for patchable dictionaries in the storage field, one can use `.Patch` on `fields.some_dictionary_field` to patch those fields. It would:
* patch the object ;-)
* return `true` if the object under this key existed, and `false` if it did not
* journal the patch mutation (which will be part of the top-level mutations variant in the transaction type for patch-enabled dictionaries).

The `.Patch` method in dictionaries:
* Requires the key or the object (from which the key would be extracted) as the first parameter.
* Requires the patch object as the second parameter, or `ARGS...` as the second and further parameters (although parameters-free constructor of a patch object is also possible, I just have no idea what could a good use of it be).

Thanks,
Dima