### PR TITLE
`TypeListSize<TypeListImpl<...>>` no longer requires `::value`.

### DIFF
--- a/bricks/README.md
+++ b/bricks/README.md
@@ -113,13 +113,13 @@ struct B { enum { x = 2 }; };
 struct C { enum { x = 3 }; };
 
 typedef TypeList<A, B, C> TYPELIST_BEFORE;
-static_assert(TypeListSize<TYPELIST_BEFORE>::value == 3, "");
+static_assert(TypeListSize<TYPELIST_BEFORE> == 3, "");
 static_assert(TypeListElement<0, TYPELIST_BEFORE>::x == 1, "");
 static_assert(TypeListElement<1, TYPELIST_BEFORE>::x == 2, "");
 static_assert(TypeListElement<2, TYPELIST_BEFORE>::x == 3, "");
 
 typedef current::metaprogramming::map<add_100, TYPELIST_BEFORE> TYPELIST_AFTER;
-static_assert(TypeListSize<TYPELIST_AFTER>::value == 3, "");
+static_assert(TypeListSize<TYPELIST_AFTER> == 3, "");
 static_assert(TypeListElement<0, TYPELIST_AFTER>::x == 101, "");
 static_assert(TypeListElement<1, TYPELIST_AFTER>::x == 102, "");
 static_assert(TypeListElement<2, TYPELIST_AFTER>::x == 103, "");
@@ -131,13 +131,13 @@ struct A { enum { y = 10 }; };
 struct B { enum { y = 15 }; };
 struct C { enum { y = 20 }; };
 typedef TypeList<A, B, C> TYPELIST_BEFORE;
-static_assert(TypeListSize<TYPELIST_BEFORE>::value == 3, "");
+static_assert(TypeListSize<TYPELIST_BEFORE> == 3, "");
 static_assert(TypeListElement<0, TYPELIST_BEFORE>::y == 10, "");
 static_assert(TypeListElement<1, TYPELIST_BEFORE>::y == 15, "");
 static_assert(TypeListElement<2, TYPELIST_BEFORE>::y == 20, "");
 
 typedef current::metaprogramming::filter<y_is_even, TYPELIST_BEFORE> TYPELIST_AFTER;
-static_assert(TypeListSize<TYPELIST_AFTER>::value == 2, "");
+static_assert(TypeListSize<TYPELIST_AFTER> == 2, "");
 static_assert(TypeListElement<0, TYPELIST_AFTER>::y == 10, "");
 static_assert(TypeListElement<1, TYPELIST_AFTER>::y == 20, "");
   

--- a/bricks/template/README.md
+++ b/bricks/template/README.md
@@ -10,13 +10,13 @@ struct B { enum { x = 2 }; };
 struct C { enum { x = 3 }; };
 
 typedef TypeList<A, B, C> TYPELIST_BEFORE;
-static_assert(TypeListSize<TYPELIST_BEFORE>::value == 3, "");
+static_assert(TypeListSize<TYPELIST_BEFORE> == 3, "");
 static_assert(TypeListElement<0, TYPELIST_BEFORE>::x == 1, "");
 static_assert(TypeListElement<1, TYPELIST_BEFORE>::x == 2, "");
 static_assert(TypeListElement<2, TYPELIST_BEFORE>::x == 3, "");
 
 typedef current::metaprogramming::map<add_100, TYPELIST_BEFORE> TYPELIST_AFTER;
-static_assert(TypeListSize<TYPELIST_AFTER>::value == 3, "");
+static_assert(TypeListSize<TYPELIST_AFTER> == 3, "");
 static_assert(TypeListElement<0, TYPELIST_AFTER>::x == 101, "");
 static_assert(TypeListElement<1, TYPELIST_AFTER>::x == 102, "");
 static_assert(TypeListElement<2, TYPELIST_AFTER>::x == 103, "");
@@ -28,13 +28,13 @@ struct A { enum { y = 10 }; };
 struct B { enum { y = 15 }; };
 struct C { enum { y = 20 }; };
 typedef TypeList<A, B, C> TYPELIST_BEFORE;
-static_assert(TypeListSize<TYPELIST_BEFORE>::value == 3, "");
+static_assert(TypeListSize<TYPELIST_BEFORE> == 3, "");
 static_assert(TypeListElement<0, TYPELIST_BEFORE>::y == 10, "");
 static_assert(TypeListElement<1, TYPELIST_BEFORE>::y == 15, "");
 static_assert(TypeListElement<2, TYPELIST_BEFORE>::y == 20, "");
 
 typedef current::metaprogramming::filter<y_is_even, TYPELIST_BEFORE> TYPELIST_AFTER;
-static_assert(TypeListSize<TYPELIST_AFTER>::value == 2, "");
+static_assert(TypeListSize<TYPELIST_AFTER> == 2, "");
 static_assert(TypeListElement<0, TYPELIST_AFTER>::y == 10, "");
 static_assert(TypeListElement<1, TYPELIST_AFTER>::y == 20, "");
   

--- a/bricks/template/docu/docu_05metaprogramming_02.cc
+++ b/bricks/template/docu/docu_05metaprogramming_02.cc
@@ -38,13 +38,13 @@ TEST(TemplateMetaprogramming, Map) {
   struct C { enum { x = 3 }; };
   
   typedef TypeList<A, B, C> TYPELIST_BEFORE;
-  static_assert(TypeListSize<TYPELIST_BEFORE>::value == 3, "");
+  static_assert(TypeListSize<TYPELIST_BEFORE> == 3, "");
   static_assert(TypeListElement<0, TYPELIST_BEFORE>::x == 1, "");
   static_assert(TypeListElement<1, TYPELIST_BEFORE>::x == 2, "");
   static_assert(TypeListElement<2, TYPELIST_BEFORE>::x == 3, "");
   
   typedef current::metaprogramming::map<add_100, TYPELIST_BEFORE> TYPELIST_AFTER;
-  static_assert(TypeListSize<TYPELIST_AFTER>::value == 3, "");
+  static_assert(TypeListSize<TYPELIST_AFTER> == 3, "");
   static_assert(TypeListElement<0, TYPELIST_AFTER>::x == 101, "");
   static_assert(TypeListElement<1, TYPELIST_AFTER>::x == 102, "");
   static_assert(TypeListElement<2, TYPELIST_AFTER>::x == 103, "");
@@ -59,13 +59,13 @@ TEST(TemplateMetaprogramming, Filter) {
   struct C { enum { y = 20 }; };
  
   typedef TypeList<A, B, C> TYPELIST_BEFORE;
-  static_assert(TypeListSize<TYPELIST_BEFORE>::value == 3, "");
+  static_assert(TypeListSize<TYPELIST_BEFORE> == 3, "");
   static_assert(TypeListElement<0, TYPELIST_BEFORE>::y == 10, "");
   static_assert(TypeListElement<1, TYPELIST_BEFORE>::y == 15, "");
   static_assert(TypeListElement<2, TYPELIST_BEFORE>::y == 20, "");
   
   typedef current::metaprogramming::filter<y_is_even, TYPELIST_BEFORE> TYPELIST_AFTER;
-  static_assert(TypeListSize<TYPELIST_AFTER>::value == 2, "");
+  static_assert(TypeListSize<TYPELIST_AFTER> == 2, "");
   static_assert(TypeListElement<0, TYPELIST_AFTER>::y == 10, "");
   static_assert(TypeListElement<1, TYPELIST_AFTER>::y == 20, "");
 }

--- a/bricks/template/typelist.h
+++ b/bricks/template/typelist.h
@@ -55,12 +55,12 @@ struct TypeListSizeExtractor<TypeListImpl<TS...>> {
 
 // `TypeListSize<TypeListImpl<TS...>>::value` is the number of types in `TS...`.
 template <typename T>
-using TypeListSize = TypeListSizeExtractor<T>;
+inline constexpr static int TypeListSize = TypeListSizeExtractor<T>::value;
 
-static_assert(TypeListSize<TypeListImpl<>>::value == 0, "");
-static_assert(TypeListSize<TypeListImpl<int>>::value == 1, "");
-static_assert(TypeListSize<TypeListImpl<int, int>>::value == 2, "");
-static_assert(TypeListSize<TypeListImpl<int, int, int>>::value == 3, "");
+static_assert(TypeListSize<TypeListImpl<>> == 0, "");
+static_assert(TypeListSize<TypeListImpl<int>> == 1, "");
+static_assert(TypeListSize<TypeListImpl<int, int>> == 2, "");
+static_assert(TypeListSize<TypeListImpl<int, int, int>> == 3, "");
 
 // `DuplicateTypeInTypeList` and `ConfirmTypeListContainsNoDuplicates` are just compile-error-readable names
 // for two helper classes that wrap contained types and inherit from all the wrapped types respectively.

--- a/bricks/template/typelist.h
+++ b/bricks/template/typelist.h
@@ -55,7 +55,7 @@ struct TypeListSizeExtractor<TypeListImpl<TS...>> {
 
 // `TypeListSize<TypeListImpl<TS...>>::value` is the number of types in `TS...`.
 template <typename T>
-inline constexpr static int TypeListSize = TypeListSizeExtractor<T>::value;
+inline constexpr size_t TypeListSize = TypeListSizeExtractor<T>::value;
 
 static_assert(TypeListSize<TypeListImpl<>> == 0, "");
 static_assert(TypeListSize<TypeListImpl<int>> == 1, "");

--- a/regression_tests/typesystem/test.sh
+++ b/regression_tests/typesystem/test.sh
@@ -19,7 +19,7 @@ TEST_LIST=(
 )
 
 CPLUSPLUS=${CPLUSPLUS:-g++}
-CPPFLAGS=${CPPFLAGS:- -std=c++11 -ftemplate-backtrace-limit=0  -ftemplate-depth=10000}
+CPPFLAGS=${CPPFLAGS:- -std=c++17 -ftemplate-backtrace-limit=0  -ftemplate-depth=10000}
 OS=$(uname)
 if [[ ""$OS != "Darwin" ]]; then
 	LDFLAGS=${LDFLAGS:- -pthread}

--- a/regression_tests/typesystem/typelist_dynamic.cc
+++ b/regression_tests/typesystem/typelist_dynamic.cc
@@ -48,7 +48,7 @@ TEST(TypeTest, TypeListImpl) {
   using current::metaprogramming::Flatten;
   typedef Flatten<map<ST, DATA_TYPES>> STORAGE_TYPES;
 
-  static_assert(TypeListSize<STORAGE_TYPES>::value == TypeListSize<DATA_TYPES>::value * 2, "");
+  static_assert(TypeListSize<STORAGE_TYPES> == TypeListSize<DATA_TYPES> * 2, "");
 }
 
 #endif  // CURRENT_COVERAGE_REPORT_MODE


### PR DESCRIPTION
I'd rather make this change now, before it's too late.

Also, ran our regression tests. Impressive they still build and pass.

Thanks,
Dima