### PR TITLE
Streamed sockets

### DIFF
--- a/examples/streamed_sockets/speedtest/Makefile
+++ b/examples/streamed_sockets/speedtest/Makefile
@@ -1,0 +1,1 @@
+../../../scripts/Makefile

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -17,14 +17,24 @@ DEFINE_double(max_seconds_of_silence, 1.5, "Terminate the connection if it sends
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
 
+  using namespace current::net;
+  using namespace current::vt100;
+
+#ifndef NDEBUG
+  {
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
   std::chrono::microseconds const t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
   size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
   std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
 
   std::vector<uint8_t> buffer(static_cast<size_t>(1e9 * FLAGS_receive_buffer_gb));
-
-  using namespace current::net;
-  using namespace current::vt100;
 
   current::ProgressLine progress;
 

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -1,0 +1,96 @@
+#include <deque>
+
+#include "../../../blocks/xterm/progress.h"
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/strings/printf.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_uint16(port, 9001, "The port to use.");
+DEFINE_double(buffer_size_gb, 2.0, "The size of the buffer the read the data into.");
+DEFINE_double(window_size_seconds, 5.0, "The length of sliding window the throughput within which is reported.");
+DEFINE_double(window_size_gb, 20.0, "The maximum amount of data per the sliding window to report the throughput.");
+DEFINE_double(output_frequency, 0.1, "The minimim amount of time, in seconds, between terminal updates.");
+DEFINE_double(max_seconds_of_silence, 1.5, "Terminate the connection if it sends nothing for this long, in seconds.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  std::chrono::microseconds const t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
+  size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
+  std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
+
+  std::vector<uint8_t> buffer(static_cast<size_t>(1e9 * FLAGS_buffer_size_gb));
+
+  using namespace current::net;
+  using namespace current::vt100;
+
+  current::ProgressLine progress;
+
+  progress << "starting on " << cyan << bold << "localhost:" << FLAGS_port;
+
+  while (true) {
+    try {
+      size_t total_bytes_received = 0ull;
+      std::deque<std::pair<std::chrono::microseconds, size_t>> history;  // { unix epoch time, total bytes received }.
+
+      Socket socket(FLAGS_port);
+      progress << "listening on " << cyan << bold << "localhost:" << FLAGS_port;
+      Connection connection(socket.Accept());
+      progress << "connected, " << cyan << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port
+               << reset << " <= " << magenta << connection.RemoteIPAndPort().ip << ':'
+               << connection.RemoteIPAndPort().port << reset;
+
+      std::chrono::microseconds t_next_output = current::time::Now() + t_output_frequency;
+      std::chrono::microseconds t_last_successful_receive = current::time::Now();
+      while (true) {
+        size_t const size = connection.BlockingRead(&buffer[0], buffer.size());
+        std::chrono::microseconds const t_now = current::time::Now();
+        if (size) {
+          total_bytes_received += size;
+          t_last_successful_receive = t_now;
+          history.emplace_back(t_now, total_bytes_received);
+          std::chrono::microseconds const t_cutoff = t_now - t_window_size;
+          size_t const size_cutoff =
+              (total_bytes_received > window_size_bytes ? total_bytes_received - window_size_bytes : 0);
+          if (t_now >= t_next_output) {
+            if (history.size() >= 2) {
+              while (history.size() > 2 &&
+                     (history.front().first <= t_cutoff || history.front().second <= size_cutoff)) {
+                history.pop_front();
+              }
+              double const gb = 1e-9 * (history.back().second - history.front().second);
+              double const s = 1e-6 * (history.back().first - history.front().first).count();
+              progress << bold << green << current::strings::Printf("%.2lfGB/s", gb / s) << reset << ", " << bold
+                       << yellow << current::strings::Printf("%.2lfGB", gb) << reset << '/' << bold << blue
+                       << current::strings::Printf("%.1lfs", s) << reset << ", " << cyan
+                       << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port << reset
+                       << " <= " << magenta << connection.RemoteIPAndPort().ip << ':'
+                       << connection.RemoteIPAndPort().port << reset;
+            }
+            t_next_output = t_now + t_output_frequency;
+          }
+        } else {
+          std::this_thread::yield();
+          if (t_now >= t_next_output) {
+            double const seconds_of_silence = 1e-6 * (t_now - t_last_successful_receive).count();
+            double const seconds_timeout = std::max(0.0, FLAGS_max_seconds_of_silence - seconds_of_silence);
+            progress << "dropping connection in " << bold << red << current::strings::Printf("%.1lfs", seconds_timeout)
+                     << reset;
+            t_next_output = t_now + t_output_frequency;
+            if (!seconds_timeout) {
+              progress << "dropping connection";
+              break;
+            }
+          }
+        }
+      }
+    } catch (current::net::SocketBindException const&) {
+      progress << "can not bind to " << red << bold << "localhost:" << FLAGS_port << reset
+               << ", check for other apps holding the post";
+    } catch (current::Exception const& e) {
+      progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
+    }
+  }
+}

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -72,9 +72,9 @@ int main(int argc, char** argv) {
               }
               double const gb = 1e-9 * (history.back().second - history.front().second);
               double const s = 1e-6 * (history.back().first - history.front().first).count();
-              progress << bold << green << current::strings::Printf("%.2lfGB/s", gb / s) << reset << ", " << bold
-                       << yellow << current::strings::Printf("%.2lfGB", gb) << reset << '/' << bold << blue
-                       << current::strings::Printf("%.1lfs", s) << reset << ", " << cyan
+              progress << bold << green << current::strings::Printf("%.3lfGB/s", gb / s) << reset << ", " << bold
+                       << yellow << current::strings::Printf("%.3lfGB", gb) << reset << '/' << bold << blue
+                       << current::strings::Printf("%.2lfs", s) << reset << ", " << cyan
                        << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port << reset
                        << " <= " << magenta << connection.RemoteIPAndPort().ip << ':'
                        << connection.RemoteIPAndPort().port << reset;

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -126,5 +126,6 @@ int main(int argc, char** argv) {
     } catch (current::Exception const& e) {
       progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.
   }
 }

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -8,7 +8,7 @@
 #include "../../../bricks/time/chrono.h"
 
 DEFINE_uint16(port, 9001, "The port to use.");
-DEFINE_double(buffer_size_gb, 2.0, "The size of the buffer the read the data into.");
+DEFINE_double(receive_buffer_gb, 0.5, "The size of the buffer the read the data into.");
 DEFINE_double(window_size_seconds, 5.0, "The length of sliding window the throughput within which is reported.");
 DEFINE_double(window_size_gb, 20.0, "The maximum amount of data per the sliding window to report the throughput.");
 DEFINE_double(output_frequency, 0.1, "The minimim amount of time, in seconds, between terminal updates.");
@@ -21,7 +21,7 @@ int main(int argc, char** argv) {
   size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
   std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
 
-  std::vector<uint8_t> buffer(static_cast<size_t>(1e9 * FLAGS_buffer_size_gb));
+  std::vector<uint8_t> buffer(static_cast<size_t>(1e9 * FLAGS_receive_buffer_gb));
 
   using namespace current::net;
   using namespace current::vt100;

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -1,3 +1,27 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
 #include <deque>
 
 #include "../../../blocks/xterm/progress.h"

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -54,9 +54,9 @@ int main(int argc, char** argv) {
   }
 #endif
 
-  std::chrono::microseconds const t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
-  size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
-  std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
+  const std::chrono::microseconds t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
+  const size_t window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
+  const std::chrono::microseconds t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
 
   std::vector<uint8_t> buffer(static_cast<size_t>(1e9 * FLAGS_receive_buffer_gb));
 
@@ -79,14 +79,14 @@ int main(int argc, char** argv) {
       std::chrono::microseconds t_next_output = current::time::Now() + t_output_frequency;
       std::chrono::microseconds t_last_successful_receive = current::time::Now();
       while (true) {
-        size_t const size = connection.BlockingRead(&buffer[0], buffer.size());
-        std::chrono::microseconds const t_now = current::time::Now();
+        const size_t size = connection.BlockingRead(&buffer[0], buffer.size());
+        const std::chrono::microseconds t_now = current::time::Now();
         if (size) {
           total_bytes_received += size;
           t_last_successful_receive = t_now;
           history.emplace_back(t_now, total_bytes_received);
-          std::chrono::microseconds const t_cutoff = t_now - t_window_size;
-          size_t const size_cutoff =
+          const std::chrono::microseconds t_cutoff = t_now - t_window_size;
+          const size_t size_cutoff =
               (total_bytes_received > window_size_bytes ? total_bytes_received - window_size_bytes : 0);
           if (t_now >= t_next_output) {
             if (history.size() >= 2) {
@@ -94,8 +94,8 @@ int main(int argc, char** argv) {
                      (history.front().first <= t_cutoff || history.front().second <= size_cutoff)) {
                 history.pop_front();
               }
-              double const gb = 1e-9 * (history.back().second - history.front().second);
-              double const s = 1e-6 * (history.back().first - history.front().first).count();
+              const double gb = 1e-9 * (history.back().second - history.front().second);
+              const double s = 1e-6 * (history.back().first - history.front().first).count();
               progress << bold << green << current::strings::Printf("%.3lfGB/s", gb / s) << reset << ", " << bold
                        << yellow << current::strings::Printf("%.3lfGB", gb) << reset << '/' << bold << blue
                        << current::strings::Printf("%.2lfs", s) << reset << ", " << cyan
@@ -108,8 +108,8 @@ int main(int argc, char** argv) {
         } else {
           std::this_thread::yield();
           if (t_now >= t_next_output) {
-            double const seconds_of_silence = 1e-6 * (t_now - t_last_successful_receive).count();
-            double const seconds_timeout = std::max(0.0, FLAGS_max_seconds_of_silence - seconds_of_silence);
+            const double seconds_of_silence = 1e-6 * (t_now - t_last_successful_receive).count();
+            const double seconds_timeout = std::max(0.0, FLAGS_max_seconds_of_silence - seconds_of_silence);
             progress << "dropping connection in " << bold << red << current::strings::Printf("%.1lfs", seconds_timeout)
                      << reset;
             t_next_output = t_now + t_output_frequency;
@@ -120,10 +120,10 @@ int main(int argc, char** argv) {
           }
         }
       }
-    } catch (current::net::SocketBindException const&) {
+    } catch (const current::net::SocketBindException&) {
       progress << "can not bind to " << red << bold << "localhost:" << FLAGS_port << reset
                << ", check for other apps holding the post";
-    } catch (current::Exception const& e) {
+    } catch (const current::Exception& e) {
       progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -72,9 +72,9 @@ int main(int argc, char** argv) {
             }
             double const gb = 1e-9 * (history.back().second - history.front().second);
             double const s = 1e-6 * (history.back().first - history.front().first).count();
-            progress << bold << green << current::strings::Printf("%.2lfGB/s", gb / s) << reset << ", " << bold
-                     << yellow << current::strings::Printf("%.2lfGB", gb) << reset << '/' << bold << blue
-                     << current::strings::Printf("%.1lfs", s) << reset << ", " << magenta
+            progress << bold << green << current::strings::Printf("%.3lfGB/s", gb / s) << reset << ", " << bold
+                     << yellow << current::strings::Printf("%.3lfGB", gb) << reset << '/' << bold << blue
+                     << current::strings::Printf("%.2lfs", s) << reset << ", " << magenta
                      << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port << reset << " => "
                      << cyan << connection.RemoteIPAndPort().ip << ':' << connection.RemoteIPAndPort().port << reset;
           }

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -9,7 +9,7 @@
 
 DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
 DEFINE_uint16(port, 9001, "The destination port to send data to.");
-DEFINE_double(buffer_size_gb, 2.0, "Write buffer size.");
+DEFINE_double(send_buffer_mb, 2.0, "Write buffer size.");
 DEFINE_double(window_size_seconds, 5.0, "The length of sliding window the throughput within which is reported.");
 DEFINE_double(window_size_gb, 20.0, "The maximum amount of data per the sliding window to report the throughput.");
 DEFINE_double(output_frequency, 0.1, "The minimim amount of time, in seconds, between terminal updates.");
@@ -27,19 +27,13 @@ int main(int argc, char** argv) {
 
   current::ProgressLine progress;
 
-  progress << current::strings::Printf("allocating %.1lfGB", FLAGS_buffer_size_gb);
-  size_t const buffer_size = static_cast<size_t>(1e9 * FLAGS_buffer_size_gb);
+  progress << current::strings::Printf("allocating %.1lfMB", FLAGS_send_buffer_mb);
+  size_t const buffer_size = static_cast<size_t>(1e6 * FLAGS_send_buffer_mb);
   std::vector<char> data(buffer_size);
 
-  progress << current::strings::Printf("initializing %.1lfGB", FLAGS_buffer_size_gb);
-  memset(&data[0], '.', buffer_size);
-  {
-    // A poor man's way of creating a somewhat random buffer by not spending much time doing it. -- D.K.
-    uint8_t tmp = 0;
-    for (size_t i = 0; i < buffer_size; i += (rand() & 0xff)) {
-      data[i] = 'a' + tmp;
-      tmp = (tmp + 1) % 26;
-    }
+  progress << current::strings::Printf("initializing %.1lfMB", FLAGS_send_buffer_mb);
+  for (char& c : data) {
+    c = 'a' + (rand() % 256);
   }
 
   progress << "preparing to send";

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -55,14 +55,14 @@ int main(int argc, char** argv) {
   }
 #endif
 
-  std::chrono::microseconds const t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
-  size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
-  std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
+  const std::chrono::microseconds t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
+  const size_t window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
+  const std::chrono::microseconds t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
 
   current::ProgressLine progress;
 
   progress << current::strings::Printf("allocating %.1lfMB", FLAGS_send_buffer_mb);
-  size_t const buffer_size = static_cast<size_t>(1e6 * FLAGS_send_buffer_mb);
+  const size_t buffer_size = static_cast<size_t>(1e6 * FLAGS_send_buffer_mb);
   std::vector<char> data(buffer_size);
 
   progress << current::strings::Printf("initializing %.1lfMB", FLAGS_send_buffer_mb);
@@ -82,20 +82,20 @@ int main(int argc, char** argv) {
       std::chrono::microseconds t_next_output = current::time::Now() + t_output_frequency;
       std::chrono::microseconds t_last_successful_receive = current::time::Now();
       while (true) {
-        connection.BlockingWrite(reinterpret_cast<void const*>(&data[0]), data.size(), true);
-        std::chrono::microseconds const t_now = current::time::Now();
+        connection.BlockingWrite(reinterpret_cast<const void*>(&data[0]), data.size(), true);
+        const std::chrono::microseconds t_now = current::time::Now();
         total_bytes_sent += data.size();
         t_last_successful_receive = t_now;
         history.emplace_back(t_now, total_bytes_sent);
-        std::chrono::microseconds const t_cutoff = t_now - t_window_size;
-        size_t const size_cutoff = (total_bytes_sent > window_size_bytes ? total_bytes_sent - window_size_bytes : 0);
+        const std::chrono::microseconds t_cutoff = t_now - t_window_size;
+        const size_t size_cutoff = (total_bytes_sent > window_size_bytes ? total_bytes_sent - window_size_bytes : 0);
         if (t_now >= t_next_output) {
           if (history.size() >= 2) {
             while (history.size() > 2 && (history.front().first <= t_cutoff || history.front().second <= size_cutoff)) {
               history.pop_front();
             }
-            double const gb = 1e-9 * (history.back().second - history.front().second);
-            double const s = 1e-6 * (history.back().first - history.front().first).count();
+            const double gb = 1e-9 * (history.back().second - history.front().second);
+            const double s = 1e-6 * (history.back().first - history.front().first).count();
             progress << bold << green << current::strings::Printf("%.3lfGB/s", gb / s) << reset << ", " << bold
                      << yellow << current::strings::Printf("%.3lfGB", gb) << reset << '/' << bold << blue
                      << current::strings::Printf("%.2lfs", s) << reset << ", " << magenta
@@ -105,9 +105,9 @@ int main(int argc, char** argv) {
           t_next_output = t_now + t_output_frequency;
         }
       }
-    } catch (current::net::SocketConnectException const&) {
+    } catch (const current::net::SocketConnectException&) {
       progress << "can not connect to " << red << bold << FLAGS_host << ':' << FLAGS_port << reset;
-    } catch (current::Exception const& e) {
+    } catch (const current::Exception& e) {
       progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -18,12 +18,22 @@ DEFINE_double(max_seconds_of_no_sends, 2.5, "Terminate the connection if can't s
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
 
+  using namespace current::net;
+  using namespace current::vt100;
+
+#ifndef NDEBUG
+  {
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
   std::chrono::microseconds const t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
   size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
   std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
-
-  using namespace current::net;
-  using namespace current::vt100;
 
   current::ProgressLine progress;
 

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -110,5 +110,6 @@ int main(int argc, char** argv) {
     } catch (current::Exception const& e) {
       progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.
   }
 }

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -1,0 +1,86 @@
+#include <deque>
+
+#include "../../../blocks/xterm/progress.h"
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/strings/printf.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
+DEFINE_uint16(port, 9001, "The destination port to send data to.");
+DEFINE_double(buffer_size_gb, 2.0, "Write buffer size.");
+DEFINE_double(window_size_seconds, 5.0, "The length of sliding window the throughput within which is reported.");
+DEFINE_double(window_size_gb, 20.0, "The maximum amount of data per the sliding window to report the throughput.");
+DEFINE_double(output_frequency, 0.1, "The minimim amount of time, in seconds, between terminal updates.");
+DEFINE_double(max_seconds_of_no_sends, 2.5, "Terminate the connection if can't send anything for this long.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  std::chrono::microseconds const t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
+  size_t const window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
+  std::chrono::microseconds const t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
+
+  using namespace current::net;
+  using namespace current::vt100;
+
+  current::ProgressLine progress;
+
+  progress << current::strings::Printf("allocating %.1lfGB", FLAGS_buffer_size_gb);
+  size_t const buffer_size = static_cast<size_t>(1e9 * FLAGS_buffer_size_gb);
+  std::vector<char> data(buffer_size);
+
+  progress << current::strings::Printf("initializing %.1lfGB", FLAGS_buffer_size_gb);
+  memset(&data[0], '.', buffer_size);
+  {
+    // A poor man's way of creating a somewhat random buffer by not spending much time doing it. -- D.K.
+    uint8_t tmp = 0;
+    for (size_t i = 0; i < buffer_size; i += (rand() & 0xff)) {
+      data[i] = 'a' + tmp;
+      tmp = (tmp + 1) % 26;
+    }
+  }
+
+  progress << "preparing to send";
+  while (true) {
+    try {
+      Connection connection(ClientSocket(FLAGS_host, FLAGS_port));
+      progress << "connected, " << magenta << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port
+               << reset << " => " << cyan << connection.RemoteIPAndPort().ip << ':' << connection.RemoteIPAndPort().port
+               << reset;
+      size_t total_bytes_sent = 0ull;
+      std::deque<std::pair<std::chrono::microseconds, size_t>> history;  // { unix epoch time, total bytes received }.
+      std::chrono::microseconds t_next_output = current::time::Now() + t_output_frequency;
+      std::chrono::microseconds t_last_successful_receive = current::time::Now();
+      while (true) {
+        connection.BlockingWrite(reinterpret_cast<void const*>(&data[0]), data.size(), true);
+        std::chrono::microseconds const t_now = current::time::Now();
+        total_bytes_sent += data.size();
+        t_last_successful_receive = t_now;
+        history.emplace_back(t_now, total_bytes_sent);
+        std::chrono::microseconds const t_cutoff = t_now - t_window_size;
+        size_t const size_cutoff = (total_bytes_sent > window_size_bytes ? total_bytes_sent - window_size_bytes : 0);
+        if (t_now >= t_next_output) {
+          if (history.size() >= 2) {
+            while (history.size() > 2 && (history.front().first <= t_cutoff || history.front().second <= size_cutoff)) {
+              history.pop_front();
+            }
+            double const gb = 1e-9 * (history.back().second - history.front().second);
+            double const s = 1e-6 * (history.back().first - history.front().first).count();
+            progress << bold << green << current::strings::Printf("%.2lfGB/s", gb / s) << reset << ", " << bold
+                     << yellow << current::strings::Printf("%.2lfGB", gb) << reset << '/' << bold << blue
+                     << current::strings::Printf("%.1lfs", s) << reset << ", " << magenta
+                     << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port << reset << " => "
+                     << cyan << connection.RemoteIPAndPort().ip << ':' << connection.RemoteIPAndPort().port << reset;
+          }
+          t_next_output = t_now + t_output_frequency;
+        }
+      }
+    } catch (current::net::SocketConnectException const&) {
+      progress << "can not connect to " << red << bold << FLAGS_host << ':' << FLAGS_port << reset;
+    } catch (current::Exception const& e) {
+      progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
+    }
+  }
+}

--- a/examples/streamed_sockets/speedtest/sender.cc
+++ b/examples/streamed_sockets/speedtest/sender.cc
@@ -1,3 +1,27 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
 #include <deque>
 
 #include "../../../blocks/xterm/progress.h"


### PR DESCRIPTION
Hi Max,

Shaped the streamed sockets benchmarking code. Here's the teaser:

![image](https://user-images.githubusercontent.com/2159447/64912965-0ec61800-d6ec-11e9-834b-de10d4f19738.png)

---

I have also used it to confirm the per-instance EC2 AWS network capacity numbers are as advertised by Amazon. They match. The numbers are:

* 1.2 gigabytes per second (~10 gigabits per second) via a single TCP connection, and
* 3.1 gigabytes per second (~25 gigabits per second) across all TCP connections.

The best way to see these numbers for yourself would likely be to unpack this archive of screenshots and swipe through them with left and right arrows: [ec2_speed_test.zip](https://github.com/C5T/Current/files/3613088/ec2_speed_test.zip). My test scenario is:

* Start one connection between two hosts, on port 9001. Observe 1.2GB/s.
* Start another one, on port 9002. Observe both at 1.2GB/s.
* Add the 3rd, 4th, and 5th ones, on ports 9003 to 9005. Observe the connections getting throttled, to the max. total throughput of 3.1GB/s.
* Then, begin terminating the connections, bottom to top. Observe the throttling do its job, allowing for higher per-connection throughput as the number of connections gets fewer and fewer.
* Obviously, when back to two, and then one connection, they each will show 1.2GB/s.

---

Test setup.

Instance type: `m4.16xlarge`.

Kernel: `Amazon Linux 2 AMI (HVM), SSD Volume Type - ami-0b69ea66ff7391e80 (64-bit x86) / ami-09c61c4850b7465cb (64-bit Arm)`

Commands:
```
sudo yum install -y git make clang
git clone -b streamed_sockets https://github.com/dkorolev/current
cd current/examples/streamed_sockets/speedtest
NDEBUG=1 make
```

I have two machines as above. On one I copy the `./.current/sender` into `~`, on the other I copy `./.current/receiver` into `~`. Then I run the following "send" commands in my five terminals on the left:

```
PEM=...
SENDER_EXTERNAL_IP=...
INTERNAL_SENDTO=172.30.0.157
ssh -i $PEM ec2-user@$SENDER_EXTERNAL_IP ./sender --host $INTERNAL_SENDTO --port {9001..9005}
```

And the following "receive" commands in my five terminals on the right:

```
PEM=...
RECEIVER_INTERNAL_IP=...
ssh -i $PEM ec2-user@$RECEIVER_INTERNAL_IP ./receiver --port {9001..9005}
```

When terminating them bottom-to-top, it's sufficient to Ctrl+C either the sender or the receiver, so I alternated those in my series of screenshots.

The test uses the `3b9a2aeddaddd6ae7b9ff0a1ead2f6cfde0dadfa` commit.