### PR TITLE
Added support for custom `gtest` comparators.

### DIFF
--- a/3rdparty/gtest/gtest-custom-comparators.h
+++ b/3rdparty/gtest/gtest-custom-comparators.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef THIRDPARTY_GTEST_CUSTOM_COMPARATORS_H
+#define THIRDPARTY_GTEST_CUSTOM_COMPARATORS_H
+
+#include <string>
+#include <ostream>
+#include <functional>  // For `std::decay_t<>`, reluctant to bring in `current::decay` here.
+
+// NOTE(dkorolev): This file is added manually to allow writing cleaner unit tests for external user-defined types.
+//                 The user can partially specialize `CustomComparator` for their own types in `namespace ::gtest`,
+//                 and use `EXPECT_EQ` / `EXPECT_NE` in their unit tests to do the job natively.
+namespace gtest {
+template <typename LHS, typename RHS>
+struct CustomComparator {
+  template <typename LHS_INSTANCE, typename RHS_INSTANCE>
+  static bool EXPECT_EQ_IMPL(LHS_INSTANCE&& lhs, RHS_INSTANCE&& rhs) {
+    return std::forward<LHS_INSTANCE>(lhs) == std::forward<RHS_INSTANCE>(rhs);
+  }
+  template <typename LHS_INSTANCE, typename RHS_INSTANCE>
+  static bool EXPECT_NE_IMPL(LHS_INSTANCE&& lhs, RHS_INSTANCE&& rhs) {
+    return std::forward<LHS_INSTANCE>(lhs) != std::forward<RHS_INSTANCE>(rhs);
+  }
+};
+}  // namespace gtest
+
+#endif  // THIRDPARTY_GTEST_CUSTOM_COMPARATORS_H

--- a/3rdparty/gtest/gtest.h
+++ b/3rdparty/gtest/gtest.h
@@ -26,6 +26,8 @@ SOFTWARE.
 #ifndef THIRDPARTY_GTEST_H
 #define THIRDPARTY_GTEST_H
 
+#include "gtest-custom-comparators.h"   // Must be the first header `#include`-d. -- D.K.
+
 #define GTEST_HAS_TR1_TUPLE 0  // Suppress Visual Studio warnings.
 
 #include "src/gtest-all.cc"

--- a/3rdparty/gtest/include/gtest/gtest.h
+++ b/3rdparty/gtest/include/gtest/gtest.h
@@ -1441,7 +1441,8 @@ AssertionResult CmpHelperEQ(const char* lhs_expression,
                             const char* rhs_expression,
                             const T1& lhs,
                             const T2& rhs) {
-  if (lhs == rhs) {
+  if (::gtest::CustomComparator<typename std::decay<T1>::type,
+                                typename std::decay<T2>::type>::EXPECT_EQ_IMPL(lhs, rhs)) {
     return AssertionSuccess();
   }
 
@@ -1455,6 +1456,35 @@ GTEST_API_ AssertionResult CmpHelperEQ(const char* lhs_expression,
                                        const char* rhs_expression,
                                        BiggestInt lhs,
                                        BiggestInt rhs);
+
+// NOTE(dkorolev): Manually copy-pasted the above for `_NE` as well as for `_EQ`, for custom comparators.
+#if 1
+template <typename T1, typename T2>
+AssertionResult CmpHelperNEFailure(const char* lhs_expression,
+                                   const char* rhs_expression,
+                                   const T1& lhs, const T2& rhs) {
+  return NeFailure(lhs_expression,
+                   rhs_expression,
+                   FormatForComparisonFailureMessage(lhs, rhs),
+                   FormatForComparisonFailureMessage(rhs, lhs),
+                   false);
+}
+template <typename T1, typename T2>
+AssertionResult CmpHelperNE(const char* lhs_expression,
+                            const char* rhs_expression,
+                            const T1& lhs,
+                            const T2& rhs) {
+  if (::gtest::CustomComparator<typename std::decay<T1>::type,
+                                typename std::decay<T2>::type>::EXPECT_NE_IMPL(lhs, rhs)) {
+    return AssertionSuccess();
+  }
+  return CmpHelperNEFailure(lhs_expression, rhs_expression, lhs, rhs);
+}
+GTEST_API_ AssertionResult CmpHelperNE(const char* lhs_expression,
+                                       const char* rhs_expression,
+                                       BiggestInt lhs,
+                                       BiggestInt rhs);
+#endif
 
 // The helper class for {ASSERT|EXPECT}_EQ.  The template argument
 // lhs_is_null_literal is true iff the first argument to ASSERT_EQ()
@@ -1570,7 +1600,8 @@ GTEST_API_ AssertionResult CmpHelper##op_name(\
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 
 // Implements the helper function for {ASSERT|EXPECT}_NE
-GTEST_IMPL_CMP_HELPER_(NE, !=);
+// NOTE(dkorolev): Commented out, as it is defined explicitly above.
+// GTEST_IMPL_CMP_HELPER_(NE, !=);
 // Implements the helper function for {ASSERT|EXPECT}_LE
 GTEST_IMPL_CMP_HELPER_(LE, <=);
 // Implements the helper function for {ASSERT|EXPECT}_LT

--- a/3rdparty/gtest/include/gtest/internal/gtest-internal.h
+++ b/3rdparty/gtest/include/gtest/internal/gtest-internal.h
@@ -209,6 +209,11 @@ GTEST_API_ AssertionResult EqFailure(const char* expected_expression,
                                      const std::string& expected_value,
                                      const std::string& actual_value,
                                      bool ignoring_case);
+GTEST_API_ AssertionResult NeFailure(const char* expected_expression,
+                                     const char* actual_expression,
+                                     const std::string& expected_value,
+                                     const std::string& actual_value,
+                                     bool ignoring_case);
 
 // Constructs a failure message for Boolean assertions such as EXPECT_TRUE.
 GTEST_API_ std::string GetBoolAssertionFailureMessage(

--- a/3rdparty/gtest/src/gtest.cc
+++ b/3rdparty/gtest/src/gtest.cc
@@ -1387,6 +1387,41 @@ AssertionResult EqFailure(const char* lhs_expression,
   return AssertionFailure() << msg;
 }
 
+// NOTE(dkorolev): Copy-pasted from `EqFailure`, for custom user-defined comparators to print user-friendly outputs.
+AssertionResult NeFailure(const char* lhs_expression,
+                          const char* rhs_expression,
+                          const std::string& lhs_value,
+                          const std::string& rhs_value,
+                          bool ignoring_case) {
+  Message msg;
+  msg << "Expected inequality of these values:";
+  msg << "\n  " << lhs_expression;
+  if (lhs_value != lhs_expression) {
+    msg << "\n    Which is: " << lhs_value;
+  }
+  msg << "\n  " << rhs_expression;
+  if (rhs_value != rhs_expression) {
+    msg << "\n    Which is: " << rhs_value;
+  }
+
+  if (ignoring_case) {
+    msg << "\nIgnoring case";
+  }
+
+  if (!lhs_value.empty() && !rhs_value.empty()) {
+    const std::vector<std::string> lhs_lines =
+        SplitEscapedString(lhs_value);
+    const std::vector<std::string> rhs_lines =
+        SplitEscapedString(rhs_value);
+    if (lhs_lines.size() > 1 || rhs_lines.size() > 1) {
+      msg << "\nWith diff:\n"
+          << edit_distance::CreateUnifiedDiff(lhs_lines, rhs_lines);
+    }
+  }
+
+  return AssertionFailure() << msg;
+}
+
 // Constructs a failure message for Boolean assertions such as EXPECT_TRUE.
 std::string GetBoolAssertionFailureMessage(
     const AssertionResult& assertion_result,

--- a/bricks/gtest_extentions_test/Makefile
+++ b/bricks/gtest_extentions_test/Makefile
@@ -1,0 +1,1 @@
+../../scripts/Makefile

--- a/bricks/gtest_extentions_test/custom.h
+++ b/bricks/gtest_extentions_test/custom.h
@@ -1,0 +1,35 @@
+#include "../../3rdparty/gtest/gtest-custom-comparators.h"
+
+namespace test_gtest_extensions {
+
+struct LooksLikeString {
+  std::string string;
+  bool operator==(LooksLikeString const& rhs) const { return string == rhs.string; }
+};
+inline void PrintTo(LooksLikeString const& s, std::ostream* os) { *os << "LooksLikeString(\"" << s.string << "\")"; }
+
+struct CrossComparableA {
+  std::string a;
+};
+inline void PrintTo(CrossComparableA const& a, std::ostream* os) { *os << "CrossComparableA(\"" << a.a << "\")"; }
+
+struct CrossComparableB {
+  std::string b;
+};
+inline void PrintTo(CrossComparableB const& b, std::ostream* os) { *os << "CrossComparableB(\"" << b.b << "\")"; }
+
+}  // namespace test_gtest_extensions
+
+namespace gtest {
+template <>
+struct CustomComparator<::test_gtest_extensions::CrossComparableA, ::test_gtest_extensions::CrossComparableB> {
+  static bool EXPECT_EQ_IMPL(test_gtest_extensions::CrossComparableA const& a,
+                             test_gtest_extensions::CrossComparableB const& b) {
+    return a.a == b.b;
+  }
+  static bool EXPECT_NE_IMPL(test_gtest_extensions::CrossComparableA const& a,
+                             test_gtest_extensions::CrossComparableB const& b) {
+    return a.a != b.b;
+  }
+};
+}  // namespace gtest

--- a/bricks/gtest_extentions_test/test.cc
+++ b/bricks/gtest_extentions_test/test.cc
@@ -1,0 +1,32 @@
+#include "../../3rdparty/gtest/gtest-main-with-dflags.h"
+
+DEFINE_bool(actually_run_comparisons, false, "Set to true to actually run, not just compile, the comparisons.");
+
+#include "custom.h"  // This could be in the `test.cc` file, but want to make sure we're `make check`-friendly. -- D.K.
+
+TEST(GtestExtensions, CustomPrinter) {
+  using namespace test_gtest_extensions;
+  LooksLikeString a;
+  LooksLikeString b;
+  a.string = "foo";
+  b.string = "bar";
+  if (FLAGS_actually_run_comparisons) {
+    EXPECT_EQ(a, b) << "This should compile.";
+  }
+}
+
+TEST(GtestExtensions, CustomComparator) {
+  using namespace test_gtest_extensions;
+  CrossComparableA a;
+  CrossComparableB b;
+  a.a = "foo";
+  b.b = "bar";
+  if (FLAGS_actually_run_comparisons) {
+    EXPECT_EQ(a, b) << "This should compile.";
+  }
+  a.a = "ok";
+  b.b = "ok";
+  if (FLAGS_actually_run_comparisons) {
+    EXPECT_NE(a, b) << "This should compile.";
+  }
+}


### PR DESCRIPTION
A thin-ish wrapper to allow custom comparisons of user objects with `EXPECT_EQ` / `EXPECT_NE`.