### PR TITLE
`s/typename std::result_of<...>::type/std::result_of_t<...>/g`.

### DIFF
--- a/bricks/sync/waitable_atomic.h
+++ b/bricks/sync/waitable_atomic.h
@@ -63,7 +63,7 @@ class ScopedUniqueLock {
   void operator=(const ScopedUniqueLock&) = delete;
 };
 
-class IntrusiveClient {
+class IntrusiveClient final {
  public:
   class Interface {
    public:
@@ -146,7 +146,7 @@ class WaitableAtomicImpl {
 
     // A generic implementation for both mutable and immutable scoped accessors.
     template <class PARENT>
-    class ScopedAccessorImpl : private ScopedUniqueLock, public NotifyIfMutable<PARENT>::impl_t {
+    class ScopedAccessorImpl final : private ScopedUniqueLock, public NotifyIfMutable<PARENT>::impl_t {
      public:
       using parent_t = PARENT;
       using optional_notifier_t = typename NotifyIfMutable<PARENT>::impl_t;
@@ -210,13 +210,13 @@ class WaitableAtomicImpl {
     }
 
     template <typename F>
-    typename std::result_of<F(const data_t&)>::type ImmutableUse(F&& f) const {
+    std::result_of_t<F(const data_t&)> ImmutableUse(F&& f) const {
       auto scope = ImmutableScopedAccessor();
       return f(*scope);
     }
 
     template <typename F>
-    typename std::result_of<F(data_t&)>::type MutableUse(F&& f) {
+    std::result_of_t<F(data_t&)> MutableUse(F&& f) {
       auto scope = MutableScopedAccessor();
       return f(*scope);
     }

--- a/bricks/util/object_interface.h
+++ b/bricks/util/object_interface.h
@@ -41,12 +41,12 @@ SOFTWARE.
   template <>                                                   \
   struct CURRENT_OBJECT_INTERFACE_METHODS_WRAPPER<type> : CURRENT_OBJECT_INTERFACE_IMPL_POINTER_CONTAINER<type>
 
-#define CURRENT_FORWARD_METHOD(method)                                                                                \
-  template <typename... ARGS>                                                                                         \
-  typename std::result_of<decltype(&CURRENT_IMPLEMENTATION_POINTER_TYPE::method)(CURRENT_IMPLEMENTATION_POINTER_TYPE, \
-                                                                                 ARGS...)>::type                      \
-  method(ARGS&&... args) {                                                                                            \
-    return this->CURRENT_IMPLEMENTATION_POINTER->method(std::forward<ARGS>(args)...);                                 \
+#define CURRENT_FORWARD_METHOD(method)                                                                         \
+  template <typename... ARGS>                                                                                  \
+  std::result_of_t<decltype(&CURRENT_IMPLEMENTATION_POINTER_TYPE::method)(CURRENT_IMPLEMENTATION_POINTER_TYPE, \
+                                                                          ARGS...)>                            \
+  method(ARGS&&... args) {                                                                                     \
+    return this->CURRENT_IMPLEMENTATION_POINTER->method(std::forward<ARGS>(args)...);                          \
   }
 
 #endif  // BRICKS_UTIL_OBJECT_INTERFACE_H

--- a/bricks/util/test.cc
+++ b/bricks/util/test.cc
@@ -766,7 +766,7 @@ TEST(CustomHashFunction, Smoke) {
 struct ObjectWithInterface {
   int calls = 0;
   int total_calls() { return ++calls; }
-  int add(int a, int b) const { return a + b; }  // `static` won't work with the inner `std::result_of`. -- D.K.
+  int add(int a, int b) const { return a + b; }  // `static` won't work with the inner `std::result_of_t<>`. -- D.K.
 };
 
 CURRENT_OBJECT_INTERFACE(ObjectWithInterface) {
@@ -799,7 +799,7 @@ namespace object_with_interface_test_namespace {
 struct NamespacedObjectWithInterface {
   int calls = 0;
   int total_calls() { return ++calls; }
-  int add(int a, int b) const { return a + b; }  // `static` won't work with the inner `std::result_of`. -- D.K.
+  int add(int a, int b) const { return a + b; }  // `static` won't work with the inner `std::result_of_t<>`. -- D.K.
 };
 
 CURRENT_OBJECT_INTERFACE(NamespacedObjectWithInterface) {

--- a/storage/base.h
+++ b/storage/base.h
@@ -156,12 +156,12 @@ struct TypeListMapperImpl;
 template <typename FIELDS, int... NS>
 struct TypeListMapperImpl<FIELDS, current::variadic_indexes::indexes<NS...>> {
 #ifdef CURRENT_STORAGE_PATCH_SUPPORT
-  using result = TypeList<typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::update_event_t...,
-                          typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::delete_event_t...,
-                          typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::patch_event_t...>;
+  using result = TypeList<typename std::result_of_t<FIELDS(FieldInfoByIndex<NS>)>::update_event_t...,
+                          typename std::result_of_t<FIELDS(FieldInfoByIndex<NS>)>::delete_event_t...,
+                          typename std::result_of_t<FIELDS(FieldInfoByIndex<NS>)>::patch_event_t...>;
 #else
-  using result = TypeList<typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::update_event_t...,
-                          typename std::result_of<FIELDS(FieldInfoByIndex<NS>)>::type::delete_event_t...>;
+  using result = TypeList<typename std::result_of_t<FIELDS(FieldInfoByIndex<NS>)>::update_event_t...,
+                          typename std::result_of_t<FIELDS(FieldInfoByIndex<NS>)>::delete_event_t...>;
 #endif  // CURRENT_STORAGE_PATCH_SUPPORT
 };
 

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -362,12 +362,12 @@ class StorageImpl {
 
   // Used for applying updates by dispatching corresponding events.
   template <typename... ARGS>
-  typename std::result_of<FIELDS(ARGS...)>::type operator()(ARGS&&... args) {
+  std::result_of_t<FIELDS(ARGS...)> operator()(ARGS&&... args) {
     return fields_(std::forward<ARGS>(args)...);
   }
 
   template <typename F>
-  using f_result_t = typename std::result_of<F(fields_by_ref_t)>::type;
+  using f_result_t = std::result_of_t<F(fields_by_ref_t)>;
 
   template <current::locks::MutexLockStatus MLS = current::locks::MutexLockStatus::NeedToLock, typename F>
   ::current::Future<::current::storage::TransactionResult<f_result_t<F>>, ::current::StrictFuture::Strict>

--- a/storage/transaction_policy.h
+++ b/storage/transaction_policy.h
@@ -51,7 +51,7 @@ class Synchronous final {
   ~Synchronous() { destructing_ = true; }
 
   template <typename F>
-  using f_result_t = typename std::result_of<F()>::type;
+  using f_result_t = std::result_of_t<F()>;
 
   // Read-write transaction returning non-void type.
   template <typename F, class = std::enable_if_t<!std::is_void<f_result_t<F>>::value>>

--- a/utils/operational_transformation/ot.h
+++ b/utils/operational_transformation/ot.h
@@ -45,7 +45,7 @@ static std::string AsUTF8String(const std::deque<wchar_t>& rope) {
 }
 
 template <typename PROCESSOR>
-typename std::result_of<decltype(&PROCESSOR::GenerateOutput)(PROCESSOR*, const std::deque<wchar_t>&, bool)>::type OT(
+std::result_of_t<decltype(&PROCESSOR::GenerateOutput)(PROCESSOR*, const std::deque<wchar_t>&, bool)> OT(
     const std::string& json, PROCESSOR&& processor) {
   rapidjson::Document document;
   if (document.Parse<0>(&json[0]).HasParseError()) {


### PR DESCRIPTION
`s/typename std::result_of<...>::type/std::result_of_t<...>/g`, plus two `final`-s I noted are missing in `bricks::sync`.

And here's how this PR looks in Slack :-)

![image](https://user-images.githubusercontent.com/2159447/65443638-5a12b180-dde3-11e9-82b9-bf1e640dd246.png)
