### PR TITLE
Fixed several compilation warnings discovered by the llvm 9.1.0 clang.

### DIFF
--- a/blocks/http/impl/posix_server.h
+++ b/blocks/http/impl/posix_server.h
@@ -272,7 +272,7 @@ class HTTPServerPOSIX final {
     HTTPRoutesScope scope;
     current::FileSystem::ScanDir(
         dir,
-        [this, &dir, &options, &scope](const current::FileSystem::ScanDirItemInfo& item_info) {
+        [this, &options, &scope](const current::FileSystem::ScanDirItemInfo& item_info) {
           // Ignore files named with a leading dot (means hidden in POSIX) before checking MIME type.
           if (item_info.basename.front() == '.') {
             return;

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -1615,7 +1615,7 @@ TEST(HTTPAPI, ResponseSmokeTest) {
                     }) +
       HTTP(FLAGS_net_api_test_port)
           .Register("/response10",
-                    [send_response](Request r) {
+                    [](Request r) {
                       SerializableVariant v;
                       v.template Construct<SerializableObject>();
                       r(v);

--- a/blocks/http/types.h
+++ b/blocks/http/types.h
@@ -122,9 +122,7 @@ template <typename REQUEST>
 struct FillBody<REQUEST, false> {
   template <typename T>
   static typename std::enable_if<IS_CURRENT_STRUCT_OR_VARIANT(current::decay<T>)>::type Fill(
-      REQUEST& request,
-      T&& object,
-      const std::string& content_type) {
+      REQUEST& request, T&& object, const std::string& content_type) {
     request.body = JSON(std::forward<T>(object));
     request.content_type = !content_type.empty() ? content_type : net::constants::kDefaultJSONContentType;
   }

--- a/bricks/graph/gnuplot.h
+++ b/bricks/graph/gnuplot.h
@@ -235,8 +235,8 @@ struct GNUPlot {
       }
     }
     if (output_format_ != "gnuplot") {
-      CURRENT_ASSERT(!bricks::system::SystemCall(current::strings::Printf(
-          strings::Printf("gnuplot <%s >%s", input_file_name.c_str(), output_file_name.c_str()).c_str())));
+      CURRENT_ASSERT(!bricks::system::SystemCall(
+                         strings::Printf("gnuplot <%s >%s", input_file_name.c_str(), output_file_name.c_str())));
       return current::FileSystem::ReadFileAsString(output_file_name.c_str());
     } else {
       // For unit tests, just compare the inputs.

--- a/bricks/sync/test.cc
+++ b/bricks/sync/test.cc
@@ -181,7 +181,7 @@ TEST(OwnedBorrowed, BorrowedWithCallbackOutlivingTheOwner) {
     std::atomic_bool terminating(false);
     // The `unique_ptr` ugliness is to have the pre-initialized `current::BorrowedWithCallback` movable.
     thread = std::make_unique<std::thread>(
-        [&log, &terminating](std::unique_ptr<current::BorrowedWithCallback<Container>> y0) {
+        [&terminating](std::unique_ptr<current::BorrowedWithCallback<Container>> y0) {
           current::BorrowedWithCallback<Container>& y = *y0.get();
           EXPECT_TRUE(static_cast<bool>(y));
           // Keep incrementing until external termination request.

--- a/karl/test_service/http_subscriber.h
+++ b/karl/test_service/http_subscriber.h
@@ -66,7 +66,7 @@ class HTTPStreamSubscriber {
       HTTP(ChunkedGET(url,
                       [this](const std::string& header, const std::string& value) { OnHeader(header, value); },
                       [this](const std::string& chunk_body) { OnChunk(chunk_body); },
-                      [this]() {}));
+                      []() {}));
     } catch (current::net::NetworkException& e) {
       std::cerr << e.DetailedDescription() << std::endl;
       CURRENT_ASSERT(false);

--- a/nlp/nlp.h
+++ b/nlp/nlp.h
@@ -146,10 +146,8 @@ struct OrImplWithVariant {
                 size_t begin,
                 size_t end,
                 std::function<void(const emitted_t&)> emit) const {
-    lhs_impl_.EvalImpl(
-        query, begin, end, [&query, begin, end, &emit](const LHS_TYPE& value) { emit(emitted_t(value)); });
-    rhs_impl_.EvalImpl(
-        query, begin, end, [&query, begin, end, &emit](const RHS_TYPE& value) { emit(emitted_t(value)); });
+    lhs_impl_.EvalImpl(query, begin, end, [&emit](const LHS_TYPE& value) { emit(emitted_t(value)); });
+    rhs_impl_.EvalImpl(query, begin, end, [&emit](const RHS_TYPE& value) { emit(emitted_t(value)); });
   }
 };
 
@@ -165,8 +163,8 @@ struct OrImplSameType {
                 size_t begin,
                 size_t end,
                 std::function<void(const emitted_t&)> emit) const {
-    lhs_impl_.EvalImpl(query, begin, end, [&query, begin, end, &emit](const TYPE& value) { emit(emitted_t(value)); });
-    rhs_impl_.EvalImpl(query, begin, end, [&query, begin, end, &emit](const TYPE& value) { emit(emitted_t(value)); });
+    lhs_impl_.EvalImpl(query, begin, end, [&emit](const TYPE& value) { emit(emitted_t(value)); });
+    rhs_impl_.EvalImpl(query, begin, end, [&emit](const TYPE& value) { emit(emitted_t(value)); });
   }
 };
 

--- a/storage/api.h
+++ b/storage/api.h
@@ -336,11 +336,11 @@ struct PerFieldRESTfulHandlerGenerator {
         handler.Enter(
             std::move(request),
             // Capture by reference since this lambda is run synchronously.
-            [&storage, &handler, &generic_input, &field_name](Request request, const Optional<std::string>& url_key) {
+            [&handler, &generic_input, &field_name](Request request, const Optional<std::string>& url_key) {
               const specific_field_t& field = generic_input.storage(::current::storage::ImmutableFieldByIndex<INDEX>());
               generic_input.storage.template ReadOnlyTransaction<current::locks::MutexLockStatus::AlreadyLocked>(
                                         // Capture local variables by value for safe async transactions.
-                                        [&storage, handler, generic_input, &field, url_key, field_name](
+                                        [handler, generic_input, &field, url_key, field_name](
                                             immutable_fields_t fields) -> Response {
                                           using RowColGETInput =
                                               RESTfulGETRowColInput<STORAGE,
@@ -619,7 +619,7 @@ class RESTfulStorage {
                   storage.template ReadOnlyTransaction<current::locks::MutexLockStatus::AlreadyLocked>(
                               // TODO(dkorolev): Revisit this as Owned/Borrowed are the organic part of Storage.
                               // Capture local variables by value for safe async transactions.
-                              [&storage, &f_run_query, handler, cqs_parameters, type_erased_query, context](
+                              [&f_run_query, handler, cqs_parameters, type_erased_query, context](
                                   immutable_fields_t fields) -> Response {
                                 return handler.RunQuery(
                                     context, f_run_query, fields, std::move(type_erased_query), cqs_parameters);
@@ -668,7 +668,7 @@ class RESTfulStorage {
                   storage.template ReadWriteTransaction<current::locks::MutexLockStatus::AlreadyLocked>(
                               // TODO(dkorolev): Revisit this as Owned/Borrowed are the organic part of Storage.
                               // Capture local variables by value for safe async transactions.
-                              [&storage, &f_run_command, handler, cqs_parameters, type_erased_command, ctx](
+                              [&f_run_command, handler, cqs_parameters, type_erased_command, ctx](
                                   mutable_fields_t fields) -> Response {
                                 return handler.RunCommand(
                                     ctx, f_run_command, fields, std::move(type_erased_command), cqs_parameters);

--- a/storage/container/many_to_many.h
+++ b/storage/container/many_to_many.h
@@ -69,12 +69,8 @@ class GenericManyToMany {
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }
 
-  bool Has(sfinae::CF<key_t> key) const {
-    return map_.find(key) != map_.end();
-  }
-  bool Has(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const {
-    return map_.find(key_t(row, col)) != map_.end();
-  }
+  bool Has(sfinae::CF<key_t> key) const { return map_.find(key) != map_.end(); }
+  bool Has(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const { return map_.find(key_t(row, col)) != map_.end(); }
 
   void Add(const T& object) {
     const auto now = current::time::Now();

--- a/storage/container/one_to_many.h
+++ b/storage/container/one_to_many.h
@@ -68,12 +68,8 @@ class GenericOneToMany {
   bool Empty() const { return map_.empty(); }
   size_t Size() const { return map_.size(); }
 
-  bool Has(sfinae::CF<key_t> key) const {
-    return map_.find(key) != map_.end();
-  }
-  bool Has(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const {
-    return map_.find(key_t(row, col)) != map_.end();
-  }
+  bool Has(sfinae::CF<key_t> key) const { return map_.find(key) != map_.end(); }
+  bool Has(sfinae::CF<row_t> row, sfinae::CF<col_t> col) const { return map_.find(key_t(row, col)) != map_.end(); }
 
   // Adds specified object and overwrites existing one if it has the same row and col.
   // Removes all other existing objects with the same col.

--- a/stream/pubsub.h
+++ b/stream/pubsub.h
@@ -348,7 +348,7 @@ class PubSubHTTPEndpointImpl : public AbstractSubscriberObject {
       }
       auto current_us = std::chrono::microseconds(0);
       // Obtain current timestamp only when it's necessary by parsing the `raw_log_line`.
-      const auto GetCurrentUs = [this, &current_us, &raw_log_line]() -> std::chrono::microseconds {
+      const auto GetCurrentUs = [&current_us, &raw_log_line]() -> std::chrono::microseconds {
         if (!current_us.count()) {
           current_us = ParseJSON<ts_only_t>(raw_log_line.substr(0, raw_log_line.find('\t'))).us;
         }

--- a/stream/replicator.h
+++ b/stream/replicator.h
@@ -157,7 +157,7 @@ class SubscribableRemoteStream final {
           HTTP(ChunkedGET(bare_stream.GetURLToSubscribe(index_, checked_subscription_),
                           [this](const std::string& header, const std::string& value) { OnHeader(header, value); },
                           [this](const std::string& chunk_body) { OnChunk(chunk_body); },
-                          [this]() {}));
+                          [](){}));
         } catch (StreamTerminatedBySubscriber&) {
           break;
         } catch (RemoteStreamMalformedChunkException&) {

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -574,7 +574,7 @@ class Stream final {
 
       auto http_chunked_subscriber = std::make_unique<PubSubHTTPEndpoint<entry_t, PERSISTENCE_LAYER, J>>(
           subscription_id, borrowed_impl, std::move(r), std::move(request_params));
-      const auto done_callback = [this, borrowed_impl, subscription_id]() {
+      const auto done_callback = [borrowed_impl, subscription_id]() {
         // Note: Called from a locked section of `borrowed_impl->http_subscriptions_mutex`.
         borrowed_impl->http_subscriptions[subscription_id].second = nullptr;
       };


### PR DESCRIPTION
Hi @dkorolev and @mzhurovich . I've updated my xCode and got several new warnings. Most of them were about unused variables captured by lambdas. I removed them, but if their presence is important for some reasons, we can also declare them unused explicitly.