### PR TITLE
CURRENT_USE_BASE_CONSTRUCTORS

### DIFF
--- a/typesystem/serialization/test.cc
+++ b/typesystem/serialization/test.cc
@@ -1609,9 +1609,9 @@ namespace serialization_test {
 
 CURRENT_STRUCT_T(CurrentStructTUsingSubtype) {
   CURRENT_EXTRACT_T_SUBTYPE(single_element_t, extracted_single_element_t);
-  CURRENT_EXTRACT_T_SUBTYPE(vector_element_t, extracted_vector_element_t);
+  CURRENT_EXTRACT_T_SUBTYPE(vector_element_t);
   CURRENT_FIELD(xs, extracted_single_element_t);
-  CURRENT_FIELD(xv, std::vector<extracted_vector_element_t>);
+  CURRENT_FIELD(xv, std::vector<vector_element_t>);
 };
 
 CURRENT_STRUCT_T(CurrentStructTUsingDerived) {

--- a/typesystem/serialization/test.cc
+++ b/typesystem/serialization/test.cc
@@ -1562,10 +1562,16 @@ CURRENT_STRUCT_T(TemplatedBase) {
 };
 
 CURRENT_STRUCT(EmptyDerivedFromNonTemplatedBase, NonTemplatedBase) {
-  CURRENT_CONSTRUCTOR(EmptyDerivedFromNonTemplatedBase)(uint32_t n) : SUPER(n) {}
+  CURRENT_USE_BASE_CONSTRUCTORS(EmptyDerivedFromNonTemplatedBase);
 };
 
-CURRENT_STRUCT(EmptyDerivedFromTemplatedBase, TemplatedBase<std::string>) {};
+CURRENT_STRUCT(EmptyDerivedFromTemplatedBase, TemplatedBase<std::string>) {
+  CURRENT_USE_BASE_CONSTRUCTORS(EmptyDerivedFromTemplatedBase);
+};
+
+CURRENT_STRUCT_T(TemplateDerivedFromNonTemplatedBase, TemplatedBase<std::string>) {
+  CURRENT_USE_T_BASE_CONSTRUCTORS(TemplateDerivedFromNonTemplatedBase);
+};
 
 CURRENT_STRUCT(NonEmptyDerivedFromNonTemplatedBase, NonTemplatedBase) {
   CURRENT_FIELD(u, uint32_t);
@@ -1592,24 +1598,36 @@ TEST(JSONSerialization, DerivedSupportsConstructorForwarding) {
 
   EXPECT_EQ("{'n':3,'u':4}", SingleQuoted(JSON(NonEmptyDerivedFromNonTemplatedBase(3, 4))));
 
+  EXPECT_EQ("{'i':12321,'x':'baz'}", SingleQuoted(JSON(EmptyDerivedFromTemplatedBase(12321, "baz"))));
+
+  EXPECT_EQ("{'i':12321,'x':'baz'}", SingleQuoted(JSON(TemplateDerivedFromNonTemplatedBase<std::string>(12321, "baz"))));
+
   EXPECT_EQ("{'i':12321,'x':'baz','w':101}", SingleQuoted(JSON(NonEmptyDerivedFromTemplatedBase(12321, "baz", 101))));
 }
 
 namespace serialization_test {
 
 CURRENT_STRUCT_T(CurrentStructTUsingSubtype) {
+  CURRENT_EXTRACT_T_SUBTYPE(single_element_t, extracted_single_element_t);
   CURRENT_EXTRACT_T_SUBTYPE(vector_element_t, extracted_vector_element_t);
-  CURRENT_FIELD(xs, std::vector<extracted_vector_element_t>);
+  CURRENT_FIELD(xs, extracted_single_element_t);
+  CURRENT_FIELD(xv, std::vector<extracted_vector_element_t>);
+};
+
+CURRENT_STRUCT_T(CurrentStructTUsingDerived) {
+  CURRENT_FIELD(x, CurrentStructTUsingSubtype<T>);
 };
 
 // NOTE(dkorolev): I recall we had a `static_assert` that only `CURRENT_STRUCT`-s can be the bases
 //                 for `CURRENT_STRUCT_T`-s. This test may need to be revisited as we re-enable that check.
 struct VectorOfUInt32s {
   using vector_element_t = uint32_t;
+  using single_element_t = uint32_t;
 };
 
 struct VectorOfStrings {
   using vector_element_t = std::string;
+  using single_element_t = std::string;
 };
 
 }  // namespace serialization_test
@@ -1618,12 +1636,22 @@ TEST(JSONSerialization, CanSerializeWithSubtypesOfTInCurrentStructT) {
   using namespace serialization_test;
 
   CurrentStructTUsingSubtype<VectorOfUInt32s> u;
-  u.xs.push_back(42);
-  EXPECT_EQ("{'xs':[42]}", SingleQuoted(JSON(u)));
+  u.xs = 42;
+  u.xv.push_back(42);
+  EXPECT_EQ("{'xs':42,'xv':[42]}", SingleQuoted(JSON(u)));
 
   CurrentStructTUsingSubtype<VectorOfStrings> s;
-  s.xs.push_back("hello");
-  EXPECT_EQ("{'xs':['hello']}", SingleQuoted(JSON(s)));
+  s.xs = "hello";
+  s.xv.push_back("world");
+  EXPECT_EQ("{'xs':'hello','xv':['world']}", SingleQuoted(JSON(s)));
+
+  CurrentStructTUsingDerived<VectorOfUInt32s> du;
+  du.x = u;
+  EXPECT_EQ("{'x':{'xs':42,'xv':[42]}}", SingleQuoted(JSON(du)));
+
+  CurrentStructTUsingDerived<VectorOfStrings> ds;
+  ds.x = s;
+  EXPECT_EQ("{'x':{'xs':'hello','xv':['world']}}", SingleQuoted(JSON(ds)));
 }
 
 #endif  // CURRENT_TYPE_SYSTEM_SERIALIZATION_TEST_CC

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -440,19 +440,33 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   constexpr static const char* CURRENT_EXPORTED_STRUCT_NAME() { return #original_struct_name "_Z"; } \
   using template_inner_t_internal = std::true_type;                                                  \
   using template_inner_t_impl = original_template_inner_type
+
+#define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                        \
+  using CRNT_super_t =                                                                                          \
+      typename std::conditional<std::is_same<INSTANTIATION_TYPE, ::crnt::r::DF>::value, SUPER, CSSH_##s>::type; \
+  using CRNT_super_t::CRNT_super_t
+
+#define CURRENT_USE_T_BASE_CONSTRUCTORS(s)                                                               \
+  using CRNT_super_t = typename std::conditional<std::is_same<INSTANTIATION_TYPE, ::crnt::r::DF>::value, \
+                                                 SUPER,                                                  \
+                                                 CURRENT_STRUCT_T_SUPER_HELPER_##s>::type;               \
+  using CRNT_super_t::CRNT_super_t
 #else
 // I sure hope this is how it should be. -- D.K.
 #define CURRENT_EXPORTED_TEMPLATED_STRUCT(original_struct_name, original_template_inner_type)        \
   constexpr static const char* CURRENT_EXPORTED_STRUCT_NAME() { return #original_struct_name "_Z"; } \
   using template_inner_t = original_template_inner_type
+
+#define CURRENT_USE_BASE_CONSTRUCTORS(s) using SUPER::SUPER
+#define CURRENT_USE_T_BASE_CONSTRUCTORS(s) using SUPER::SUPER
 #endif
 
-#define CURRENT_EXTRACT_T_SUBTYPE(subtype, exported_subtype)             \
-  struct CRNT_##exported_subtype_##_helper_t { using subtype = int; };   \
-  using exported_subtype =                                               \
-    typename std::conditional<std::is_same<T, ::crnt::r::DummyT>::value, \
-                              CRNT_##exported_subtype_##_helper_t,       \
-                              T>::type::subtype
+#define CURRENT_EXTRACT_T_SUBTYPE(subtype, exported_subtype) \
+  struct CRNT_##exported_subtype##_helper_t {                \
+    using subtype = int;                                     \
+  };                                                         \
+  using exported_subtype = typename std::                    \
+      conditional<std::is_same<T, ::crnt::r::DummyT>::value, CRNT_##exported_subtype##_helper_t, T>::type::subtype
 
 namespace current {
 

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -444,7 +444,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 // Can't just write "using SUPER::SUPER", because SUPER always uses ::crnt::r::DF,
 // which means for different INSTANTIATION_TYPEs it isn't actually a base to the "s" struct.
 // Use CSSH_##s and CURRENT_STRUCT_T_SUPER_HELPER_##s for this cases instead,
-// as they always base to the "s" regardless of what the INSTANTIATION_TYPE is.
+// as they are always the base class to the "s" regardless of what the INSTANTIATION_TYPE is.
 #define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                        \
   using CRNT_super_t =                                                                                          \
       typename std::conditional<std::is_same<INSTANTIATION_TYPE, ::crnt::r::DF>::value, SUPER, CSSH_##s>::type; \

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -441,6 +441,10 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   using template_inner_t_internal = std::true_type;                                                  \
   using template_inner_t_impl = original_template_inner_type
 
+// Can't just write "using SUPER::SUPER", because SUPER always uses ::crnt::r::DF,
+// which means for different INSTANTIATION_TYPEs it isn't actually a base to the "s" struct.
+// Use CSSH_##s and CURRENT_STRUCT_T_SUPER_HELPER_##s for this cases instead,
+// as they always base to the "s" regardless of what the INSTANTIATION_TYPE is.
 #define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                        \
   using CRNT_super_t =                                                                                          \
       typename std::conditional<std::is_same<INSTANTIATION_TYPE, ::crnt::r::DF>::value, SUPER, CSSH_##s>::type; \
@@ -457,6 +461,8 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   constexpr static const char* CURRENT_EXPORTED_STRUCT_NAME() { return #original_struct_name "_Z"; } \
   using template_inner_t = original_template_inner_type
 
+// A "simple" solution with using SUPER::SUPER works only for Windows,
+// as SUPER always corresponds to the base type no matter what INSTANTIATION_TYPE is.
 #define CURRENT_USE_BASE_CONSTRUCTORS(s) using SUPER::SUPER
 #define CURRENT_USE_T_BASE_CONSTRUCTORS(s) using SUPER::SUPER
 #endif

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -461,12 +461,27 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CURRENT_USE_T_BASE_CONSTRUCTORS(s) using SUPER::SUPER
 #endif
 
-#define CURRENT_EXTRACT_T_SUBTYPE(subtype, exported_subtype) \
-  struct CRNT_##exported_subtype##_helper_t {                \
-    using subtype = int;                                     \
-  };                                                         \
-  using exported_subtype = typename std::                    \
+#define CURRENT_EXTRACT_T_SUBTYPE_IMPL(subtype, exported_subtype) \
+  struct CRNT_##exported_subtype##_helper_t {                     \
+    using subtype = int;                                          \
+  };                                                              \
+  using exported_subtype = typename std::                         \
       conditional<std::is_same<T, ::crnt::r::DummyT>::value, CRNT_##exported_subtype##_helper_t, T>::type::subtype
+
+#define CETS_IMPL1(a) CURRENT_EXTRACT_T_SUBTYPE_IMPL(a, a)
+#define CETS_IMPL2(a, b) CURRENT_EXTRACT_T_SUBTYPE_IMPL(a, b)
+
+#define CETS_N_ARGS_IMPL2(_1, _2, n, ...) n
+#define CETS_N_ARGS_IMPL(args) CETS_N_ARGS_IMPL2 args
+
+#define CETS_NARGS(...) CETS_N_ARGS_IMPL((__VA_ARGS__, 2, 1, 0))
+
+#define CETS_CHOOSER2(n) CETS_IMPL##n
+#define CETS_CHOOSER1(n) CETS_CHOOSER2(n)
+#define CETS_CHOOSERX(n) CETS_CHOOSER1(n)
+
+#define CETS_SWITCH(x, y) x y
+#define CURRENT_EXTRACT_T_SUBTYPE(...) CETS_SWITCH(CETS_CHOOSERX(CETS_NARGS(__VA_ARGS__)), (__VA_ARGS__))
 
 namespace current {
 


### PR DESCRIPTION
Hi @dkorolev, CC @mzhurovich 

I added new macro `CURRENT_USE_BASE_CONSTRUCTORS` to fix that `using SUPER::SUPER` problem we had discussed before. It works on both Windows and Linux, although I have several concerns:
* Naming, as usual. `CURRENT_EXPOSE_BASE_CONSTRUCTORS` or `CURRENT_FORWARD_BASE_CONSTRUCTORS` might be better.
* I'm not sure why `CURRENT_STRUCT` and `CURRENT_STRUCT_T` use different names for similar entities: `CSSH_##s` and `CURRENT_STRUCT_T_SUPER_HELPER_##s`. If there is no special meaning behind this difference, we could make them equal and get rid of the second `CURRENT_USE_T_BASE_CONSTRUCTORS`

I also fixed `CURRENT_EXTRACT_T_SUBTYPE`, cause it didn't work when being used multiple times.