### PR TITLE
Trivial latency measurements

### DIFF
--- a/examples/streamed_sockets/speedtest/forward.cc
+++ b/examples/streamed_sockets/speedtest/forward.cc
@@ -1,0 +1,61 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// Simple TCP traffic forwarder.
+//
+// Example usage A, one hop:
+// 1) Start ./.current/receiver  # Listens on 9001.
+// 2) Start ./.current/forward   # Forwards 9002 to 9001.
+// 3) Start ./.current/sender --port 9002
+//
+// Example usage B, two hops:
+// 1) Start ./.current/receiver  # Listens on 9001.
+// 2) Start ./.current/forward   # Forwards 9002 to 9001.
+// 3) Start ./.current/forward --listen_port 9003 --sendto_port 9002
+// 4) Start ./.current/sender --port 9003
+//
+// Multiple hops can be simulated.
+
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+
+DEFINE_uint16(listen_port, 9002, "The port to listen on.");
+DEFINE_string(sendto_host, "localhost", "The host to forward to.");
+DEFINE_uint16(sendto_port, 9001, "The port to forward to.");
+DEFINE_uint64(n, 1 << 20, "Buffer size, in bytes.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
+
+  current::net::Socket socket(FLAGS_listen_port);
+  current::net::Connection recvfrom(socket.Accept());
+
+  std::vector<uint8_t> buffer(FLAGS_n);
+  while (true) {
+    const size_t size = recvfrom.BlockingRead(&buffer[0], buffer.size());
+    sendto.BlockingWrite(&buffer[0], size, true);
+  }
+}

--- a/examples/streamed_sockets/speedtest/forward.cc
+++ b/examples/streamed_sockets/speedtest/forward.cc
@@ -48,10 +48,10 @@ DEFINE_uint64(n, 1 << 20, "Buffer size, in bytes.");
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
 
-  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
-
   current::net::Socket socket(FLAGS_listen_port);
   current::net::Connection recvfrom(socket.Accept());
+
+  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
 
   std::vector<uint8_t> buffer(FLAGS_n);
   while (true) {

--- a/examples/streamed_sockets/speedtest/latency_trivial.cc
+++ b/examples/streamed_sockets/speedtest/latency_trivial.cc
@@ -1,0 +1,102 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// The simplest possible high-throughput TCP latency measuring tool.
+// Does not even check what is being returned, just assumes what is read is correct.
+//
+// The default flags assumes `./.current/forward` is run, and localhost:9001 is forwared back to localhost:9002.
+//
+// To run, first start this tool, and then `./.current/forward`. They would both terminate afterwards.
+
+#include <cstdlib>
+#include <thread>
+
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_string(sendto_host, "localhost", "The host to send data to.");
+DEFINE_uint16(sendto_port, 9002, "The port to send data to.");
+DEFINE_uint16(listen_port, 9001, "The port to listen on.");
+
+DEFINE_uint64(n, 1 << 25, "The number of bytes in each block to send.");
+DEFINE_uint32(k, 20, "The number of blocks to send.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
+
+  current::net::Socket socket(FLAGS_listen_port);
+  current::net::Connection recvfrom(socket.Accept());
+
+  std::vector<std::chrono::microseconds> send_begin(FLAGS_k);
+  std::vector<std::chrono::microseconds> send_end(FLAGS_k);
+  std::atomic_size_t sent_done(0u);
+
+  std::vector<std::chrono::microseconds> recv_begin(FLAGS_k);
+  std::vector<std::chrono::microseconds> recv_end(FLAGS_k);
+  std::atomic_size_t recv_done(0u);
+
+  std::thread thread_send([&sendto, &sent_done, &send_begin, &send_end]() {
+    std::vector<uint8_t> buffer(FLAGS_n);
+    for (uint8_t& b : buffer) {
+      b = rand();
+    }
+    for (size_t k = 0u; k < FLAGS_k; ++k) {
+      send_begin[k] = current::time::Now();
+      sendto.BlockingWrite(&buffer[0], buffer.size(), true);
+      send_end[k] = current::time::Now();
+      sent_done = k + 1u;
+    }
+  });
+
+  std::thread thread_recv([&recvfrom, &recv_done, &recv_begin, &recv_end]() {
+    std::vector<uint8_t> buffer(FLAGS_n);
+    for (size_t k = 0u; k < FLAGS_k; ++k) {
+      recv_begin[k] = current::time::Now();
+      recvfrom.BlockingRead(&buffer[0], buffer.size(), current::net::Connection::BlockingReadPolicy::FillFullBuffer);
+      recv_end[k] = current::time::Now();
+      recv_done = k + 1u;
+    }
+  });
+
+  std::thread thread_dump([&]() {
+    const double coef = 1e-3 * FLAGS_n;  // (GB/s) == 1e-3 * (B/us).
+    for (size_t k = 1u; k < FLAGS_k; ++k) {
+      while (!(k < sent_done && k < recv_done)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      printf("Block %5d sent at %.3lfGB/s, received at %.3lf GB/s, average latency %.2lfms\n",
+             static_cast<int>(k),
+             coef / ((send_end[k] - send_begin[k]).count() + 1),
+             coef / ((recv_end[k] - recv_begin[k]).count() + 1),
+             1e-3 * ((recv_begin[k] + recv_end[k]).count() - (send_begin[k] + send_end[k]).count()) / 2);
+    }
+  });
+
+  thread_send.join();
+  thread_recv.join();
+  thread_dump.join();
+}

--- a/examples/streamed_sockets/speedtest/latency_trivial.cc
+++ b/examples/streamed_sockets/speedtest/latency_trivial.cc
@@ -27,7 +27,7 @@ SOFTWARE.
 //
 // The default flags assumes `./.current/forward` is run, and localhost:9001 is forwared back to localhost:9002.
 //
-// To run, first start this tool, and then `./.current/forward`. They would both terminate afterwards.
+// To run, first start `./.current/forward`, and then this tool. They would both terminate automatically.
 
 #include <cstdlib>
 #include <thread>

--- a/examples/streamed_sockets/speedtest/latency_trivial.cc
+++ b/examples/streamed_sockets/speedtest/latency_trivial.cc
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
     }
     for (size_t k = 0u; k < FLAGS_k; ++k) {
       send_begin[k] = current::time::Now();
-      sendto.BlockingWrite(&buffer[0], buffer.size(), true);
+      sendto.BlockingWrite(&buffer[0], buffer.size(), false);  // `false` is no `MSG_MORE`.
       send_end[k] = current::time::Now();
       sent_done = k + 1u;
     }

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+./.current/forward &
+./.current/latency_trivial &
+
+wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.3hops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.3hops
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+./.current/forward --listen_port 9003 &
+./.current/forward --sendto_port 9003 &
+./.current/latency_trivial &
+
+wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+./.current/forward --listen_port 9004 &
+./.current/forward --listen_port 9003 --sendto_port 9004 &
+./.current/forward --sendto_port 9003 &
+./.current/latency_trivial &
+
+wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
@@ -4,9 +4,9 @@ trap "kill 0" EXIT
 
 NDEBUG=1 make -j .current/forward .current/latency_trivial
 
-./.current/forward --listen_port 9004 &
 ./.current/forward --listen_port 9003 --sendto_port 9004 &
-./.current/forward --sendto_port 9003 &
-./.current/latency_trivial &
+./.current/forward --listen_port 9002 --sendto_port 9003 &
+./.current/forward --listen_port 9001 --sendto_port 9002 &
+./.current/latency_trivial --sendto_port 9001 --listen_port 9004 &
 
 wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.nhops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.nhops
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+N=${1:-4}
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+echo "Running for $N hops."
+
+for i in $(seq 2 $N); do
+  ./.current/forward --listen_port $((9001 + N - i)) --sendto_port $((9002 + N - i)) &
+done
+./.current/latency_trivial --sendto_port 9001 --listen_port $((9000 + N)) &
+
+wait

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
       }
     } catch (const current::net::SocketBindException&) {
       progress << "can not bind to " << red << bold << "localhost:" << FLAGS_port << reset
-               << ", check for other apps holding the post";
+               << ", check for other apps holding the port";
     } catch (const current::Exception& e) {
       progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }


### PR DESCRIPTION
Hi Max,

While I am unsuccessfully trying to get both high throughput and low latency, here is a tiny test for the lowest bound on latency.

It's the lower bound because the code checks nothing :-) except the number of bytes sent/received, and the timestamps of begin/end of send/receive.

---

I have run this code on `m4.16xlarge` EC2 instances. It's very simple. On one machine you issue:

```
while true ; do ./.current/forward --sendto_host $OTHER_IP ; done
```

and on the other one:

```
./.current/latency_trivial --sendto_host $OTHER_IP --n 100000000 --k 10000
```

(The value of `--n` here is 100M, so that there are approximately 12 lines printed per second. The `--k` parameter is just to keep it running effectively forever.)

The result looks like this:

```
Block     1 sent at 1.652GB/s, received at 1.666 GB/s, average latency 3.94ms
Block     2 sent at 1.631GB/s, received at 1.625 GB/s, average latency 3.80ms
Block     3 sent at 1.594GB/s, received at 1.607 GB/s, average latency 3.65ms
Block     4 sent at 1.632GB/s, received at 1.628 GB/s, average latency 3.48ms
Block     5 sent at 1.573GB/s, received at 1.555 GB/s, average latency 3.92ms
Block     6 sent at 1.601GB/s, received at 1.622 GB/s, average latency 3.87ms
Block     7 sent at 1.586GB/s, received at 1.608 GB/s, average latency 3.03ms
Block     8 sent at 1.658GB/s, received at 1.609 GB/s, average latency 3.51ms
Block     9 sent at 1.412GB/s, received at 1.443 GB/s, average latency 3.66ms
Block    10 sent at 1.210GB/s, received at 1.201 GB/s, average latency 3.19ms
Block    11 sent at 1.198GB/s, received at 1.201 GB/s, average latency 3.37ms
Block    12 sent at 1.195GB/s, received at 1.200 GB/s, average latency 3.08ms
Block    13 sent at 1.212GB/s, received at 1.201 GB/s, average latency 3.28ms
Block    14 sent at 1.193GB/s, received at 1.199 GB/s, average latency 3.48ms
Block    15 sent at 1.208GB/s, received at 1.202 GB/s, average latency 3.49ms
Block    16 sent at 1.195GB/s, received at 1.201 GB/s, average latency 3.52ms
Block    17 sent at 1.194GB/s, received at 1.201 GB/s, average latency 3.08ms
Block    18 sent at 1.206GB/s, received at 1.200 GB/s, average latency 3.06ms
Block    19 sent at 1.194GB/s, received at 1.201 GB/s, average latency 3.03ms
```

---

The key observations are:

1. EC2's throttling really works. It's easy to see the GB/s dropping to exactly 1.2 after about a second. Well done, Amazon.
2. The latency is, well non-negligible. I was honestly expecting better. And experimenting with different `--n`, on both the `forward` side and the latency-measuring one did not help much.
3. **There are bad apples on EC2**! For this particular test, the first two machines, A and B, I spinned up were capped at 0.6GB/s. I added a third one, C, and discovered that A <=> C can do 1.2GB/s, while A <=> B and B <=> C can only do 0.6GB/s. This is something to be aware of.
