### PR TITLE
And removed those dynamically created `current` symlinks from git.

### DIFF
--- a/examples/datafest_talk/tier5_online_tool/step2_rides_by_months/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step2_rides_by_months/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step3_static_member/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step3_static_member/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step4_multithreading/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step4_multithreading/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step5_avg_speed_by_hour/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step5_avg_speed_by_hour/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step6_correct_avg_speed_by_hour/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step6_correct_avg_speed_by_hour/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step7_return_json/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step7_return_json/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step8_average_speed_per_hour_histogram/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step8_average_speed_per_hour_histogram/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current

--- a/examples/datafest_talk/tier5_online_tool/step9_custom_json/.gitignore
+++ b/examples/datafest_talk/tier5_online_tool/step9_custom_json/.gitignore
@@ -1,0 +1,2 @@
+# `current` here is the the symlink, created dynamically to avoid circular paths.
+current


### PR DESCRIPTION
A follow-up after https://github.com/C5T/Current/pull/837/commits/e370c43aa5762b42fdd6d78aafa6945d383f0dba from https://github.com/C5T/Current/pull/837.