### PR TITLE
Streamed sockets larger test.

### DIFF
--- a/examples/streamed_sockets/latencytest/Makefile
+++ b/examples/streamed_sockets/latencytest/Makefile
@@ -1,0 +1,1 @@
+../../../scripts/Makefile

--- a/examples/streamed_sockets/latencytest/blob.h
+++ b/examples/streamed_sockets/latencytest/blob.h
@@ -34,7 +34,7 @@ struct Blob {
   uint64_t index;
   uint64_t request_origin;
   uint64_t request_sequence_id;
-  uint64_t extra2;
+  uint64_t unused_extra_8bytes;
 };
 
 static_assert(sizeof(Blob) == 32);

--- a/examples/streamed_sockets/latencytest/blob.h
+++ b/examples/streamed_sockets/latencytest/blob.h
@@ -25,8 +25,8 @@ SOFTWARE.
 #ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
 #define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 namespace current::examples::streamed_sockets {
 

--- a/examples/streamed_sockets/latencytest/blob.h
+++ b/examples/streamed_sockets/latencytest/blob.h
@@ -1,0 +1,47 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
+
+#include <cstdint>
+#include <cstddef>
+
+namespace current::examples::streamed_sockets {
+
+struct Blob {
+  uint64_t index;
+  uint64_t request_id;
+  uint64_t extra1;
+  uint64_t extra2;
+};
+
+static_assert(sizeof(Blob) == 32);
+static_assert((sizeof(Blob) & (sizeof(Blob) - 1u)) == 0u, "`sizeof(Blob)` should be a power of two for this example.");
+static_assert(offsetof(Blob, index) == 0);
+static_assert(offsetof(Blob, request_id) == 8);
+
+}  // namespace current::examples::streamed_sockets
+
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H

--- a/examples/streamed_sockets/latencytest/forward.cc
+++ b/examples/streamed_sockets/latencytest/forward.cc
@@ -44,6 +44,7 @@ DEFINE_uint64(blobs_per_file,
               "The number of blobs per file saved, defaults to 256MB files.");
 DEFINE_uint32(max_total_files, 4u, "The maximum number of data files to keep, defaults to four files, for 1GB total.");
 DEFINE_bool(wipe_files_at_startup, true, "Unset to not wipe the files from the previous run.");
+DEFINE_bool(skip_fwrite, false, "Set to not `fwrite()` into the files; for network perftesting only.");
 
 namespace current::examples::streamed_sockets {
 
@@ -104,7 +105,8 @@ inline void RunForwarder() {
                                                        FLAGS_filebase,
                                                        FLAGS_blobs_per_file,
                                                        FLAGS_max_total_files,
-                                                       FLAGS_wipe_files_at_startup);
+                                                       FLAGS_wipe_files_at_startup,
+                                                       FLAGS_skip_fwrite);
   std::thread t_send = SpawnThreadWorker<SendingWorker<>>(buffer, mutable_state, FLAGS_host, FLAGS_port);
 
   t_source.join();

--- a/examples/streamed_sockets/latencytest/forward.cc
+++ b/examples/streamed_sockets/latencytest/forward.cc
@@ -87,11 +87,11 @@ struct SinkOf<State> {
 inline void RunForwarder() {
   const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
   const size_t actual_n = [min_n]() {
-    size_t min_power_of_to_ge_min_n = 1u;
-    while (min_power_of_to_ge_min_n < min_n) {
-      min_power_of_to_ge_min_n *= 2u;
+    size_t min_power_of_two_greater_than_or_equals_to_min_n = 1u;
+    while (min_power_of_two_greater_than_or_equals_to_min_n < min_n) {
+      min_power_of_two_greater_than_or_equals_to_min_n *= 2u;
     }
-    return min_power_of_to_ge_min_n;
+    return min_power_of_two_greater_than_or_equals_to_min_n;
   }();
 
   std::vector<Blob> buffer(actual_n);

--- a/examples/streamed_sockets/latencytest/forward.cc
+++ b/examples/streamed_sockets/latencytest/forward.cc
@@ -33,9 +33,9 @@ SOFTWARE.
 #include "../../../bricks/net/tcp/tcp.h"
 #include "../../../bricks/time/chrono.h"
 
-DEFINE_uint16(listen_port, 9009, "The local port to listen on.");
+DEFINE_uint16(listen_port, 8002, "The local port to listen on.");
 DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
-DEFINE_uint16(port, 9001, "The destination port to send data to.");
+DEFINE_uint16(port, 8004, "The destination port to send data to.");
 DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
 DEFINE_string(dirname, ".current", "The dir name for the stored data files.");
 DEFINE_string(filebase, "fwd.", "The filename prefix for the stored data files.");

--- a/examples/streamed_sockets/latencytest/forward.cc
+++ b/examples/streamed_sockets/latencytest/forward.cc
@@ -83,7 +83,7 @@ struct SinkOf<State> {
   static size_t Get(const State& state) { return std::min(state.saved, state.sent); }
 };
 
-inline void RunPassthrough() {
+inline void RunForwrad() {
   const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
   const size_t actual_n = [min_n]() {
     size_t min_power_of_to_ge_min_n = 1u;
@@ -128,5 +128,5 @@ int main(int argc, char** argv) {
   }
 #endif
 
-  current::examples::streamed_sockets::RunPassthrough();
+  current::examples::streamed_sockets::RunForwrad();
 }

--- a/examples/streamed_sockets/latencytest/forward.cc
+++ b/examples/streamed_sockets/latencytest/forward.cc
@@ -83,7 +83,7 @@ struct SinkOf<State> {
   static size_t Get(const State& state) { return std::min(state.saved, state.sent); }
 };
 
-inline void RunForwrad() {
+inline void RunForwarder() {
   const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
   const size_t actual_n = [min_n]() {
     size_t min_power_of_to_ge_min_n = 1u;
@@ -128,5 +128,5 @@ int main(int argc, char** argv) {
   }
 #endif
 
-  current::examples::streamed_sockets::RunForwrad();
+  current::examples::streamed_sockets::RunForwarder();
 }

--- a/examples/streamed_sockets/latencytest/generator.cc
+++ b/examples/streamed_sockets/latencytest/generator.cc
@@ -1,0 +1,89 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#include "blob.h"
+
+#include "../../../blocks/xterm/progress.h"
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/strings/printf.h"
+#include "../../../bricks/time/chrono.h"
+#include "../../../bricks/util/random.h"
+
+DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
+DEFINE_uint16(port, 9010, "The destination port to send data to.");
+DEFINE_double(send_buffer_mb, 5.0, "Send buffer size.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  using namespace current::vt100;
+  using current::examples::streamed_sockets::Blob;
+
+#ifndef NDEBUG
+  {
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
+  const size_t N = std::max(static_cast<size_t>(8u),
+                            static_cast<size_t>((1e6 * FLAGS_send_buffer_mb + sizeof(Blob) - 1) / sizeof(Blob)));
+  const double real_mb = 1e-6 * N * sizeof(Blob);
+
+  current::ProgressLine progress;
+
+  progress << current::strings::Printf("allocating %.1lfMB", real_mb);
+  std::vector<Blob> data(N);
+
+  progress << current::strings::Printf("initializing %.1lfMB", real_mb);
+  for (Blob& b : data) {
+    b.request_id = current::random::RandomUInt64(0x00000000, 0xffffffff);
+  }
+
+  progress << "preparing to send";
+  while (true) {
+    try {
+      current::net::Connection connection(current::net::ClientSocket(FLAGS_host, FLAGS_port));
+      progress << "connected, " << magenta << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port
+               << reset << " => " << cyan << connection.RemoteIPAndPort().ip << ':' << connection.RemoteIPAndPort().port
+               << reset;
+      while (true) {
+        const uint64_t begin_index = current::random::RandomUInt64(0, N / 4);
+        const uint64_t end_index = N - current::random::RandomUInt64(0, N / 4);
+        connection.BlockingWrite(
+            reinterpret_cast<const void*>(&data[begin_index]), (end_index - begin_index) * sizeof(Blob), true);
+      }
+    } catch (const current::net::SocketConnectException&) {
+      progress << "connecting to " << red << bold << FLAGS_host << ':' << FLAGS_port << reset;
+    } catch (const current::Exception& e) {
+      progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.
+  }
+}

--- a/examples/streamed_sockets/latencytest/generator.cc
+++ b/examples/streamed_sockets/latencytest/generator.cc
@@ -175,7 +175,6 @@ int main(int argc, char** argv) {
 
   // The code to listen to the confirmations of own requests.
   std::thread t_listener([&timestamps, &progress]() {
-
     progress << "listening, to measure latency, on localhost:" << FLAGS_listen_port;
     current::net::Socket socket(FLAGS_listen_port);
     progress << "accepting connections, to measure latency, on localhost:" << FLAGS_listen_port;
@@ -192,7 +191,7 @@ int main(int argc, char** argv) {
     }
   });
 
-  // The code that originate requests.
+  // The code that originates the requests.
   uint64_t request_sequence_id = 0;
   while (true) {
     try {

--- a/examples/streamed_sockets/latencytest/generator.cc
+++ b/examples/streamed_sockets/latencytest/generator.cc
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#include <deque>
+
 #include "blob.h"
 
 #include "../../../blocks/xterm/progress.h"
@@ -29,12 +31,101 @@ SOFTWARE.
 #include "../../../bricks/dflags/dflags.h"
 #include "../../../bricks/net/tcp/tcp.h"
 #include "../../../bricks/strings/printf.h"
+#include "../../../bricks/sync/waitable_atomic.h"
 #include "../../../bricks/time/chrono.h"
 #include "../../../bricks/util/random.h"
 
 DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
-DEFINE_uint16(port, 9010, "The destination port to send data to.");
+DEFINE_uint16(port, 8001, "The destination port to send data to.");
 DEFINE_double(send_buffer_mb, 5.0, "Send buffer size.");
+DEFINE_uint16(listen_port, 8005, "The port to listen for the confirmations of own requests, to measure latency.");
+DEFINE_double(latency_output_frequency, 2, "The frequency of latency outputs, in seconds.");
+DEFINE_double(latency_measurement_time_window, 10, "The width of the latency measurement time window, in seconds.");
+
+struct LatencyTracker {
+  const std::chrono::microseconds t_time_window_width;
+  size_t n = 0u;
+  int64_t sum = 0;
+  std::deque<std::pair<std::chrono::microseconds, int64_t>> q;
+  LatencyTracker() : t_time_window_width(static_cast<int64_t>(1e6 * FLAGS_latency_measurement_time_window)) {}
+  void Add(std::chrono::microseconds ts, int64_t latency) {
+    ++n;
+    q.emplace_back(ts, latency);
+    sum += latency;
+    const std::chrono::microseconds t_cutoff = ts - t_time_window_width;
+    while (q.front().first < t_cutoff) {
+      --n;
+      sum -= q.front().second;
+      q.pop_front();
+    }
+  }
+  std::string State() const {
+    if (!n) {
+      return "N/A";
+    } else {
+      std::vector<int64_t> v;
+      v.reserve(n);
+      for (const auto& e : q) {
+        v.push_back(e.second);
+      }
+      std::ostringstream os;
+      int64_t* b = &v[0];
+      int64_t* e = &v[0] + n;
+      int64_t p;
+
+      os << current::strings::Printf("%.1lfms", 1e-3 * (sum / n));
+
+      p = n / 2;
+      std::nth_element(b, b + p, e);
+      os << current::strings::Printf(" / %.1lfms", 1e-3 * b[p]);
+
+      p = n * 9 / 10;
+      std::nth_element(b, b + p, e);
+      os << current::strings::Printf(" / %.1lfms", 1e-3 * b[p]);
+
+      p = n * 99 / 100;
+      std::nth_element(b, b + p, e);
+      os << current::strings::Printf(" / %.1lfms", 1e-3 * b[p]);
+
+      os << " / N=" << n;
+
+      return os.str();
+    }
+  }
+};
+
+using deque_t = std::deque<std::pair<uint64_t, int64_t>>;  // { request sequence index, timestamp in us }.
+using deques_t = std::pair<deque_t, deque_t>;              // sent, received
+inline void RelaxQueues(deques_t& dqs, current::ProgressLine& progress) {
+  const std::chrono::microseconds t_output_frequency =
+      std::chrono::microseconds(static_cast<int64_t>(1e6 * FLAGS_latency_output_frequency));
+  static std::chrono::microseconds t_next_output = current::time::Now() + t_output_frequency;
+
+  static LatencyTracker all;
+  static LatencyTracker evens;
+  static LatencyTracker odds;
+
+  while (!dqs.first.empty() && !dqs.second.empty() && dqs.first.front().first == dqs.second.front().first) {
+    const uint64_t req_id = dqs.first.front().first;
+    const int64_t ts_sent = dqs.first.front().second;
+    const int64_t ts_received = dqs.second.front().second;
+    // std::cerr << req_id << '\t' << ts_received - ts_sent << '\n';
+    dqs.first.pop_front();
+    dqs.second.pop_front();
+
+    const std::chrono::microseconds t_now = current::time::Now();
+    all.Add(t_now, ts_received - ts_sent);
+    if (req_id & 1) {
+      evens.Add(t_now, ts_received - ts_sent);
+    } else {
+      odds.Add(t_now, ts_received - ts_sent);
+    }
+    if (t_now >= t_next_output) {
+      progress << all.State() << " | " << evens.State() << " | " << odds.State();
+      t_next_output = t_now + t_output_frequency;
+    }
+  }
+}
 
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
@@ -54,27 +145,54 @@ int main(int argc, char** argv) {
 
   const size_t N = std::max(static_cast<size_t>(8u),
                             static_cast<size_t>((1e6 * FLAGS_send_buffer_mb + sizeof(Blob) - 1) / sizeof(Blob)));
-  const double real_mb = 1e-6 * N * sizeof(Blob);
+  // const double real_mb = 1e-6 * N * sizeof(Blob);
+
+  std::cout << "Format: { all, evens, odds } * \"$(average) / $(median) / $(p90) / $(p99) / N=$(sample size)\"."
+            << std::endl;
 
   current::ProgressLine progress;
 
-  progress << current::strings::Printf("allocating %.1lfMB", real_mb);
+  // progress << current::strings::Printf("allocating %.1lfMB", real_mb);
   std::vector<Blob> data(N);
 
-  progress << current::strings::Printf("initializing %.1lfMB", real_mb);
+  // progress << current::strings::Printf("initializing %.1lfMB", real_mb);
   for (Blob& b : data) {
     using namespace current::examples::streamed_sockets;
     b.request_origin = current::random::RandomUInt64(request_origin_range_lo, request_origin_range_hi);
   }
 
-  progress << "preparing to send";
+  current::WaitableAtomic<deques_t> timestamps;
+
+  // The code to listen to the confirmations of own requests.
+  std::thread t_listener([&timestamps, &progress]() {
+
+    progress << "listening, to measure latency, on localhost:" << FLAGS_listen_port;
+    current::net::Socket socket(FLAGS_listen_port);
+    progress << "accepting connections, to measure latency, on localhost:" << FLAGS_listen_port;
+    current::net::Connection connection(socket.Accept());
+    progress << "";
+
+    Blob blob;
+    while (connection.BlockingRead(reinterpret_cast<uint8_t*>(&blob), sizeof(Blob))) {
+      const int64_t t_now = current::time::Now().count();
+      timestamps.MutableUse([t_now, &blob, &progress](deques_t& dqs) {
+        dqs.second.emplace_back(blob.request_sequence_id, t_now);
+        RelaxQueues(dqs, progress);
+      });
+      // std::cerr << "<< " << t_now << '\t' << blob.request_sequence_id << '\n';
+    }
+  });
+
+  // The code that originate requests.
+  // progress << "preparing to send";
   uint64_t request_sequence_id = 0;
   while (true) {
     try {
       current::net::Connection connection(current::net::ClientSocket(FLAGS_host, FLAGS_port));
-      progress << "connected, " << magenta << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port
-               << reset << " => " << cyan << connection.RemoteIPAndPort().ip << ':' << connection.RemoteIPAndPort().port
-               << reset;
+      // progress
+      //   << "connected, " << magenta << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port
+      //   << reset << " => " << cyan << connection.RemoteIPAndPort().ip << ':' << connection.RemoteIPAndPort().port
+      //   << reset;
       while (true) {
         const uint64_t begin_index = current::random::RandomUInt64(0, N / 4);
         const uint64_t end_index = N - current::random::RandomUInt64(0, N / 4);
@@ -85,22 +203,29 @@ int main(int argc, char** argv) {
         data[a].request_origin = current::examples::streamed_sockets::request_origin_latencytest;
         data[b].request_origin = current::examples::streamed_sockets::request_origin_latencytest;
         data[a].request_sequence_id = request_sequence_id;
-        data[b].request_sequence_id = request_sequence_id + 1u;
-        // const int64_t t_begin = current::time::Now().count();
+        data[b].request_sequence_id = request_sequence_id + 1;
+        const int64_t t_begin = current::time::Now().count();
         connection.BlockingWrite(
             reinterpret_cast<const void*>(&data[begin_index]), (end_index - begin_index) * sizeof(Blob), true);
-        // const int64_t t_end = current::time::Now().count();
+        const int64_t t_end = current::time::Now().count();
         data[a].request_origin = request_origin_a_save;
         data[b].request_origin = request_origin_b_save;
-        // std::cerr << t_begin << '\t' << request_sequence_id << '\n';
-        // std::cerr << t_end << '\t' << request_sequence_id + 1 << '\n';
+        // std::cerr << ">> " << t_begin << '\t' << request_sequence_id << '\n';
+        // std::cerr << "<< " << t_end << '\t' << request_sequence_id + 1 << '\n';
+        timestamps.MutableUse([t_begin, t_end, request_sequence_id, &progress](deques_t& dqs) {
+          dqs.first.emplace_back(request_sequence_id, t_begin);
+          dqs.first.emplace_back(request_sequence_id + 1, t_end);
+          RelaxQueues(dqs, progress);
+        });
         request_sequence_id += 2;
       }
     } catch (const current::net::SocketConnectException&) {
-      progress << "connecting to " << red << bold << FLAGS_host << ':' << FLAGS_port << reset;
+      // progress << "connecting to " << red << bold << FLAGS_host << ':' << FLAGS_port << reset;
     } catch (const current::Exception& e) {
-      progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
+      // progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.
   }
+
+  t_listener.join();
 }

--- a/examples/streamed_sockets/latencytest/generator.cc
+++ b/examples/streamed_sockets/latencytest/generator.cc
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
         data[b].request_sequence_id = request_sequence_id + 1;
         const int64_t t_begin = current::time::Now().count();
         connection.BlockingWrite(
-            reinterpret_cast<const void*>(&data[begin_index]), (end_index - begin_index) * sizeof(Blob), true);
+            reinterpret_cast<const void*>(&data[begin_index]), (end_index - begin_index) * sizeof(Blob), false);
         const int64_t t_end = current::time::Now().count();
         data[a].request_origin = request_origin_a_save;
         data[b].request_origin = request_origin_b_save;

--- a/examples/streamed_sockets/latencytest/indexer.cc
+++ b/examples/streamed_sockets/latencytest/indexer.cc
@@ -1,0 +1,120 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#include "blob.h"
+#include "next_ripcurrent.h"
+#include "workers/indexer.h"
+#include "workers/receiver.h"
+#include "workers/sender.h"
+
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_uint16(listen_port, 9010, "The local port to listen on.");
+DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
+DEFINE_uint16(port, 9009, "The destination port to send data to.");
+DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
+DEFINE_uint64(max_index_block, 512, "Index max. this many entries per state mutex lock, throttling.");
+
+namespace current::examples::streamed_sockets {
+
+struct State {
+  volatile size_t read = 0u;
+  volatile size_t indexed = 0u;
+  volatile size_t done = 0u;
+};
+
+template <>
+struct OutputOf<State, ReceivingWorker> {
+  static void Set(State& state, size_t value) { state.read = value; }
+};
+
+template <>
+struct InputOf<State, IndexingWorker> {
+  static size_t Get(const State& state) { return state.read; }
+};
+
+template <>
+struct InputOf<State, SendingWorker> {
+  static size_t Get(const State& state) { return state.indexed; }
+};
+
+template <>
+struct OutputOf<State, IndexingWorker> {
+  static void Set(State& state, size_t value) { state.indexed = value; }
+};
+
+template <>
+struct OutputOf<State, SendingWorker> {
+  static void Set(State& state, size_t value) { state.done = value; }
+};
+
+template <>
+struct SinkOf<State> {
+  static size_t Get(const State& state) { return state.done; }
+};
+
+inline void RunIndexer() {
+  const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
+  const size_t actual_n = [min_n]() {
+    size_t min_power_of_to_ge_min_n = 1u;
+    while (min_power_of_to_ge_min_n < min_n) {
+      min_power_of_to_ge_min_n *= 2u;
+    }
+    return min_power_of_to_ge_min_n;
+  }();
+
+  std::vector<Blob> buffer(actual_n);
+
+  current::WaitableAtomic<State> mutable_state;
+
+  std::thread t_source = SpawnThreadSource<ReceivingWorker>(buffer, mutable_state, FLAGS_listen_port);
+  std::thread t_indexing = SpawnThreadWorker<IndexingWorker>(buffer, mutable_state, FLAGS_max_index_block);
+  std::thread t_send = SpawnThreadWorker<SendingWorker>(buffer, mutable_state, FLAGS_host, FLAGS_port);
+
+  t_source.join();
+  t_indexing.join();
+  t_send.join();
+}
+
+}  // namespace current::examples::streamed_sockets
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+#ifndef NDEBUG
+  {
+    using namespace current::vt100;
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
+  current::examples::streamed_sockets::RunIndexer();
+}

--- a/examples/streamed_sockets/latencytest/indexer.cc
+++ b/examples/streamed_sockets/latencytest/indexer.cc
@@ -116,11 +116,11 @@ struct SinkOf<State> {
 inline void RunIndexer() {
   const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
   const size_t actual_n = [min_n]() {
-    size_t min_power_of_to_ge_min_n = 1u;
-    while (min_power_of_to_ge_min_n < min_n) {
-      min_power_of_to_ge_min_n *= 2u;
+    size_t min_power_of_two_greater_than_or_equals_to_min_n = 1u;
+    while (min_power_of_two_greater_than_or_equals_to_min_n < min_n) {
+      min_power_of_two_greater_than_or_equals_to_min_n *= 2u;
     }
-    return min_power_of_to_ge_min_n;
+    return min_power_of_two_greater_than_or_equals_to_min_n;
   }();
 
   std::vector<Blob> buffer(actual_n);

--- a/examples/streamed_sockets/latencytest/indexer.cc
+++ b/examples/streamed_sockets/latencytest/indexer.cc
@@ -48,6 +48,7 @@ DEFINE_uint64(blobs_per_file,
               "The number of blobs per file saved, defaults to 256MB files.");
 DEFINE_uint32(max_total_files, 4u, "The maximum number of data files to keep, defaults to four files, for 1GB total.");
 DEFINE_bool(wipe_files_at_startup, true, "Unset to not wipe the files from the previous run.");
+DEFINE_bool(skip_fwrite, false, "Set to not `fwrite()` into the files; for network perftesting only.");
 
 namespace current::examples::streamed_sockets {
 
@@ -134,7 +135,8 @@ inline void RunIndexer() {
                                                        FLAGS_filebase,
                                                        FLAGS_blobs_per_file,
                                                        FLAGS_max_total_files,
-                                                       FLAGS_wipe_files_at_startup);
+                                                       FLAGS_wipe_files_at_startup,
+                                                       FLAGS_skip_fwrite);
   std::thread t_send1 = SpawnThreadWorker<SendingWorker<One>>(buffer, mutable_state, FLAGS_host1, FLAGS_port1);
   std::thread t_send2 = SpawnThreadWorker<SendingWorker<Two>>(buffer, mutable_state, FLAGS_host2, FLAGS_port2);
 

--- a/examples/streamed_sockets/latencytest/indexer.cc
+++ b/examples/streamed_sockets/latencytest/indexer.cc
@@ -34,11 +34,11 @@ SOFTWARE.
 #include "../../../bricks/net/tcp/tcp.h"
 #include "../../../bricks/time/chrono.h"
 
-DEFINE_uint16(listen_port, 9010, "The local port to listen on.");
+DEFINE_uint16(listen_port, 8001, "The local port to listen on.");
 DEFINE_string(host1, "127.0.0.1", "The destination address to send data to.");
-DEFINE_uint16(port1, 9009, "The destination port to send data to.");
+DEFINE_uint16(port1, 8002, "The destination port to send data to.");
 DEFINE_string(host2, "127.0.0.1", "The destination address to send data to.");
-DEFINE_uint16(port2, 9008, "The destination port to send data to.");
+DEFINE_uint16(port2, 8003, "The destination port to send data to.");
 DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
 DEFINE_uint64(max_index_block, 512, "Index max. this many entries per state mutex lock, throttling.");
 DEFINE_string(dirname, ".current", "The dir name for the stored data files.");

--- a/examples/streamed_sockets/latencytest/next_ripcurrent.h
+++ b/examples/streamed_sockets/latencytest/next_ripcurrent.h
@@ -1,0 +1,184 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// TODO(dkorolev): RipCurrent style:
+// 1) Clean syntax (macros and metaprogramming) to define sources and workers.
+// 2) Clean syntax (macros and metaprogramming) to define pipelines.
+// 3) Lazy instantiation with of sources and workers, with pre-provided constructer parameters.
+// 4) The HTTP/HTML/gnuplot/graphviz status page.
+
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_NEXT_RIPCURRENT_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_NEXT_RIPCURRENT_H
+
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "../../../bricks/sync/waitable_atomic.h"
+
+namespace current::examples::streamed_sockets {
+
+template <class T_STATE, class T_SOURCE_OR_WORKER>
+struct InputOf;
+
+template <class T_STATE, class T_SOURCE_OR_WORKER>
+struct OutputOf;
+
+template <class T_STATE>
+struct SinkOf;
+
+template <class T_SOURCE, class T_BLOB, class T_WAITABLE_ATOMIC_STATE, typename... ARGS>
+std::thread SpawnThreadSource(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STATE& mutable_state, ARGS&&... args) {
+  using state_t = typename T_WAITABLE_ATOMIC_STATE::data_t;
+  return std::thread([&buffer, &mutable_state, worker = std::make_unique<T_SOURCE>(std::forward<ARGS>(args)...) ]() {
+    const state_t& volatile_immutable_state = mutable_state.ImmutableUse([](const state_t& value) { return value; });
+
+    const size_t total_buffer_size = buffer.size();
+    if ((total_buffer_size & (total_buffer_size - 1u)) != 0u) {
+      std::cerr << "Internal error, must be a power of two." << std::endl;
+      std::exit(-1);
+    }
+
+    const size_t total_buffer_size_in_bytes = buffer.size() * sizeof(T_BLOB);
+    const size_t total_buffer_size_in_bytes_minus_one = total_buffer_size_in_bytes - 1u;
+    if ((total_buffer_size_in_bytes & total_buffer_size_in_bytes_minus_one) != 0u) {
+      std::cerr << "Internal error, must be a power of two." << std::endl;
+      std::exit(-1);
+    }
+
+    uint8_t* buffer_in_bytes = reinterpret_cast<uint8_t*>(&buffer[0]);
+
+    // The number of bytes "available" is effectively the total bytes read plus the size of part
+    // of the buffer that is not presently used by the blobs already read but not yet processed.
+    size_t trailing_total_blobs_done = 0u;
+    size_t trailing_total_bytes_aval = 0u;
+
+    size_t updating_total_bytes_read = 0u;
+    size_t updating_total_blobs_read = 0u;
+
+    // Updates the value of `trailing_total_bytes_aval`.
+    // The resulting value may well result in the queue being full, in which case
+    // the outer loop will wait on the condition_variable until some room frees up.
+    const auto Update =
+        [&trailing_total_bytes_aval, total_buffer_size_in_bytes, &trailing_total_blobs_done](const state_t& state) {
+          trailing_total_blobs_done = std::max(trailing_total_blobs_done, SinkOf<state_t>::Get(state));
+          trailing_total_bytes_aval = (trailing_total_blobs_done * sizeof(T_BLOB) + total_buffer_size_in_bytes);
+        };
+
+    // Checks whether waiting on the condition variable is required, i.e. checks if the buffer is full.
+    const auto IsReady = [&updating_total_bytes_read, &trailing_total_bytes_aval]() {
+      return trailing_total_bytes_aval != updating_total_bytes_read;
+    };
+
+    while (true) {
+      Update(volatile_immutable_state);
+      if (!IsReady()) {
+        mutable_state.Wait([&IsReady, &Update](const state_t& value) {
+          Update(value);
+          return IsReady();
+        });
+      }
+
+      const size_t bgn = (updating_total_bytes_read & total_buffer_size_in_bytes_minus_one);
+      const size_t end = (trailing_total_bytes_aval & total_buffer_size_in_bytes_minus_one);
+      const auto DoWorkOverCircularBufferInBytes = [&](size_t bgn, size_t end) {
+        const size_t bytes_read = worker->DoGetInput(buffer_in_bytes + bgn, buffer_in_bytes + end);
+        if (bytes_read) {
+          updating_total_bytes_read += bytes_read;
+          const size_t candidate_total_blobs_read_value = updating_total_bytes_read / sizeof(T_BLOB);
+          if (candidate_total_blobs_read_value != updating_total_blobs_read) {
+            updating_total_blobs_read = candidate_total_blobs_read_value;
+            mutable_state.MutableUse([candidate_total_blobs_read_value](state_t& state) {
+              OutputOf<state_t, T_SOURCE>::Set(state, candidate_total_blobs_read_value);
+            });
+          }
+        }
+      };
+      if (bgn < end) {
+        DoWorkOverCircularBufferInBytes(bgn, end);
+      } else {
+        DoWorkOverCircularBufferInBytes(bgn, total_buffer_size_in_bytes);
+      }
+    }
+  });
+}
+
+template <class T_WORKER, class T_BLOB, class T_WAITABLE_ATOMIC_STATE, typename... ARGS>
+std::thread SpawnThreadWorker(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STATE& mutable_state, ARGS&&... args) {
+  using state_t = typename T_WAITABLE_ATOMIC_STATE::data_t;
+  return std::thread([&buffer, &mutable_state, worker = std::make_unique<T_WORKER>(std::forward<ARGS>(args)...) ]() {
+    const state_t& volatile_immutable_state = mutable_state.ImmutableUse([](const state_t& value) { return value; });
+
+    const size_t total_buffer_size = buffer.size();
+    const size_t total_buffer_size_minus_one = total_buffer_size - 1u;
+    if ((total_buffer_size & total_buffer_size_minus_one) != 0u) {
+      std::cerr << "Internal error, must be a power of two." << std::endl;
+      std::exit(-1);
+    }
+
+    T_BLOB* const immutable_buffer_ptr = &buffer[0];
+    // NOTE(dkorolev): And/or: `T_BLOB* mutable_buffer_ptr = &buffer[0];`
+
+    size_t updating_total_blobs_done = 0u;
+    size_t trailing_total_blobs_read = 0u;
+    const auto Update = [&trailing_total_blobs_read](const state_t& state) {
+      trailing_total_blobs_read = std::max(trailing_total_blobs_read, InputOf<state_t, T_WORKER>::Get(state));
+    };
+    const auto IsReady = [&trailing_total_blobs_read, &updating_total_blobs_done]() {
+      return updating_total_blobs_done < trailing_total_blobs_read;
+    };
+
+    while (true) {
+      Update(volatile_immutable_state);
+      if (!IsReady()) {
+        mutable_state.Wait([&IsReady, &Update](const state_t& value) {
+          Update(value);
+          return IsReady();
+        });
+      }
+
+      const auto DoWorkOverCircularBuffer = [&](size_t begin, size_t end) {
+        T_BLOB* const ptr_begin = immutable_buffer_ptr + begin;
+        T_BLOB* const ptr_end = immutable_buffer_ptr + end;
+        const size_t processed = (worker->DoWork(ptr_begin, ptr_end) - ptr_begin);
+        updating_total_blobs_done += processed;
+        mutable_state.MutableUse([updating_total_blobs_done](state_t& state) {
+          OutputOf<state_t, T_WORKER>::Set(state, updating_total_blobs_done);
+        });
+      };
+
+      const size_t bgn = (updating_total_blobs_done & total_buffer_size_minus_one);
+      const size_t end = (trailing_total_blobs_read & total_buffer_size_minus_one);
+      if (bgn < end) {
+        DoWorkOverCircularBuffer(bgn, end);
+      } else {
+        DoWorkOverCircularBuffer(bgn, buffer.size());
+      }
+    }
+  });
+}
+
+}  // namespace current::examples::streamed_sockets
+
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_NEXT_RIPCURRENT_H

--- a/examples/streamed_sockets/latencytest/next_ripcurrent.h
+++ b/examples/streamed_sockets/latencytest/next_ripcurrent.h
@@ -109,8 +109,8 @@ std::thread SpawnThreadSource(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STA
           const size_t candidate_total_blobs_read_value = updating_total_bytes_read / sizeof(T_BLOB);
           if (candidate_total_blobs_read_value != updating_total_blobs_read) {
             updating_total_blobs_read = candidate_total_blobs_read_value;
-            mutable_state.MutableUse([candidate_total_blobs_read_value](state_t& state) {
-              OutputOf<state_t, T_SOURCE>::Set(state, candidate_total_blobs_read_value);
+            mutable_state.MutableUse([updating_total_blobs_read](state_t& state) {
+              OutputOf<state_t, T_SOURCE>::Set(state, updating_total_blobs_read);
             });
           }
         }

--- a/examples/streamed_sockets/latencytest/next_ripcurrent.h
+++ b/examples/streamed_sockets/latencytest/next_ripcurrent.h
@@ -25,7 +25,7 @@ SOFTWARE.
 // TODO(dkorolev): RipCurrent style:
 // 1) Clean syntax (macros and metaprogramming) to define sources and workers.
 // 2) Clean syntax (macros and metaprogramming) to define pipelines.
-// 3) Lazy instantiation with of sources and workers, with pre-provided constructer parameters.
+// 3) Lazy instantiation with of sources and workers, with pre-provided constructor parameters.
 // 4) The HTTP/HTML/gnuplot/graphviz status page.
 
 #ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_NEXT_RIPCURRENT_H

--- a/examples/streamed_sockets/latencytest/passthrough.cc
+++ b/examples/streamed_sockets/latencytest/passthrough.cc
@@ -50,12 +50,12 @@ struct OutputOf<State, ReceivingWorker> {
 };
 
 template <>
-struct InputOf<State, SendingWorker> {
+struct InputOf<State, SendingWorker<>> {
   static size_t Get(const State& state) { return state.read; }
 };
 
 template <>
-struct OutputOf<State, SendingWorker> {
+struct OutputOf<State, SendingWorker<>> {
   static void Set(State& state, size_t value) { state.done = value; }
 };
 
@@ -79,7 +79,7 @@ inline void RunPassthrough() {
   current::WaitableAtomic<State> mutable_state;
 
   std::thread t_source = SpawnThreadSource<ReceivingWorker>(buffer, mutable_state, FLAGS_listen_port);
-  std::thread t_send = SpawnThreadWorker<SendingWorker>(buffer, mutable_state, FLAGS_host, FLAGS_port);
+  std::thread t_send = SpawnThreadWorker<SendingWorker<>>(buffer, mutable_state, FLAGS_host, FLAGS_port);
 
   t_source.join();
   t_send.join();

--- a/examples/streamed_sockets/latencytest/passthrough.cc
+++ b/examples/streamed_sockets/latencytest/passthrough.cc
@@ -1,0 +1,105 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#include "blob.h"
+#include "next_ripcurrent.h"
+#include "workers/receiver.h"
+#include "workers/sender.h"
+
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_uint16(listen_port, 9009, "The local port to listen on.");
+DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
+DEFINE_uint16(port, 9001, "The destination port to send data to.");
+DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
+
+namespace current::examples::streamed_sockets {
+
+struct State {
+  volatile size_t read = 0u;
+  volatile size_t done = 0u;
+};
+
+template <>
+struct OutputOf<State, ReceivingWorker> {
+  static void Set(State& state, size_t value) { state.read = value; }
+};
+
+template <>
+struct InputOf<State, SendingWorker> {
+  static size_t Get(const State& state) { return state.read; }
+};
+
+template <>
+struct OutputOf<State, SendingWorker> {
+  static void Set(State& state, size_t value) { state.done = value; }
+};
+
+template <>
+struct SinkOf<State> {
+  static size_t Get(const State& state) { return state.done; }
+};
+
+inline void RunPassthrough() {
+  const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
+  const size_t actual_n = [min_n]() {
+    size_t min_power_of_to_ge_min_n = 1u;
+    while (min_power_of_to_ge_min_n < min_n) {
+      min_power_of_to_ge_min_n *= 2u;
+    }
+    return min_power_of_to_ge_min_n;
+  }();
+
+  std::vector<Blob> buffer(actual_n);
+
+  current::WaitableAtomic<State> mutable_state;
+
+  std::thread t_source = SpawnThreadSource<ReceivingWorker>(buffer, mutable_state, FLAGS_listen_port);
+  std::thread t_send = SpawnThreadWorker<SendingWorker>(buffer, mutable_state, FLAGS_host, FLAGS_port);
+
+  t_source.join();
+  t_send.join();
+}
+
+}  // namespace current::examples::streamed_sockets
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+#ifndef NDEBUG
+  {
+    using namespace current::vt100;
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
+  current::examples::streamed_sockets::RunPassthrough();
+}

--- a/examples/streamed_sockets/latencytest/processor.cc
+++ b/examples/streamed_sockets/latencytest/processor.cc
@@ -1,0 +1,101 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#include "workers/processor.h"
+#include "blob.h"
+#include "next_ripcurrent.h"
+#include "workers/receiver.h"
+
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+
+DEFINE_uint16(listen_port, 9008, "The local port to listen on.");
+DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
+
+namespace current::examples::streamed_sockets {
+
+struct State {
+  volatile size_t read = 0u;
+  volatile size_t processed = 0u;
+};
+
+template <>
+struct OutputOf<State, ReceivingWorker> {
+  static void Set(State& state, size_t value) { state.read = value; }
+};
+
+template <>
+struct InputOf<State, ProcessingWorker> {
+  static size_t Get(const State& state) { return state.read; }
+};
+
+template <>
+struct OutputOf<State, ProcessingWorker> {
+  static void Set(State& state, size_t value) { state.processed = value; }
+};
+
+template <>
+struct SinkOf<State> {
+  static size_t Get(const State& state) { return state.processed; }
+};
+
+inline void RunProcess() {
+  const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
+  const size_t actual_n = [min_n]() {
+    size_t min_power_of_to_ge_min_n = 1u;
+    while (min_power_of_to_ge_min_n < min_n) {
+      min_power_of_to_ge_min_n *= 2u;
+    }
+    return min_power_of_to_ge_min_n;
+  }();
+
+  std::vector<Blob> buffer(actual_n);
+
+  current::WaitableAtomic<State> mutable_state;
+
+  std::thread t_source = SpawnThreadSource<ReceivingWorker>(buffer, mutable_state, FLAGS_listen_port);
+  std::thread t_process = SpawnThreadWorker<ProcessingWorker>(buffer, mutable_state);
+
+  t_source.join();
+  t_process.join();
+}
+
+}  // namespace current::examples::streamed_sockets
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+#ifndef NDEBUG
+  {
+    using namespace current::vt100;
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
+  current::examples::streamed_sockets::RunProcess();
+}

--- a/examples/streamed_sockets/latencytest/processor.cc
+++ b/examples/streamed_sockets/latencytest/processor.cc
@@ -30,7 +30,9 @@ SOFTWARE.
 #include "../../../blocks/xterm/vt100.h"
 #include "../../../bricks/dflags/dflags.h"
 
-DEFINE_uint16(listen_port, 9008, "The local port to listen on.");
+DEFINE_uint16(listen_port, 8004, "The local port to listen on.");
+DEFINE_string(host, "127.0.0.1", "The destination address to send the confirmations to.");
+DEFINE_uint16(port, 8005, "The destination port to send the confirmations to.");
 DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
 
 namespace current::examples::streamed_sockets {
@@ -75,7 +77,7 @@ inline void RunProcess() {
   current::WaitableAtomic<State> mutable_state;
 
   std::thread t_source = SpawnThreadSource<ReceivingWorker>(buffer, mutable_state, FLAGS_listen_port);
-  std::thread t_process = SpawnThreadWorker<ProcessingWorker>(buffer, mutable_state);
+  std::thread t_process = SpawnThreadWorker<ProcessingWorker>(buffer, mutable_state, FLAGS_host, FLAGS_port);
 
   t_source.join();
   t_process.join();

--- a/examples/streamed_sockets/latencytest/processor.cc
+++ b/examples/streamed_sockets/latencytest/processor.cc
@@ -65,11 +65,11 @@ struct SinkOf<State> {
 inline void RunProcess() {
   const size_t min_n = std::max(static_cast<size_t>(8u), static_cast<size_t>(1e6 * FLAGS_buffer_mb) / sizeof(Blob));
   const size_t actual_n = [min_n]() {
-    size_t min_power_of_to_ge_min_n = 1u;
-    while (min_power_of_to_ge_min_n < min_n) {
-      min_power_of_to_ge_min_n *= 2u;
+    size_t min_power_of_two_greater_than_or_equals_to_min_n = 1u;
+    while (min_power_of_two_greater_than_or_equals_to_min_n < min_n) {
+      min_power_of_two_greater_than_or_equals_to_min_n *= 2u;
     }
-    return min_power_of_to_ge_min_n;
+    return min_power_of_two_greater_than_or_equals_to_min_n;
   }();
 
   std::vector<Blob> buffer(actual_n);

--- a/examples/streamed_sockets/latencytest/run_all_locally.sh
+++ b/examples/streamed_sockets/latencytest/run_all_locally.sh
@@ -6,8 +6,8 @@ NDEBUG=1 make -j .current/generator .current/indexer .current/forward .current/p
 
 ./.current/terminator --silent &
 ./.current/processor &
-./.current/forward &
-./.current/indexer &
+./.current/forward $* &
+./.current/indexer $* &
 ./.current/generator &
 
 wait

--- a/examples/streamed_sockets/latencytest/run_all_locally.sh
+++ b/examples/streamed_sockets/latencytest/run_all_locally.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/generator .current/indexer .current/forward .current/processor .current/terminator
+
+./.current/terminator --silent &
+./.current/processor &
+./.current/forward &
+./.current/indexer &
+./.current/generator &
+
+wait

--- a/examples/streamed_sockets/latencytest/terminator.cc
+++ b/examples/streamed_sockets/latencytest/terminator.cc
@@ -1,0 +1,138 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// NOTE(dkorolev): The copy-past of `../speedtest/receiver.cc`, with port changed, to keep everyhing in a single dir.
+
+#include <deque>
+
+#include "../../../blocks/xterm/progress.h"
+#include "../../../blocks/xterm/vt100.h"
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/strings/printf.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_uint16(port, 8003, "The port to use.");
+DEFINE_double(receive_buffer_gb, 0.5, "The size of the buffer the read the data into.");
+DEFINE_double(window_size_seconds, 5.0, "The length of sliding window the throughput within which is reported.");
+DEFINE_double(window_size_gb, 20.0, "The maximum amount of data per the sliding window to report the throughput.");
+DEFINE_double(output_frequency, 0.1, "The minimim amount of time, in seconds, between terminal updates.");
+DEFINE_double(max_seconds_of_silence, 1.5, "Terminate the connection if it sends nothing for this long, in seconds.");
+DEFINE_bool(silent, false, "Set to suppress GB/s output, for the `./run_all_locally.sh` script.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  using namespace current::net;
+  using namespace current::vt100;
+
+#ifndef NDEBUG
+  {
+    std::cout << yellow << bold << "warning" << reset << ": unoptimized build";
+#if defined(CURRENT_POSIX) || defined(CURRENT_APPLE)
+    std::cout << ", run " << cyan << "NDEBUG=1 make clean all";
+#endif
+    std::cout << std::endl;
+  }
+#endif
+
+  const std::chrono::microseconds t_window_size(static_cast<int64_t>(FLAGS_window_size_seconds * 1e6));
+  const size_t window_size_bytes = static_cast<size_t>(FLAGS_window_size_gb * 1e9);
+  const std::chrono::microseconds t_output_frequency(static_cast<int64_t>(FLAGS_output_frequency * 1e6));
+
+  std::vector<uint8_t> buffer(static_cast<size_t>(1e9 * FLAGS_receive_buffer_gb));
+
+  current::ProgressLine progress;
+
+  progress << "starting on " << cyan << bold << "localhost:" << FLAGS_port;
+
+  while (true) {
+    try {
+      size_t total_bytes_received = 0ull;
+      std::deque<std::pair<std::chrono::microseconds, size_t>> history;  // { unix epoch time, total bytes received }.
+
+      Socket socket(FLAGS_port);
+      progress << "listening on " << cyan << bold << "localhost:" << FLAGS_port;
+      Connection connection(socket.Accept());
+      progress << "connected, " << cyan << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port
+               << reset << " <= " << magenta << connection.RemoteIPAndPort().ip << ':'
+               << connection.RemoteIPAndPort().port << reset;
+
+      if (FLAGS_silent) {
+        progress << "";
+      }
+
+      std::chrono::microseconds t_next_output = current::time::Now() + t_output_frequency;
+      std::chrono::microseconds t_last_successful_receive = current::time::Now();
+      while (true) {
+        const size_t size = connection.BlockingRead(&buffer[0], buffer.size());
+        const std::chrono::microseconds t_now = current::time::Now();
+        if (size) {
+          total_bytes_received += size;
+          t_last_successful_receive = t_now;
+          history.emplace_back(t_now, total_bytes_received);
+          const std::chrono::microseconds t_cutoff = t_now - t_window_size;
+          const size_t size_cutoff =
+              (total_bytes_received > window_size_bytes ? total_bytes_received - window_size_bytes : 0);
+          if (!FLAGS_silent && t_now >= t_next_output) {
+            if (history.size() >= 2) {
+              while (history.size() > 2 &&
+                     (history.front().first <= t_cutoff || history.front().second <= size_cutoff)) {
+                history.pop_front();
+              }
+              const double gb = 1e-9 * (history.back().second - history.front().second);
+              const double s = 1e-6 * (history.back().first - history.front().first).count();
+              progress << "Terminator: " << bold << green << current::strings::Printf("%.3lfGB/s", gb / s) << reset
+                       << ", " << bold << yellow << current::strings::Printf("%.3lfGB", gb) << reset << '/' << bold
+                       << blue << current::strings::Printf("%.2lfs", s) << reset << ", " << cyan
+                       << connection.LocalIPAndPort().ip << ':' << connection.LocalIPAndPort().port << reset
+                       << " <= " << magenta << connection.RemoteIPAndPort().ip << ':'
+                       << connection.RemoteIPAndPort().port << reset;
+            }
+            t_next_output = t_now + t_output_frequency;
+          }
+        } else {
+          std::this_thread::yield();
+          if (t_now >= t_next_output) {
+            const double seconds_of_silence = 1e-6 * (t_now - t_last_successful_receive).count();
+            const double seconds_timeout = std::max(0.0, FLAGS_max_seconds_of_silence - seconds_of_silence);
+            progress << "dropping connection in " << bold << red << current::strings::Printf("%.1lfs", seconds_timeout)
+                     << reset;
+            t_next_output = t_now + t_output_frequency;
+            if (!seconds_timeout) {
+              progress << "dropping connection";
+              break;
+            }
+          }
+        }
+      }
+    } catch (const current::net::SocketBindException&) {
+      progress << "can not bind to " << red << bold << "localhost:" << FLAGS_port << reset
+               << ", check for other apps holding the post";
+    } catch (const current::Exception& e) {
+      progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.
+  }
+}

--- a/examples/streamed_sockets/latencytest/terminator.cc
+++ b/examples/streamed_sockets/latencytest/terminator.cc
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-// NOTE(dkorolev): The copy-past of `../speedtest/receiver.cc`, with port changed, to keep everyhing in a single dir.
+// NOTE(dkorolev): The copy-paste of `../speedtest/receiver.cc`, with port changed, to keep everything in a single dir.
 
 #include <deque>
 

--- a/examples/streamed_sockets/latencytest/workers/indexer.h
+++ b/examples/streamed_sockets/latencytest/workers/indexer.h
@@ -1,0 +1,51 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_INDEXER_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_INDEXER_H
+
+#include "../blob.h"
+
+namespace current::examples::streamed_sockets {
+
+struct IndexingWorker {
+  const uint64_t max_index_block;
+  explicit IndexingWorker(uint64_t max_index_block) : max_index_block(max_index_block) {}
+
+  uint64_t total_index = 0u;
+  const Blob* DoWork(Blob* begin, Blob* end) {
+    if (end > begin + max_index_block) {
+      // NOTE(dkorolev): The only purpose of this `if` is state mutex throttling.
+      end = begin + max_index_block;
+    }
+    while (begin != end) {
+      (*begin++).index = total_index++;
+    }
+    return end;
+  }
+};
+
+}  // namespace current::examples::streamed_sockets
+
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_INDEXER_H

--- a/examples/streamed_sockets/latencytest/workers/processor.h
+++ b/examples/streamed_sockets/latencytest/workers/processor.h
@@ -22,32 +22,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
-#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_PROCESSOR_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_PROCESSOR_H
 
-#include <cstddef>
-#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+
+#include "../blob.h"
+
+#include "../../../../bricks/time/chrono.h"
 
 namespace current::examples::streamed_sockets {
 
-struct Blob {
-  uint64_t index;
-  uint64_t request_origin;
-  uint64_t request_sequence_id;
-  uint64_t extra2;
+struct ProcessingWorker {
+  ProcessingWorker() {}  // uint64_t max_index_block) : max_index_block(max_index_block) {}
+
+  uint64_t next_expected_total_index = static_cast<uint64_t>(-1);
+  const Blob* DoWork(Blob* begin, Blob* end) {
+    while (begin != end) {
+      if (next_expected_total_index == static_cast<uint64_t>(-1)) {
+        next_expected_total_index = begin->index;
+      } else if (begin->index != next_expected_total_index) {
+        std::cerr << "Broken index continuity; exiting.\n";
+        std::exit(-1);
+      }
+      if (begin->request_origin == request_origin_latencytest) {
+        // std::cerr << current::time::Now().count() << '\t' << begin->request_sequence_id << '\n';
+      }
+      ++begin;
+      ++next_expected_total_index;
+    }
+    return end;
+  }
 };
-
-static_assert(sizeof(Blob) == 32);
-static_assert((sizeof(Blob) & (sizeof(Blob) - 1u)) == 0u, "`sizeof(Blob)` should be a power of two for this example.");
-static_assert(offsetof(Blob, index) == 0);
-static_assert(offsetof(Blob, request_origin) == 8);
-
-// clang-format off
-constexpr static uint64_t request_origin_range_lo    = 0x00000000ff;
-constexpr static uint64_t request_origin_range_hi    = 0x00ffffffff;
-constexpr static uint64_t request_origin_latencytest = 0xaaffffffff;
-// clang-format on
 
 }  // namespace current::examples::streamed_sockets
 
-#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_BLOB_H
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_PROCESSOR_H

--- a/examples/streamed_sockets/latencytest/workers/processor.h
+++ b/examples/streamed_sockets/latencytest/workers/processor.h
@@ -60,7 +60,7 @@ struct ProcessingWorker {
           if (!impl) {
             impl = std::make_unique<ProcessingWorkedImpl>(host, port);
           }
-          impl->connection.BlockingWrite(reinterpret_cast<const void*>(begin), sizeof(Blob), true);
+          impl->connection.BlockingWrite(reinterpret_cast<const void*>(begin), sizeof(Blob), false);
           // std::cerr << current::time::Now().count() << '\t' << begin->request_sequence_id << '\n';
         }
         ++begin;

--- a/examples/streamed_sockets/latencytest/workers/receiver.h
+++ b/examples/streamed_sockets/latencytest/workers/receiver.h
@@ -1,0 +1,63 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_RECEIVER_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_RECEIVER_H
+
+#include "../blob.h"
+
+#include "../../../../bricks/net/tcp/tcp.h"
+#include "../../../../bricks/time/chrono.h"
+
+namespace current::examples::streamed_sockets {
+
+struct ReceivingWorker {
+  struct ReceivingWorkerImpl {
+    current::net::Socket socket;
+    current::net::Connection connection;
+    ReceivingWorkerImpl(uint16_t port) : socket(port), connection(socket.Accept()) {}
+  };
+  std::unique_ptr<ReceivingWorkerImpl> impl;
+
+  const uint16_t port;
+  explicit ReceivingWorker(uint16_t port) : port(port) {}
+
+  size_t DoGetInput(uint8_t* begin, uint8_t* end) {
+    try {
+      if (!impl) {
+        impl = std::make_unique<ReceivingWorkerImpl>(port);
+      }
+      return impl->connection.BlockingRead(begin, end - begin);
+    } catch (const current::net::SocketException&) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));  // Don't eat up 100% CPU when unable to connect.
+    } catch (const current::Exception&) {
+    }
+    impl = nullptr;
+    return 0u;
+  }
+};
+
+}  // namespace current::examples::streamed_sockets
+
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_RECEIVER_H

--- a/examples/streamed_sockets/latencytest/workers/saver.h
+++ b/examples/streamed_sockets/latencytest/workers/saver.h
@@ -98,11 +98,13 @@ struct SavingWorker {
     const Blob* end_blob = begin + blobs_left_in_block;
     if (end_blob < end) {
       // Write the currently open file (to close it and repen a new one, on the very next call to `DoWork()`).
-      fwrite(begin, blobs_left_in_block, sizeof(Blob), current_file);
+      // TODO(dkorolev): Uncomment this!
+      // fwrite(begin, blobs_left_in_block, sizeof(Blob), current_file);
       return end_blob;
     } else {
       // The whole [begin, end) range is part of the blob that is currenyly being written.
-      fwrite(begin, end - begin, sizeof(Blob), current_file);
+      // TODO(dkorolev): Uncomment this!
+      // fwrite(begin, end - begin, sizeof(Blob), current_file);
       return end;
     }
     return end;

--- a/examples/streamed_sockets/latencytest/workers/saver.h
+++ b/examples/streamed_sockets/latencytest/workers/saver.h
@@ -98,13 +98,11 @@ struct SavingWorker {
     const Blob* end_blob = begin + blobs_left_in_block;
     if (end_blob < end) {
       // Write the currently open file (to close it and repen a new one, on the very next call to `DoWork()`).
-      // TODO(dkorolev): Uncomment this!
-      // fwrite(begin, blobs_left_in_block, sizeof(Blob), current_file);
+      fwrite(begin, blobs_left_in_block, sizeof(Blob), current_file);
       return end_blob;
     } else {
       // The whole [begin, end) range is part of the blob that is currenyly being written.
-      // TODO(dkorolev): Uncomment this!
-      // fwrite(begin, end - begin, sizeof(Blob), current_file);
+      fwrite(begin, end - begin, sizeof(Blob), current_file);
       return end;
     }
     return end;

--- a/examples/streamed_sockets/latencytest/workers/saver.h
+++ b/examples/streamed_sockets/latencytest/workers/saver.h
@@ -1,0 +1,114 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// NOTE(dkorolev): This implementation is quick and dirty, no error checking whatsoever, just to measure the throughput.
+
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_SAVER_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_SAVER_H
+
+#include <cstdio>
+#include <queue>
+
+#include "../blob.h"
+
+#include "../../../../bricks/file/file.h"
+#include "../../../../bricks/net/tcp/tcp.h"
+#include "../../../../bricks/strings/printf.h"
+#include "../../../../bricks/time/chrono.h"
+
+namespace current::examples::streamed_sockets {
+
+struct SavingWorker {
+  const std::string dirname;
+  const std::string filebase;
+  const size_t blobs_per_file;
+  const size_t max_total_files;
+  uint64_t next_anticipated_index = 0u;
+  std::queue<uint64_t> written_files_indexes;  // Unique `uint64_t`, `file_index` == `begin->index / blobs_per_file`.
+  FILE* current_file = nullptr;                // The handle of the file for block `written_file_indexes.back()`.
+  SavingWorker(std::string input_dirname,
+               std::string input_filebase,
+               size_t blobs_per_file,
+               size_t max_total_files,
+               bool wipe_files_at_startup)
+      : dirname(std::move(input_dirname)),
+        filebase(std::move(input_filebase)),
+        blobs_per_file(blobs_per_file),
+        max_total_files(max_total_files) {
+    if (wipe_files_at_startup && !dirname.empty() && !filebase.empty()) {
+      std::vector<std::string> files_to_remove;
+      FileSystem::ScanDir(dirname, [this, &files_to_remove](const FileSystem::ScanDirItemInfo& info) {
+        const std::string& fn = info.basename;
+        if (fn.length() >= filebase.length() && fn.substr(0u, filebase.length()) == filebase) {
+          files_to_remove.push_back(fn);
+        }
+      });
+      for (const std::string& filename_to_remove : files_to_remove) {
+        FileSystem::RmFile(FileSystem::JoinPath(dirname, filename_to_remove));
+      }
+    }
+  }
+
+  std::string FullFilenameForBlobIndex(uint64_t blob_index) const {
+    return FileSystem::JoinPath(
+        dirname,
+        filebase + strings::Printf("0x%016llx-0x%016llx.bin",
+                                   static_cast<long long>(blob_index * blobs_per_file),
+                                   static_cast<long long>((blob_index + 1u) * blobs_per_file) - 1u));
+  }
+
+  const Blob* DoWork(const Blob* begin, const Blob* end) {
+    const uint64_t begin_blob_index = begin->index / blobs_per_file;
+    if (written_files_indexes.empty() || !(written_files_indexes.back() == begin_blob_index)) {
+      if (current_file) {
+        fclose(current_file);
+      }
+      current_file = nullptr;
+      written_files_indexes.push(begin_blob_index);
+      if (max_total_files) {
+        while (written_files_indexes.size() > max_total_files) {
+          FileSystem::RmFile(FullFilenameForBlobIndex(written_files_indexes.front()));
+          written_files_indexes.pop();
+        }
+      }
+      current_file = fopen(FullFilenameForBlobIndex(begin_blob_index).c_str(), "wb");
+    }
+    const uint64_t blobs_left_in_block = blobs_per_file - (begin->index - begin_blob_index * blobs_per_file);
+    const Blob* end_blob = begin + blobs_left_in_block;
+    if (end_blob < end) {
+      // Write the currently open file (to close it and repen a new one, on the very next call to `DoWork()`).
+      fwrite(begin, blobs_left_in_block, sizeof(Blob), current_file);
+      return end_blob;
+    } else {
+      // The whole [begin, end) range is part of the blob that is currenyly being written.
+      fwrite(begin, end - begin, sizeof(Blob), current_file);
+      return end;
+    }
+    return end;
+  }
+};
+
+}  // namespace current::examples::streamed_sockets
+
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_SAVER_H

--- a/examples/streamed_sockets/latencytest/workers/sender.h
+++ b/examples/streamed_sockets/latencytest/workers/sender.h
@@ -32,6 +32,7 @@ SOFTWARE.
 
 namespace current::examples::streamed_sockets {
 
+template <typename = void>
 struct SendingWorker {
   struct SendingWorkedImpl {
     current::net::Connection connection;

--- a/examples/streamed_sockets/latencytest/workers/sender.h
+++ b/examples/streamed_sockets/latencytest/workers/sender.h
@@ -50,7 +50,7 @@ struct SendingWorker {
         if (!impl) {
           impl = std::make_unique<SendingWorkedImpl>(host, port);
         }
-        impl->connection.BlockingWrite(reinterpret_cast<const void*>(begin), (end - begin) * sizeof(Blob), true);
+        impl->connection.BlockingWrite(reinterpret_cast<const void*>(begin), (end - begin) * sizeof(Blob), false);
         return end;
       } catch (const current::net::SocketException&) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));  // Don't eat up 100% CPU when unable to connect.

--- a/examples/streamed_sockets/latencytest/workers/sender.h
+++ b/examples/streamed_sockets/latencytest/workers/sender.h
@@ -1,0 +1,66 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_SENDER_H
+#define EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_SENDER_H
+
+#include "../blob.h"
+
+#include "../../../../bricks/net/tcp/tcp.h"
+#include "../../../../bricks/time/chrono.h"
+
+namespace current::examples::streamed_sockets {
+
+struct SendingWorker {
+  struct SendingWorkedImpl {
+    current::net::Connection connection;
+    SendingWorkedImpl(const std::string& host, uint16_t port) : connection(current::net::ClientSocket(host, port)) {}
+  };
+  std::unique_ptr<SendingWorkedImpl> impl;
+
+  const std::string host;
+  const uint16_t port;
+  SendingWorker(std::string host, uint16_t port) : host(std::move(host)), port(port) {}
+
+  const Blob* DoWork(Blob* const begin, Blob* const end) {
+    while (true) {
+      try {
+        if (!impl) {
+          impl = std::make_unique<SendingWorkedImpl>(host, port);
+        }
+        impl->connection.BlockingWrite(reinterpret_cast<const void*>(begin), (end - begin) * sizeof(Blob), true);
+        return end;
+      } catch (const current::net::SocketException&) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));  // Don't eat up 100% CPU when unable to connect.
+      } catch (const current::Exception&) {
+      }
+      impl = nullptr;
+      return begin;
+    }
+  }
+};
+
+}  // namespace current::examples::streamed_sockets
+
+#endif  // EXAMPLES_STREAMED_SOCKETS_LATENCYTEST_WORKERS_SENDER_H

--- a/examples/streamed_sockets/speedtest/forward.cc
+++ b/examples/streamed_sockets/speedtest/forward.cc
@@ -1,0 +1,61 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// Simple TCP traffic forwarder.
+//
+// Example usage A, one hop:
+// 1) Start ./.current/receiver  # Listens on 9001.
+// 2) Start ./.current/forward   # Forwards 9002 to 9001.
+// 3) Start ./.current/sender --port 9002
+//
+// Example usage B, two hops:
+// 1) Start ./.current/receiver  # Listens on 9001.
+// 2) Start ./.current/forward   # Forwards 9002 to 9001.
+// 3) Start ./.current/forward --listen_port 9003 --sendto_port 9002
+// 4) Start ./.current/sender --port 9003
+//
+// Multiple hops can be simulated.
+
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+
+DEFINE_uint16(listen_port, 9002, "The port to listen on.");
+DEFINE_string(sendto_host, "localhost", "The host to forward to.");
+DEFINE_uint16(sendto_port, 9001, "The port to forward to.");
+DEFINE_uint64(n, 1 << 20, "Buffer size, in bytes.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
+
+  current::net::Socket socket(FLAGS_listen_port);
+  current::net::Connection recvfrom(socket.Accept());
+
+  std::vector<uint8_t> buffer(FLAGS_n);
+  while (true) {
+    const size_t size = recvfrom.BlockingRead(&buffer[0], buffer.size());
+    sendto.BlockingWrite(&buffer[0], size, true);
+  }
+}

--- a/examples/streamed_sockets/speedtest/forward.cc
+++ b/examples/streamed_sockets/speedtest/forward.cc
@@ -48,10 +48,10 @@ DEFINE_uint64(n, 1 << 20, "Buffer size, in bytes.");
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
 
-  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
-
   current::net::Socket socket(FLAGS_listen_port);
   current::net::Connection recvfrom(socket.Accept());
+
+  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
 
   std::vector<uint8_t> buffer(FLAGS_n);
   while (true) {

--- a/examples/streamed_sockets/speedtest/latency_trivial.cc
+++ b/examples/streamed_sockets/speedtest/latency_trivial.cc
@@ -1,0 +1,102 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2019 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+// The simplest possible high-throughput TCP latency measuring tool.
+// Does not even check what is being returned, just assumes what is read is correct.
+//
+// The default flags assumes `./.current/forward` is run, and localhost:9001 is forwared back to localhost:9002.
+//
+// To run, first start this tool, and then `./.current/forward`. They would both terminate afterwards.
+
+#include <cstdlib>
+#include <thread>
+
+#include "../../../bricks/dflags/dflags.h"
+#include "../../../bricks/net/tcp/tcp.h"
+#include "../../../bricks/time/chrono.h"
+
+DEFINE_string(sendto_host, "localhost", "The host to send data to.");
+DEFINE_uint16(sendto_port, 9002, "The port to send data to.");
+DEFINE_uint16(listen_port, 9001, "The port to listen on.");
+
+DEFINE_uint64(n, 1 << 25, "The number of bytes in each block to send.");
+DEFINE_uint32(k, 20, "The number of blocks to send.");
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
+
+  current::net::Connection sendto(current::net::ClientSocket(FLAGS_sendto_host, FLAGS_sendto_port));
+
+  current::net::Socket socket(FLAGS_listen_port);
+  current::net::Connection recvfrom(socket.Accept());
+
+  std::vector<std::chrono::microseconds> send_begin(FLAGS_k);
+  std::vector<std::chrono::microseconds> send_end(FLAGS_k);
+  std::atomic_size_t sent_done(0u);
+
+  std::vector<std::chrono::microseconds> recv_begin(FLAGS_k);
+  std::vector<std::chrono::microseconds> recv_end(FLAGS_k);
+  std::atomic_size_t recv_done(0u);
+
+  std::thread thread_send([&sendto, &sent_done, &send_begin, &send_end]() {
+    std::vector<uint8_t> buffer(FLAGS_n);
+    for (uint8_t& b : buffer) {
+      b = rand();
+    }
+    for (size_t k = 0u; k < FLAGS_k; ++k) {
+      send_begin[k] = current::time::Now();
+      sendto.BlockingWrite(&buffer[0], buffer.size(), true);
+      send_end[k] = current::time::Now();
+      sent_done = k + 1u;
+    }
+  });
+
+  std::thread thread_recv([&recvfrom, &recv_done, &recv_begin, &recv_end]() {
+    std::vector<uint8_t> buffer(FLAGS_n);
+    for (size_t k = 0u; k < FLAGS_k; ++k) {
+      recv_begin[k] = current::time::Now();
+      recvfrom.BlockingRead(&buffer[0], buffer.size(), current::net::Connection::BlockingReadPolicy::FillFullBuffer);
+      recv_end[k] = current::time::Now();
+      recv_done = k + 1u;
+    }
+  });
+
+  std::thread thread_dump([&]() {
+    const double coef = 1e-3 * FLAGS_n;  // (GB/s) == 1e-3 * (B/us).
+    for (size_t k = 1u; k < FLAGS_k; ++k) {
+      while (!(k < sent_done && k < recv_done)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      printf("Block %5d sent at %.3lfGB/s, received at %.3lf GB/s, average latency %.2lfms\n",
+             static_cast<int>(k),
+             coef / ((send_end[k] - send_begin[k]).count() + 1),
+             coef / ((recv_end[k] - recv_begin[k]).count() + 1),
+             1e-3 * ((recv_begin[k] + recv_end[k]).count() - (send_begin[k] + send_end[k]).count()) / 2);
+    }
+  });
+
+  thread_send.join();
+  thread_recv.join();
+  thread_dump.join();
+}

--- a/examples/streamed_sockets/speedtest/latency_trivial.cc
+++ b/examples/streamed_sockets/speedtest/latency_trivial.cc
@@ -27,7 +27,7 @@ SOFTWARE.
 //
 // The default flags assumes `./.current/forward` is run, and localhost:9001 is forwared back to localhost:9002.
 //
-// To run, first start this tool, and then `./.current/forward`. They would both terminate afterwards.
+// To run, first start `./.current/forward`, and then this tool. They would both terminate automatically.
 
 #include <cstdlib>
 #include <thread>

--- a/examples/streamed_sockets/speedtest/latency_trivial.cc
+++ b/examples/streamed_sockets/speedtest/latency_trivial.cc
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
     }
     for (size_t k = 0u; k < FLAGS_k; ++k) {
       send_begin[k] = current::time::Now();
-      sendto.BlockingWrite(&buffer[0], buffer.size(), true);
+      sendto.BlockingWrite(&buffer[0], buffer.size(), false);  // `false` is no `MSG_MORE`.
       send_end[k] = current::time::Now();
       sent_done = k + 1u;
     }

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+./.current/forward &
+./.current/latency_trivial &
+
+wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.3hops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.3hops
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+./.current/forward --listen_port 9003 &
+./.current/forward --sendto_port 9003 &
+./.current/latency_trivial &
+
+wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+./.current/forward --listen_port 9004 &
+./.current/forward --listen_port 9003 --sendto_port 9004 &
+./.current/forward --sendto_port 9003 &
+./.current/latency_trivial &
+
+wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.4hops
@@ -4,9 +4,9 @@ trap "kill 0" EXIT
 
 NDEBUG=1 make -j .current/forward .current/latency_trivial
 
-./.current/forward --listen_port 9004 &
 ./.current/forward --listen_port 9003 --sendto_port 9004 &
-./.current/forward --sendto_port 9003 &
-./.current/latency_trivial &
+./.current/forward --listen_port 9002 --sendto_port 9003 &
+./.current/forward --listen_port 9001 --sendto_port 9002 &
+./.current/latency_trivial --sendto_port 9001 --listen_port 9004 &
 
 wait

--- a/examples/streamed_sockets/speedtest/latency_trivial.sh.nhops
+++ b/examples/streamed_sockets/speedtest/latency_trivial.sh.nhops
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+N=${1:-4}
+
+trap "kill 0" EXIT
+
+NDEBUG=1 make -j .current/forward .current/latency_trivial
+
+echo "Running for $N hops."
+
+for i in $(seq 2 $N); do
+  ./.current/forward --listen_port $((9001 + N - i)) --sendto_port $((9002 + N - i)) &
+done
+./.current/latency_trivial --sendto_port 9001 --listen_port $((9000 + N)) &
+
+wait

--- a/examples/streamed_sockets/speedtest/receiver.cc
+++ b/examples/streamed_sockets/speedtest/receiver.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
       }
     } catch (const current::net::SocketBindException&) {
       progress << "can not bind to " << red << bold << "localhost:" << FLAGS_port << reset
-               << ", check for other apps holding the post";
+               << ", check for other apps holding the port";
     } catch (const current::Exception& e) {
       progress << red << bold << "error" << reset << ": " << e.OriginalDescription() << reset;
     }


### PR DESCRIPTION
*[ NOTE: This PR contains [Trivial latency measurements, #870](https://github.com/C5T/Current/pull/870/files). ]*

Hi Max,

First of all, let me apologize up front: this code is not very clean by my standards. It has obvious flaws; in the past few dozen hours I even sacrificed restartability, so the modules should be spawned from scratch, in the right order, in order for the test to work (otherwise data packets broken and re-sent from the middle of the 32-byte block would ruin everything).

Anyway, to give you a better idea, here is the Kafka-esque picture of what I ultimately want to arrive at ([pr-871-plan.dot](https://gist.github.com/dkorolev/f4119168af05f72d2516ba825bcb8e84)), with business logic processing shards, and frontend load balancing nodes, monitoring, and high availability servicing logic omitted for clarity:

![image](https://user-images.githubusercontent.com/2159447/65604487-6d955800-df5c-11e9-860e-319f5fc48281.png)

And here is what is actually implemented in this PR ([pr-871.dot](https://gist.github.com/dkorolev/78cb594f355fef546501b5dd889321a4)):

![image](https://user-images.githubusercontent.com/2159447/65604802-e694af80-df5c-11e9-887e-ee2084557258.png)

---

The above is what I just tested on five EC2 `m4.16xlarge` x64 machines (`ami-04b762b4289fba92b (64-bit x86) / ami-03920bf5f903e90d4 (64-bit Arm)`). The five machines are, in the reverse order of what's started by `examples/streamed_sockets/latencytest/run_all_locally.sh`:

1. Generator.
1. Indexer.
1. Forwarder.
1. Processor.
1. Terminator.

The `generator` binary sends out some "fake" data, to simulate real traffic. It also injects the "real" requests, which are not really "handled" by the processor, but their latency is what's measured. This is the dotted line back.

The `indexer` binary does several things:
* It adds sequence indexes to the data. Specifically, each 32 bytes are the "blob" (`struct Blob`), and the first 8 bytes of each blob are its index.
* It sends the indexed stream of data to two destinations.
* And it keeps its own local copy (in binary files).

Basically, the indexer is the highest per-machine load I am imagining for now, business logic excluded. It has three network flows (two outbound, one inbound), and it also writes everything it receives to disk.

Obviously, in the indexing phase, the "receive from network" and "add sequence IDs" functions are synchronous, while the three immutable "outputs" -- to both network destinations and to disk -- are run in parallel.

The `forward` binary is simply sending the traffic forward and also keeps its local copy. I introduced it only to make sure the latency doesn't suffer much when another "save and send over" node is present. After all, the purpose of this experiment largely is to measure the end-to-end latency, and it is important to know we can both fan out the data streams (in the 1-to-2 manner) and save them to disk.

The `processor` binary ignores everything but the "real" requests, which it sends back to the `generator`, via the dotted line. This is the latency of which is measured, end to end, by the generator.

Finally, the `terminator` binary is, actually, a copy-paste of the `receiver` from the `../speedtest` directory. I only copied it into here to keep the test self-contained in one directory. All it does, except just receiving the second half of the splitted-in-two data flow from the indexer is measuring the GB/s of the traffic, and printing it to the standard output.

---

The TL;DR of the result of my test is:
* Given we have "bad apple" EC2 machines (of only 5 gigabits per second network), **the above setup reaches this maximum throughput**, with all network hops, all disk writes, and the "business" logic of replying to the "real" requests.
* The "production" setup of the above is performing at **54ms avg and mean** latency, and **44ms/47ms/61ms/64ms p1/p10/p90/p99** latencies respectively.

I measured the cross-instance latency (using the code from [#870](https://github.com/C5T/Current/pull/870/files)) as well, and it's about 4ms on EC2. Whether we could do better there is an open question, which I'd rather not invest extra time into.

The resulting binary files (saved by the `indexer` and the `forwarder` independently) match `MD5`-wise.

Two closing remarks:

1. Disabling the Nagle algorithm has no effect at all, on both throughput and latency.
2. Disabling writing to disk has no effect as well. It just works at the rate above 0.6GB/s, and multithreading does its job.
3. There is a lot that can be done to improve the code. And I plan to put a stop to this for now. Got some real work to do.

---

Obviously, this is a very crude test. But it does show that it is indeed possible to show decent throughput and decent latency without employing zero-copy sockets or lock-free queues.

I wish we had access to (five) machines of 1GB/s++ network per connection (which Amazon advertises, but doesn't deliver as per my experiments so far). And I see no reason why would this code not utilize the whole 1GB/s++ throughput, while indexing every single 32-byte blob, keeping offline copies of it on several machines, and performing (asynchronous!) business logic on this data stream.

Thanks,
Dima