### PR TITLE
Final tweaks and EC2 test.

### DIFF
--- a/examples/streamed_sockets/latencytest/forward.cc
+++ b/examples/streamed_sockets/latencytest/forward.cc
@@ -36,7 +36,7 @@ SOFTWARE.
 DEFINE_uint16(listen_port, 8002, "The local port to listen on.");
 DEFINE_string(host, "127.0.0.1", "The destination address to send data to.");
 DEFINE_uint16(port, 8004, "The destination port to send data to.");
-DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
+DEFINE_double(buffer_mb, 512.0, "The size of the circular buffer to use, in megabytes.");
 DEFINE_string(dirname, ".current", "The dir name for the stored data files.");
 DEFINE_string(filebase, "fwd.", "The filename prefix for the stored data files.");
 DEFINE_uint64(blobs_per_file,

--- a/examples/streamed_sockets/latencytest/generator.cc
+++ b/examples/streamed_sockets/latencytest/generator.cc
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
                             static_cast<size_t>((1e6 * FLAGS_send_buffer_mb + sizeof(Blob) - 1) / sizeof(Blob)));
 
   std::cout << "Format: " << (FLAGS_evensodds ? "{ all, evens, odds } * " : "")
-            << "\"$(average) + $(p01) / $(p10) / $(median) / $(p90) / $(p99) + N=$(sample size)\"." << std::endl;
+            << "\"$(average) + $(p01) / $(p10) / $(median) / $(p90) / $(p99) + N=$(sample size)\"" << std::endl;
 
   current::ProgressLine progress;
 
@@ -193,36 +193,29 @@ int main(int argc, char** argv) {
 
   // The code that originates the requests.
   uint64_t request_sequence_id = 0;
+  current::net::Connection connection(current::net::ClientSocket(FLAGS_host, FLAGS_port));
   while (true) {
-    try {
-      current::net::Connection connection(current::net::ClientSocket(FLAGS_host, FLAGS_port));
-      while (true) {
-        const uint64_t begin_index = current::random::RandomUInt64(0, N / 4);
-        const uint64_t end_index = N - current::random::RandomUInt64(0, N / 4);
-        const uint64_t a = begin_index;
-        const uint64_t b = end_index - 1u;
-        const uint64_t request_origin_a_save = data[a].request_origin;
-        const uint64_t request_origin_b_save = data[b].request_origin;
-        data[a].request_origin = current::examples::streamed_sockets::request_origin_latencytest;
-        data[b].request_origin = current::examples::streamed_sockets::request_origin_latencytest;
-        data[a].request_sequence_id = request_sequence_id;
-        data[b].request_sequence_id = request_sequence_id + 1;
-        const int64_t t_write = current::time::Now().count();
-        connection.BlockingWrite(
-            reinterpret_cast<const void*>(&data[begin_index]), (end_index - begin_index) * sizeof(Blob), false);
-        data[a].request_origin = request_origin_a_save;
-        data[b].request_origin = request_origin_b_save;
-        timestamps.MutableUse([t_write, request_sequence_id, &progress](deques_t& dqs) {
-          dqs.first.emplace_back(request_sequence_id, t_write);
-          dqs.first.emplace_back(request_sequence_id + 1, t_write);
-          RelaxQueues(dqs, progress);
-        });
-        request_sequence_id += 2;
-      }
-    } catch (const current::net::SocketConnectException&) {
-    } catch (const current::Exception&) {
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));  // Don't eat up 100% CPU when unable to connect.
+    const uint64_t begin_index = current::random::RandomUInt64(0, N / 4);
+    const uint64_t end_index = N - current::random::RandomUInt64(0, N / 4);
+    const uint64_t a = begin_index;
+    const uint64_t b = end_index - 1u;
+    const uint64_t request_origin_a_save = data[a].request_origin;
+    const uint64_t request_origin_b_save = data[b].request_origin;
+    data[a].request_origin = current::examples::streamed_sockets::request_origin_latencytest;
+    data[b].request_origin = current::examples::streamed_sockets::request_origin_latencytest;
+    data[a].request_sequence_id = request_sequence_id;
+    data[b].request_sequence_id = request_sequence_id + 1;
+    const int64_t t_write = current::time::Now().count();
+    connection.BlockingWrite(
+        reinterpret_cast<const void*>(&data[begin_index]), (end_index - begin_index) * sizeof(Blob), false);
+    data[a].request_origin = request_origin_a_save;
+    data[b].request_origin = request_origin_b_save;
+    timestamps.MutableUse([t_write, request_sequence_id, &progress](deques_t& dqs) {
+      dqs.first.emplace_back(request_sequence_id, t_write);
+      dqs.first.emplace_back(request_sequence_id + 1, t_write);
+      RelaxQueues(dqs, progress);
+    });
+    request_sequence_id += 2;
   }
 
   t_listener.join();

--- a/examples/streamed_sockets/latencytest/indexer.cc
+++ b/examples/streamed_sockets/latencytest/indexer.cc
@@ -39,8 +39,7 @@ DEFINE_string(host1, "127.0.0.1", "The destination address to send data to.");
 DEFINE_uint16(port1, 8002, "The destination port to send data to.");
 DEFINE_string(host2, "127.0.0.1", "The destination address to send data to.");
 DEFINE_uint16(port2, 8003, "The destination port to send data to.");
-DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
-DEFINE_uint64(max_index_block, 512, "Index max. this many entries per state mutex lock, throttling.");
+DEFINE_double(buffer_mb, 512.0, "The size of the circular buffer to use, in megabytes.");
 DEFINE_string(dirname, ".current", "The dir name for the stored data files.");
 DEFINE_string(filebase, "idx.", "The filename prefix for the stored data files.");
 DEFINE_uint64(blobs_per_file,
@@ -128,7 +127,7 @@ inline void RunIndexer() {
   current::WaitableAtomic<State> mutable_state;
 
   std::thread t_source = SpawnThreadSource<ReceivingWorker>(buffer, mutable_state, FLAGS_listen_port);
-  std::thread t_indexing = SpawnThreadWorker<IndexingWorker>(buffer, mutable_state, FLAGS_max_index_block);
+  std::thread t_indexing = SpawnThreadWorker<IndexingWorker>(buffer, mutable_state);
   std::thread t_save = SpawnThreadWorker<SavingWorker>(buffer,
                                                        mutable_state,
                                                        FLAGS_dirname,

--- a/examples/streamed_sockets/latencytest/next_ripcurrent.h
+++ b/examples/streamed_sockets/latencytest/next_ripcurrent.h
@@ -60,7 +60,7 @@ std::thread SpawnThreadSource(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STA
       std::exit(-1);
     }
 
-    const size_t total_buffer_size_in_bytes = buffer.size() * sizeof(T_BLOB);
+    const size_t total_buffer_size_in_bytes = total_buffer_size * sizeof(T_BLOB);
     const size_t total_buffer_size_in_bytes_minus_one = total_buffer_size_in_bytes - 1u;
     if ((total_buffer_size_in_bytes & total_buffer_size_in_bytes_minus_one) != 0u) {
       std::cerr << "Internal error, must be a power of two." << std::endl;
@@ -100,8 +100,6 @@ std::thread SpawnThreadSource(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STA
         });
       }
 
-      const size_t bgn = (updating_total_bytes_read & total_buffer_size_in_bytes_minus_one);
-      const size_t end = (trailing_total_bytes_aval & total_buffer_size_in_bytes_minus_one);
       const auto DoWorkOverCircularBufferInBytes = [&](size_t bgn, size_t end) {
         const size_t bytes_read = worker->DoGetInput(buffer_in_bytes + bgn, buffer_in_bytes + end);
         if (bytes_read) {
@@ -115,6 +113,9 @@ std::thread SpawnThreadSource(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STA
           }
         }
       };
+
+      const size_t bgn = (updating_total_bytes_read & total_buffer_size_in_bytes_minus_one);
+      const size_t end = (trailing_total_bytes_aval & total_buffer_size_in_bytes_minus_one);
       if (bgn < end) {
         DoWorkOverCircularBufferInBytes(bgn, end);
       } else {
@@ -173,7 +174,7 @@ std::thread SpawnThreadWorker(std::vector<T_BLOB>& buffer, T_WAITABLE_ATOMIC_STA
       if (bgn < end) {
         DoWorkOverCircularBuffer(bgn, end);
       } else {
-        DoWorkOverCircularBuffer(bgn, buffer.size());
+        DoWorkOverCircularBuffer(bgn, total_buffer_size);
       }
     }
   });

--- a/examples/streamed_sockets/latencytest/processor.cc
+++ b/examples/streamed_sockets/latencytest/processor.cc
@@ -33,7 +33,7 @@ SOFTWARE.
 DEFINE_uint16(listen_port, 8004, "The local port to listen on.");
 DEFINE_string(host, "127.0.0.1", "The destination address to send the confirmations to.");
 DEFINE_uint16(port, 8005, "The destination port to send the confirmations to.");
-DEFINE_double(buffer_mb, 32.0, "The size of the circular buffer to use, in megabytes.");
+DEFINE_double(buffer_mb, 512.0, "The size of the circular buffer to use, in megabytes.");
 
 namespace current::examples::streamed_sockets {
 

--- a/examples/streamed_sockets/latencytest/run_all_locally.sh
+++ b/examples/streamed_sockets/latencytest/run_all_locally.sh
@@ -2,12 +2,17 @@
 
 trap "kill 0" EXIT
 
-NDEBUG=1 make -j .current/generator .current/indexer .current/forward .current/processor .current/terminator
+NDEBUG=1 make -j .current/generator .current/indexer .current/forward .current/processor .current/terminator || exit 1
 
+# A flag to set locally is `--skip_fwrite`.
 ./.current/terminator --silent &
 ./.current/processor &
 ./.current/forward $* &
 ./.current/indexer $* &
-./.current/generator &
+
+sleep 0.5
+GENERATOR_FLAGS=""
+GENERATOR_FLAGS="$GENERATOR_FLAGS --evensodds"  # Full output, to compare latencies on 1st and last blobs per block sent.
+./.current/generator $GENERATOR_FLAGS &
 
 wait

--- a/examples/streamed_sockets/latencytest/workers/indexer.h
+++ b/examples/streamed_sockets/latencytest/workers/indexer.h
@@ -29,15 +29,14 @@ SOFTWARE.
 
 namespace current::examples::streamed_sockets {
 
-struct IndexingWorker {
-  const uint64_t max_index_block;
-  explicit IndexingWorker(uint64_t max_index_block) : max_index_block(max_index_block) {}
-
+struct IndexingWorker final {
   uint64_t total_index = 0u;
   const Blob* DoWork(Blob* begin, Blob* end) {
-    if (end > begin + max_index_block) {
-      // NOTE(dkorolev): The only purpose of this `if` is state mutex throttling.
-      end = begin + max_index_block;
+    // NOTE(dkorolev): Index in blocks of the size up to 32KB.
+    constexpr static size_t block_size_in_blobs = (1 << 15) / sizeof(Blob);
+    static_assert(block_size_in_blobs > 0);
+    if (end > begin + block_size_in_blobs) {
+      end = begin + block_size_in_blobs;
     }
     while (begin != end) {
       (*begin++).index = total_index++;

--- a/examples/streamed_sockets/latencytest/workers/saver.h
+++ b/examples/streamed_sockets/latencytest/workers/saver.h
@@ -39,7 +39,7 @@ SOFTWARE.
 
 namespace current::examples::streamed_sockets {
 
-struct SavingWorker {
+struct SavingWorker final {
   const std::string dirname;
   const std::string filebase;
   const size_t blobs_per_file;
@@ -82,6 +82,12 @@ struct SavingWorker {
   }
 
   const Blob* DoWork(const Blob* begin, const Blob* end) {
+    // NOTE(dkorolev): Save in blocks of the size up to 512KB.
+    constexpr static size_t block_size_in_blobs = (1 << 19) / sizeof(Blob);
+    static_assert(block_size_in_blobs > 0);
+    if (end > begin + block_size_in_blobs) {
+      end = begin + block_size_in_blobs;
+    }
     const uint64_t begin_blob_index = begin->index / blobs_per_file;
     if (written_files_indexes.empty() || !(written_files_indexes.back() == begin_blob_index)) {
       if (current_file) {


### PR DESCRIPTION
Hi @mzhurovich,

I've run some final tests (or, more like, reconciled the ones I ran earlier this week).

**Network**: The load is stable, and all as we would expect: for 0.624GB/s at the `terminator` stage, which is ~4.7GBit/s according to `ntop`, we get every single network link performing continuously at this pace, including 2x outbound traffic on the indexer (as it sends data to two places).

**CPU**:
* Generator: 9% (this is the data-sending thread, the latency-receiving one is <1%).
* Indexer: ~250% total (five active threads, ~70%, ~55%, ~50%, ~40%, and ~%35%).
* Forwarder: ~174% total (three active threads, ~70%, ~60%, and ~50%).
* Processor: ~87% total (two active threads, ~65%, and ~%25%).
* Terminator: 57% (single-threaded).

**Latency**:

Here are the overall numbers, three measurements:
```
10.6ms +  6.4ms /  6.9ms / 10.6ms / 14.5ms / 15.7ms
13.8ms +  9.4ms /  9.9ms / 13.8ms / 17.9ms / 19.8ms
14.4ms + 10.1ms / 10.6ms / 14.2ms / 18.4ms / 20.0ms
```
These are `average + p01 / p10 / median / p90 / p99`.

Also, the code measures the latency of the "first blob in block" and the "last blob in block" respectively, which are the best and the worst latency. They should, in theory, differ by, at least, the time it takes to send the block of approximately 3.75MB over the network. Which is exactly what we are observing, here are the numbers, again, on three measurements:

The first blob in each block sent:
```
 7.6ms +  6.3ms /  6.7ms /  7.6ms /  8.6ms /  9.0ms
10.9ms +  9.3ms /  9.6ms / 10.8ms / 12.4ms / 13.8ms
11.5ms + 10.1ms / 10.3ms / 11.4ms / 12.7ms / 13.8ms
```

The last blob in each block sent:
```
13.5ms + 11.2ms / 12.1ms / 13.5ms / 15.0ms / 15.9ms
16.8ms + 14.0ms / 15.1ms / 16.7ms / 18.6ms / 20.2ms
17.4ms + 14.6ms / 15.8ms / 17.4ms / 19.0ms / 20.4ms
```

**Charts**:

Network, with `nload`, `generator`:
![image](https://user-images.githubusercontent.com/2159447/65828880-9b2c1b00-e254-11e9-9b80-b741deb78f19.png)

Network, with `nload`, `indexer`:
![image](https://user-images.githubusercontent.com/2159447/65828882-a3845600-e254-11e9-884d-81eba1be9a8d.png)

Network, with `nload`, `forwarder`:
![image](https://user-images.githubusercontent.com/2159447/65828888-ac752780-e254-11e9-8ab2-7bc2b401e24b.png)

Network, with `nload`, `processor`:
![image](https://user-images.githubusercontent.com/2159447/65828892-ba2aad00-e254-11e9-9610-ebfd55720c50.png)

Network, with `nload`, `terminator`:
![image](https://user-images.githubusercontent.com/2159447/65828896-bf87f780-e254-11e9-84f0-f980c83a3580.png)

CPU, with `htop`, `generator`:
![image](https://user-images.githubusercontent.com/2159447/65828899-cadb2300-e254-11e9-864c-dc9b058f07aa.png)

CPU, with `htop`, `indexer`:
![image](https://user-images.githubusercontent.com/2159447/65828902-d0386d80-e254-11e9-9077-fed025ea84cd.png)

CPU, with `htop`, `forwarder`:
![image](https://user-images.githubusercontent.com/2159447/65828906-d75f7b80-e254-11e9-9522-d989770d1db6.png)


CPU, with `htop`, `processor`:
![image](https://user-images.githubusercontent.com/2159447/65828911-dcbcc600-e254-11e9-94cb-3e89ac977f11.png)

CPU, with `htop`, `terminator`:
![image](https://user-images.githubusercontent.com/2159447/65828912-e1817a00-e254-11e9-8245-f04d43cbc0ab.png)

NOTE 1: GB/s vs. GBit/s discrepancy can be explained by the coefficient of `(1.024)^3`.
NOTE 2: By "active threads" I mean the ones consuming real CPU. Sometimes there's one extra thread, which, I assume, is the one waiting on `.join()`-s at the end of `main()`.

Thanks,
Dima

---

For the test setup, it's same five EC2 instances, configured with:

```
wget https://raw.githubusercontent.com/dkorolev/dotfiles/master/.screenrc
sudo yum install -y git make clang
sudo amazon-linux-extras install epel
sudo yum install -y nload htop
git clone -b speedtest_extension https://github.com/dkorolev/current
cd current/examples/streamed_sockets/latencytest
NDEBUG=1 make -j
```

On the first one I run `./.current/generator --host $INDEXER_INTERNAL_IP --evensodds`, to see more fine-grained latency numbers.