### PR TITLE
`ChunkedPOST` in addition to `ChunkedGET`.

### DIFF
--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -756,7 +756,6 @@ TEST(HTTPAPI, ChunkedResponseWithHeaders) {
   EXPECT_EQ("yeah", response.headers.Get("header"));
 }
 
-// A hacky way to get back the response chunk by chunk. TODO(dkorolev): `ChunkedGET`.
 TEST(HTTPAPI, GetByChunksPrototype) {
   // Handler returning the result chunk by chunk.
   const auto scope = HTTP(FLAGS_net_api_test_port)

--- a/blocks/http/test.cc
+++ b/blocks/http/test.cc
@@ -954,14 +954,31 @@ TEST(HTTPAPI, ChunkedBodySemantics) {
     std::vector<std::string> headers;
     std::vector<std::string> chunk_by_chunk_response;
 
-    const auto response = HTTP(ChunkedPOST(url, "blah")
+    const auto response = HTTP(ChunkedPOST(url, "test")
         .OnHeader([&headers](const std::string& k, const std::string& v) { headers.push_back(k + '=' + v); })
         .OnChunk([&chunk_by_chunk_response](const std::string& s) { chunk_by_chunk_response.push_back(s); })
         .OnDone([&chunk_by_chunk_response]() { chunk_by_chunk_response.push_back("DONE"); }));
     EXPECT_EQ(200, static_cast<int>(response));
     EXPECT_EQ(
-        "{\"s\":|\"foo\"|}\n{\"s\":\"bar\"}\n|{\"s\":\"baz\"}|DONE",
+        "{\"s\":|\"foo\"|}\n{\"s\":\"test\"}\n|{\"s\":\"baz\"}|DONE",
         current::strings::Join(chunk_by_chunk_response, '|'));
+    EXPECT_EQ(4u, headers.size());
+    EXPECT_EQ("Content-Type=application/stream+json; charset=utf-8|Connection=keep-alive"
+              "|TestHeaderName=TestHeaderValue|Transfer-Encoding=chunked",
+              current::strings::Join(headers, '|'));
+  }
+
+  {
+    std::vector<std::string> headers;
+    std::vector<std::string> line_by_line_response;
+
+    const auto response = HTTP(ChunkedPOST(url, "passed")
+        .OnHeader([&headers](const std::string& k, const std::string& v) { headers.push_back(k + '=' + v); })
+        .OnLine([&line_by_line_response](const std::string& s) { line_by_line_response.push_back(s); }));
+    EXPECT_EQ(200, static_cast<int>(response));
+    EXPECT_EQ(
+        "{\"s\":\"foo\"}|{\"s\":\"passed\"}|{\"s\":\"baz\"}",
+        current::strings::Join(line_by_line_response, '|'));
     EXPECT_EQ(4u, headers.size());
     EXPECT_EQ("Content-Type=application/stream+json; charset=utf-8|Connection=keep-alive"
               "|TestHeaderName=TestHeaderValue|Transfer-Encoding=chunked",

--- a/blocks/http/types.h
+++ b/blocks/http/types.h
@@ -125,14 +125,16 @@ struct ChunkedPOST final : ChunkedBase<ChunkedPOST> {
   const std::string body;
   const std::string content_type;
   explicit ChunkedPOST(std::string url,
-                       const std::string body,
-                       const std::string content_type,
+                       std::string body,
+                       std::string content_type,
                        std::function<void(const std::string&, const std::string&)> header_callback,
                        std::function<void(const std::string&)> chunk_callback,
                        std::function<void()> done_callback = []() {})
       : ChunkedBase(std::move(url), header_callback, chunk_callback, done_callback),
         body(std::move(body)),
         content_type(std::move(content_type)) {}
+  explicit ChunkedPOST(std::string url, std::string body, std::string content_type = "")
+      : ChunkedBase(std::move(url)), body(std::move(body)), content_type(std::move(content_type)) {}
 };
 
 struct HEAD : HTTPRequestBase<HEAD> {

--- a/blocks/http/types.h
+++ b/blocks/http/types.h
@@ -133,9 +133,9 @@ struct ChunkedBase {
   }
 
   // TODO(dkorolev): Move this to `Chunk`-s if performance becomes the bottleneck.
-  T& OnLine(std::function<void(const char*)> line_callback) {
+  T& OnLine(std::function<void(const std::string&)> line_callback) {
     group_by_lines_.emplace_back(std::make_unique<current::strings::StatefulGroupByLines>(
-          [line_callback](const char* line) { line_callback(line); }));
+          [line_callback](const std::string& line) { line_callback(line); }));
     return static_cast<T&>(*this);
   }
 

--- a/bricks/net/http/constants.h
+++ b/bricks/net/http/constants.h
@@ -42,6 +42,7 @@ constexpr char kDefaultJSONContentType[] = "application/json; charset=utf-8";
 constexpr char kDefaultHTMLContentType[] = "text/html; charset=utf-8";
 constexpr char kDefaultSVGContentType[] = "image/svg+xml; charset=utf-8";
 constexpr char kDefaultPNGContentType[] = "image/png";
+constexpr char kDefaultJSONStreamContentType[] = "application/stream+json; charset=utf-8";
 
 constexpr char kHeaderKeyValueSeparator = ':';
 

--- a/bricks/strings/group_by_lines.h
+++ b/bricks/strings/group_by_lines.h
@@ -32,13 +32,13 @@ namespace current {
 namespace strings {
 
 template <typename F = std::function<void(const char*)>>
-class StatefulGroupByLines final {
+class GenericStatefulGroupByLines final {
  private:
   F f_;
   std::string residual_;
 
  public:
-  explicit StatefulGroupByLines(F&& f) : f_(std::move(f)) {}
+  explicit GenericStatefulGroupByLines(F&& f) : f_(std::move(f)) {}
   void Feed(const std::string& s) {
     Feed(s.c_str());
   }
@@ -56,12 +56,14 @@ class StatefulGroupByLines final {
       }
     }
   }
-  ~StatefulGroupByLines() {
+  ~GenericStatefulGroupByLines() {
     if (!residual_.empty()) {
       f_(residual_.c_str());
     }
   }
 };
+
+using StatefulGroupByLines = GenericStatefulGroupByLines<std::function<void(const char*)>>;
 
 }  // namespace strings
 }  // namespace current

--- a/bricks/strings/group_by_lines.h
+++ b/bricks/strings/group_by_lines.h
@@ -42,7 +42,9 @@ class GenericStatefulGroupByLines final {
   void Feed(const std::string& s) {
     Feed(s.c_str());
   }
-  void Feed(char const* s) {
+  void Feed(const char* s) {
+    // NOTE: `Feed`() will only call the callback upon seeing the newline in the input data block. If the last line
+    // does not end with a newline, it will not be forwarded until the `StatefulGroupByLines` instance is destroyed.
     while (true) {
       while (*s && *s != '\n') {
         residual_ += *s++;
@@ -58,12 +60,13 @@ class GenericStatefulGroupByLines final {
   }
   ~GenericStatefulGroupByLines() {
     if (!residual_.empty()) {
+      // Upon destruction, process the the last incomplete line, if necessary.
       f_(residual_.c_str());
     }
   }
 };
 
-using StatefulGroupByLines = GenericStatefulGroupByLines<std::function<void(const char*)>>;
+using StatefulGroupByLines = GenericStatefulGroupByLines<std::function<void(const std::string&)>>;
 
 }  // namespace strings
 }  // namespace current

--- a/bricks/strings/test.cc
+++ b/bricks/strings/test.cc
@@ -995,7 +995,7 @@ TEST(UTF8StringLength, Smoke) {
 
 TEST(StatefulGroupByLines, SmokeTrivial) {
   std::vector<std::string> lines;
-  StatefulGroupByLines splitter([&lines](const char* line) { lines.push_back(std::move(line)); });
+  StatefulGroupByLines splitter([&lines](const std::string& line) { lines.push_back(line); });
   splitter.Feed("foo\n");
   splitter.Feed("bar\n");
   splitter.Feed("baz\n");
@@ -1008,7 +1008,7 @@ TEST(StatefulGroupByLines, SmokeTrivial) {
 TEST(StatefulGroupByLines, Smoke) {
   std::vector<std::string> lines;
   {
-    StatefulGroupByLines splitter([&lines](const char* line) { lines.push_back(std::move(line)); });
+    StatefulGroupByLines splitter([&lines](const std::string& line) { lines.push_back(line); });
     splitter.Feed("fo");
     splitter.Feed("o\nbar\nb");
     ASSERT_EQ(2u, lines.size());

--- a/bricks/strings/test.cc
+++ b/bricks/strings/test.cc
@@ -44,6 +44,7 @@ using current::strings::Join;
 using current::strings::Split;
 using current::strings::SplitIntoChunks;
 using current::strings::SplitIntoKeyValuePairs;
+using current::strings::StatefulGroupByLines;
 using current::strings::EmptyFields;
 using current::strings::KeyValueParsing;
 using current::strings::KeyValueNoValueException;
@@ -990,4 +991,35 @@ TEST(Regex, SubstringIterationSmokeTest) {
 TEST(UTF8StringLength, Smoke) {
   EXPECT_EQ(4u, current::strings::UTF8StringLength("test"));
   EXPECT_EQ(4u, current::strings::UTF8StringLength("тест"));
+}
+
+TEST(StatefulGroupByLines, SmokeTrivial) {
+  std::vector<std::string> lines;
+  StatefulGroupByLines splitter([&lines](const char* line) { lines.push_back(std::move(line)); });
+  splitter.Feed("foo\n");
+  splitter.Feed("bar\n");
+  splitter.Feed("baz\n");
+  ASSERT_EQ(3u, lines.size());
+  EXPECT_EQ("foo", lines[0]);
+  EXPECT_EQ("bar", lines[1]);
+  EXPECT_EQ("baz", lines[2]);
+}
+
+TEST(StatefulGroupByLines, Smoke) {
+  std::vector<std::string> lines;
+  {
+    StatefulGroupByLines splitter([&lines](const char* line) { lines.push_back(std::move(line)); });
+    splitter.Feed("fo");
+    splitter.Feed("o\nbar\nb");
+    ASSERT_EQ(2u, lines.size());
+    EXPECT_EQ("foo", lines[0]);
+    EXPECT_EQ("bar", lines[1]);
+    splitter.Feed("a");
+    splitter.Feed("z");
+    ASSERT_EQ(2u, lines.size());
+  }
+  ASSERT_EQ(3u, lines.size());
+  EXPECT_EQ("foo", lines[0]);
+  EXPECT_EQ("bar", lines[1]);
+  EXPECT_EQ("baz", lines[2]);
 }


### PR DESCRIPTION
Hi @mzhurovich -- this is missing tests, but may well be good to go "as is", as I've confirmed it does the job (with `HTTP` examples from the [Docker API](https://docs.docker.com/engine/api/sdk/examples/)).