### PR TITLE
Introduced `ReserveLocalPort()`, added a parallel test, refactored away `PickPortForUnitTest()`, fixed Travis (again).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,40 @@
 .PHONY: all test individual_tests storage_perftest typesystem_compilation_test check wc clean
+.PHONY: individual_tests_1_of_3 individual_tests_1_of_3 individual_tests_3_of_3
+.PHONY: individual_tests_1_of_8 individual_tests_2_of_8 individual_tests_3_of_8 individual_tests_4_of_8 individual_tests_5_of_8 individual_tests_6_of_8 individual_tests_7_of_8 individual_tests_8_of_8 individual_tests_all_8
 
 all: test check
 
 test:
-	./scripts/full-test.sh
+	@./scripts/full-test.sh
 
 individual_tests:
-	./scripts/individual-tests.sh
+	@./scripts/individual-tests.sh
 
 individual_tests_1_of_3:
-	./scripts/individual-tests.sh 0 3
-
+	@./scripts/individual-tests.sh 0 3
 individual_tests_2_of_3:
-	./scripts/individual-tests.sh 1 3
-
+	@./scripts/individual-tests.sh 1 3
 individual_tests_3_of_3:
-	./scripts/individual-tests.sh 2 3
+	@./scripts/individual-tests.sh 2 3
+
+individual_tests_1_of_8:
+	@./scripts/individual-tests.sh 0 8
+individual_tests_2_of_8:
+	@./scripts/individual-tests.sh 1 8
+individual_tests_3_of_8:
+	@./scripts/individual-tests.sh 2 8
+individual_tests_4_of_8:
+	@./scripts/individual-tests.sh 3 8
+individual_tests_5_of_8:
+	@./scripts/individual-tests.sh 4 8
+individual_tests_6_of_8:
+	@./scripts/individual-tests.sh 5 8
+individual_tests_7_of_8:
+	@./scripts/individual-tests.sh 6 8
+individual_tests_8_of_8:
+	@./scripts/individual-tests.sh 7 8
+
+individual_tests_all_8: individual_tests_1_of_8 individual_tests_2_of_8 individual_tests_3_of_8 individual_tests_4_of_8 individual_tests_5_of_8 individual_tests_6_of_8 individual_tests_7_of_8 individual_tests_8_of_8
 
 storage_perftest:
 	(cd examples/Benchmark/generic ; ./run_storage_tests.sh)
@@ -27,7 +46,7 @@ typesystem_schema_typescript_tests:
 	(cd typesystem/schema ; ./test-c5t-current-schema-ts.sh)
 
 check:
-	./scripts/check-headers.sh
+	@./scripts/check-headers.sh
 
 wc:
 	echo -n "Total files: " ; (find . -name '*.cc' ; find . -iname '*.h') | grep -v 3rdparty | grep -v "/.current/" | grep -v zzz_full_test | grep -v "/sandbox/" | wc -l

--- a/blocks/http/docu/client/docu_02httpclient_01_test.cc
+++ b/blocks/http/docu/client/docu_02httpclient_01_test.cc
@@ -30,16 +30,16 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_client_port_01, PickPortForUnitTest(), "");
-
 using current::strings::Printf;
 
 // clang-format off
 
 TEST(Docu, HTTPClient01A) {
-const auto scope = HTTP(FLAGS_docu_net_client_port_01).Register("/ok", [](Request r) { r("OK"); });
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
+const auto scope = HTTP(std::move(reserved_port)).Register("/ok", [](Request r) { r("OK"); });
 #if 1
-EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_01))).body);
+EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", port))).body);
 #else
   // Simple GET.
   EXPECT_EQ("OK", HTTP(GET("http://test.tailproduce.org/ok")).body);
@@ -47,10 +47,12 @@ EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_
 }
   
 TEST(Docu, HTTPClient01B) {
-const auto scope = HTTP(FLAGS_docu_net_client_port_01).Register("/ok", [](Request r) { r("OK"); });
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
+const auto scope = HTTP(std::move(reserved_port)).Register("/ok", [](Request r) { r("OK"); });
   // More fields.
 #if 1
-const auto response = HTTP(GET(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_01)));
+const auto response = HTTP(GET(Printf("http://localhost:%d/ok", port)));
 #else
   const auto response = HTTP(GET("http://test.tailproduce.org/ok"));
 #endif

--- a/blocks/http/docu/client/docu_02httpclient_02_test.cc
+++ b/blocks/http/docu/client/docu_02httpclient_02_test.cc
@@ -30,8 +30,6 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_client_port_02, PickPortForUnitTest(), "");
-
 using current::strings::Printf;
 
 // clang-format off
@@ -41,10 +39,12 @@ CURRENT_STRUCT(SimpleType) {
 };
 
 TEST(Docu, HTTPClient02) {
-const auto scope = HTTP(FLAGS_docu_net_client_port_02).Register("/ok", [](Request r) { r("OK"); });
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
+const auto scope = HTTP(std::move(reserved_port)).Register("/ok", [](Request r) { r("OK"); });
 #if 1
-EXPECT_EQ("OK", HTTP(POST(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_02), "BODY", "text/plain")).body);
-EXPECT_EQ("OK", HTTP(POST(Printf("http://localhost:%d/ok", FLAGS_docu_net_client_port_02), SimpleType())).body);
+EXPECT_EQ("OK", HTTP(POST(Printf("http://localhost:%d/ok", port), "BODY", "text/plain")).body);
+EXPECT_EQ("OK", HTTP(POST(Printf("http://localhost:%d/ok", port), SimpleType())).body);
 #else
   // POST is supported as well.
   EXPECT_EQ("OK", HTTP(POST("http://test.tailproduce.org/ok"), "BODY", "text/plain").body);

--- a/blocks/http/docu/server/docu_03httpserver_01_test.cc
+++ b/blocks/http/docu/server/docu_03httpserver_01_test.cc
@@ -30,14 +30,13 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_server_port_01, PickPortForUnitTest(), "");
-
 using current::strings::Printf;
 
 TEST(Docu, HTTPServer01) {
-const auto port = FLAGS_docu_net_server_port_01;
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
   // Simple "OK" endpoint.
-  const auto scope = HTTP(port).Register("/ok", [](Request r) {
+  const auto scope = HTTP(std::move(reserved_port)).Register("/ok", [](Request r) {
     r("OK");
   });
 EXPECT_EQ("OK", HTTP(GET(Printf("http://localhost:%d/ok", port))).body);

--- a/blocks/http/docu/server/docu_03httpserver_02_test.cc
+++ b/blocks/http/docu/server/docu_03httpserver_02_test.cc
@@ -30,14 +30,13 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_server_port_02, PickPortForUnitTest(), "");
-
 using current::strings::Printf;
 
 TEST(Docu, HTTPServer02) {
-const auto port = FLAGS_docu_net_server_port_02;
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
   // Accessing input fields.
-  const auto scope = HTTP(port).Register("/demo", [](Request r) {
+  const auto scope = HTTP(std::move(reserved_port)).Register("/demo", [](Request r) {
     r(r.url.query["q"] + ' ' + r.method + ' ' + r.body);
   });
 EXPECT_EQ("A POST body", HTTP(POST(Printf("http://localhost:%d/demo?q=A", port), "body", "text/plain")).body);

--- a/blocks/http/docu/server/docu_03httpserver_03_test.cc
+++ b/blocks/http/docu/server/docu_03httpserver_03_test.cc
@@ -30,14 +30,13 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_server_port_03, PickPortForUnitTest(), "");
-
 using current::strings::Printf;
 
 TEST(Docu, HTTPServer03) {
-const auto port = FLAGS_docu_net_server_port_03;
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
   // Constructing a more complex response.
-  const auto scope = HTTP(port).Register("/found", [](Request r) {
+  const auto scope = HTTP(std::move(reserved_port)).Register("/found", [](Request r) {
     r("Yes.",
       HTTPResponseCode.Accepted,
       current::net::http::Headers().Set("custom", "header").Set("another", "one"),

--- a/blocks/http/docu/server/docu_03httpserver_04_test.cc
+++ b/blocks/http/docu/server/docu_03httpserver_04_test.cc
@@ -33,8 +33,6 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_server_port_04, PickPortForUnitTest(), "");
-
 using current::strings::Printf;
 
   // An input record that would be passed in as a JSON.
@@ -53,9 +51,10 @@ using current::strings::Printf;
   }; 
   
 TEST(Docu, HTTPServer04) {
-const auto port = FLAGS_docu_net_server_port_04;
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
   // Doing Penny-level arithmetics for fun and performance testing.
-  const auto scope = HTTP(port).Register("/penny", [](Request r) {
+  const auto scope = HTTP(std::move(reserved_port)).Register("/penny", [](Request r) {
     try {
       const auto input = ParseJSON<PennyInput>(r.body);
       if (input.op == "add") {

--- a/blocks/http/docu/server/docu_03httpserver_05_test.cc
+++ b/blocks/http/docu/server/docu_03httpserver_05_test.cc
@@ -34,12 +34,11 @@ SOFTWARE.
 #include "../../../../bricks/dflags/dflags.h"
 #include "../../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(docu_net_server_port_05, PickPortForUnitTest(), "");
-
 TEST(Docu, HTTPServer05) {
-const auto port = FLAGS_docu_net_server_port_05;
+auto reserved_port = current::net::ReserveLocalPort();
+const int port = reserved_port;
   // Returning a potentially unlimited response chunk by chunk.
-  const auto scope = HTTP(port).Register("/chunked", [](Request r) {
+  const auto scope = HTTP(std::move(reserved_port)).Register("/chunked", [](Request r) {
     const size_t n = atoi(r.url.query["n"].c_str());
     const size_t delay_ms = atoi(r.url.query["delay_ms"].c_str());
       

--- a/bricks/net/tcp/impl/posix.h
+++ b/bricks/net/tcp/impl/posix.h
@@ -22,6 +22,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+#if 0
+
+# NOTE(dkorolev): I have tested the `ReserveLocalPort` logic in the following way.
+# Step one: build.
+g++ -g -std=c++17 -W -Wall -Wno-strict-aliasing   -o ".current/test" "test.cc" -pthread -ldl
+ulimit -c unlimited
+# Step two: run in two terminals in parallel.
+rm -f core ; while true ; do ./.current/test --gtest_throw_on_failure --gtest_catch_exceptions=0 || break ; done
+
+#endif
+
 // TODO(dkorolev): Add Mac support and find out the right name for this header file.
 
 #ifndef BRICKS_NET_TCP_IMPL_POSIX_H
@@ -51,22 +62,25 @@ typedef int SOCKET;
 
 #endif  // CURRENT_WINDOWS
 
-#include "../../exceptions.h"
-
-#include "../../debug_log.h"
-
-#include "../../../util/singleton.h"
-
+#include <iostream>
 #include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "../../exceptions.h"
+#include "../../debug_log.h"
+
+#include "../../../util/random.h"
+#include "../../../util/singleton.h"
+
 namespace current {
 namespace net {
 
+enum class NagleAlgorithm : bool { Disable, Keep };
+
 const size_t kMaxServerQueuedConnections = 1024;
-const bool kDisableNagleAlgorithmByDefault = false;
+const NagleAlgorithm kDisableNagleAlgorithmByDefault = NagleAlgorithm::Keep;
 
 struct SocketSystemInitializer {
 #ifdef CURRENT_WINDOWS
@@ -84,17 +98,14 @@ struct SocketSystemInitializer {
 #endif  // CURRENT_WINDOWS
 };
 
-class SocketHandle : private SocketSystemInitializer {
- public:
-  // Two ways to construct SocketHandle: via NewHandle() or FromHandle(SOCKET handle).
-  struct NewHandle final {};
-  struct FromHandle final {
-    SOCKET handle;
-    FromHandle(SOCKET handle) : handle(handle) {}
-  };
+enum class BarePort : uint16_t {};
 
-  inline SocketHandle(NewHandle, const bool disable_nagle_algorithm = kDisableNagleAlgorithmByDefault)
-      : socket_(::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) {
+class SocketHandle : private SocketSystemInitializer {
+ private:
+  struct InternalInit final {};
+  explicit SocketHandle(InternalInit,
+                        NagleAlgorithm nagle_algorithm_policy = kDisableNagleAlgorithmByDefault)
+    : socket_(::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) {
     if (socket_ < 0) {
       CURRENT_THROW(SocketCreateException());  // LCOV_EXCL_LINE -- Not covered by unit tests.
     }
@@ -105,19 +116,6 @@ class SocketHandle : private SocketSystemInitializer {
 #else
     u_long just_one = 1;
 #endif  // CURRENT_WINDOWS
-
-    // LCOV_EXCL_START
-    if (disable_nagle_algorithm) {
-#ifndef CURRENT_WINDOWS
-      if (::setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, &just_one, sizeof(just_one)))
-#else
-      if (::setsockopt(socket, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char*>(&just_one), sizeof(just_one)))
-#endif  // CURRENT_WINDOWS
-      {
-        CURRENT_THROW(SocketCreateException());
-      }
-    }
-    // LCOV_EXCL_STOP
 
     if (::setsockopt(socket_,
                      SOL_SOCKET,
@@ -137,16 +135,67 @@ class SocketHandle : private SocketSystemInitializer {
       CURRENT_THROW(SocketCreateException());
     }
 #endif
+
+    // LCOV_EXCL_START
+    if (nagle_algorithm_policy == NagleAlgorithm::Disable) {
+#ifndef CURRENT_WINDOWS
+      if (::setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, &just_one, sizeof(just_one)))
+#else
+      if (::setsockopt(socket, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char*>(&just_one), sizeof(just_one)))
+#endif  // CURRENT_WINDOWS
+      {
+        CURRENT_THROW(SocketCreateException());
+      }
+    }
+    // LCOV_EXCL_STOP
+    
   }
 
-  inline SocketHandle(FromHandle from) : socket_(from.handle) {
+ public:
+  struct BindAndListen final {};
+  explicit SocketHandle(BindAndListen,
+                        BarePort bare_port,
+                        NagleAlgorithm nagle_algorithm_policy = kDisableNagleAlgorithmByDefault,
+                        int max_connections = kMaxServerQueuedConnections)
+      : SocketHandle(InternalInit(), nagle_algorithm_policy) {
+    sockaddr_in addr_server;
+    memset(&addr_server, 0, sizeof(addr_server));
+    addr_server.sin_family = AF_INET;
+    addr_server.sin_addr.s_addr = INADDR_ANY;
+    // Catch a level 4 warning of MSVS.
+    addr_server.sin_port = htons(static_cast<decltype(std::declval<sockaddr_in>().sin_port)>(bare_port));
+
+    CURRENT_BRICKS_NET_LOG("S%05d bind()+listen() ...\n", static_cast<SOCKET>(socket));
+
+    if (::bind(socket, reinterpret_cast<sockaddr*>(&addr_server), sizeof(addr_server)) == static_cast<SOCKET>(-1)) {
+      CURRENT_THROW(SocketBindException(static_cast<uint16_t>(bare_port)));
+    }
+
+    CURRENT_BRICKS_NET_LOG("S%05d bind()+listen() : bind() OK\n", static_cast<SOCKET>(socket));
+
+    if (::listen(socket, max_connections)) {
+      CURRENT_THROW(SocketListenException());  // LCOV_EXCL_LINE -- Not covered by the unit tests.
+    }
+
+    CURRENT_BRICKS_NET_LOG("S%05d bind() and listen() : listen() OK\n", static_cast<SOCKET>(socket));
+  }
+
+  struct DoNotBind final {};
+  explicit SocketHandle(DoNotBind, NagleAlgorithm nagle_algorithm_policy = kDisableNagleAlgorithmByDefault)
+        : SocketHandle(InternalInit(), nagle_algorithm_policy) {}
+
+  struct FromAcceptedHandle final {
+    SOCKET handle;
+    FromAcceptedHandle(SOCKET handle) : handle(handle) {}
+  };
+  SocketHandle(FromAcceptedHandle from) : socket_(from.handle) {
     if (socket_ < 0) {
       CURRENT_THROW(InvalidSocketException());  // LCOV_EXCL_LINE -- Not covered by unit tests.
     }
     CURRENT_BRICKS_NET_LOG("S%05d == initialized externally.\n", socket_);
   }
 
-  inline ~SocketHandle() {
+  ~SocketHandle() {
     if (socket_ != static_cast<SOCKET>(-1)) {
       CURRENT_BRICKS_NET_LOG("S%05d close() ...\n", socket_);
 #ifndef CURRENT_WINDOWS
@@ -160,14 +209,15 @@ class SocketHandle : private SocketSystemInitializer {
     }
   }
 
-  inline explicit SocketHandle(SocketHandle&& rhs) : socket_(static_cast<SOCKET>(-1)) {
+  explicit SocketHandle(SocketHandle&& rhs) : socket_(static_cast<SOCKET>(-1)) {
     std::swap(socket_, rhs.socket_);
   }
 
   // SocketHandle does not expose copy constructor and assignment operator. It should only be moved.
 
  private:
-#ifndef CURRENT_WINDOWS
+  friend class Socket;
+#if 1  // NOTE(dkorolev): Checking this in 2021, was: #ifndef CURRENT_WINDOWS
   SOCKET socket_;
 #else
   mutable SOCKET socket_;  // Need to support taking the handle away from a non-move constructor.
@@ -180,7 +230,7 @@ class SocketHandle : private SocketSystemInitializer {
   class ReadOnlyValidSocketAccessor final {
    public:
     explicit ReadOnlyValidSocketAccessor(const SOCKET& ref) : ref_(ref) {}
-    inline operator SOCKET() {
+    operator SOCKET() {
       if (!ref_) {
         CURRENT_THROW(InvalidSocketException());  // LCOV_EXCL_LINE -- Not covered by unit tests.
       }
@@ -199,13 +249,16 @@ class SocketHandle : private SocketSystemInitializer {
  private:
   SocketHandle() = delete;
   void operator=(const SocketHandle&) = delete;
-  void operator=(SocketHandle&&) = delete;
+  void operator=(SocketHandle&& rhs) {
+    socket_ = rhs.socket_;
+    rhs.socket_ = static_cast<SOCKET>(-1);
+  }
 
-#ifndef CURRENT_WINDOWS
+#if 1  // ndef CURRENT_WINDOWS
   SocketHandle(const SocketHandle&) = delete;
 #else
  public:
-  // Visual Studio seem to require this constructor, since std::move()-ing away `SocketHandle`-s
+  // Visual Studio seems to require this constructor, since std::move()-ing away `SocketHandle`-s
   // as part of `Connection` objects doesn't seem to work. TODO(dkorolev): Investigate this.
   SocketHandle(const SocketHandle& rhs) : socket_(static_cast<SOCKET>(-1)) { std::swap(socket_, rhs.socket_); }
 
@@ -215,8 +268,8 @@ class SocketHandle : private SocketSystemInitializer {
 
 struct IPAndPort {
   std::string ip;
-  int port;
-  IPAndPort(const std::string& ip = "", int port = 0) : ip(ip), port(port) {}
+  uint16_t port;
+  IPAndPort(const std::string& ip = "", uint16_t port = 0) : ip(ip), port(port) {}
   IPAndPort(const IPAndPort&) = default;
   IPAndPort(IPAndPort&&) = default;
   IPAndPort& operator=(const IPAndPort&) = default;
@@ -237,6 +290,91 @@ inline std::string InetAddrToString(const struct in_addr* in) {
   } else {
     return std::string(result);
   }
+}
+
+// NOTE(dkorolev): These are magic numbers, might use some SFINAE and DECLARE_* to make them flags-configurable later.
+constexpr static uint16_t kPickFreePortMin = 25000;
+constexpr static uint16_t kPickFreePortMax = 29000;
+
+class ReservedLocalPort final : public current::net::SocketHandle {
+ private:
+  using super_t = current::net::SocketHandle;
+  friend class Socket;
+  uint16_t port_;
+
+ public:
+  struct Construct final {};
+  ReservedLocalPort() = delete;
+  ReservedLocalPort(Construct, uint16_t port, current::net::SocketHandle&& socket) : super_t(std::move(socket)), port_(port) {}
+  ReservedLocalPort(const ReservedLocalPort&) = delete;
+  ReservedLocalPort(ReservedLocalPort&& rhs) : super_t(std::move(rhs)), port_(rhs.port_) {
+    rhs.port_ = 0;
+  }
+  ReservedLocalPort& operator=(const ReservedLocalPort&) = delete;
+  ReservedLocalPort& operator=(ReservedLocalPort&&) = delete;
+  operator uint16_t() const { return port_; }
+
+  // This one is for the tests, for `%d`-s to work in test "URL"-s construction without any `static_cast<>`-s.
+  operator int() const { return static_cast<int>(port_); }
+};
+
+namespace impl {
+
+class ReserveLocalPortImpl final {
+ private:
+  std::vector<uint16_t> order_;
+  size_t index_;
+
+ public:
+  ReserveLocalPortImpl() {
+    for (uint16_t port = kPickFreePortMin; port <= kPickFreePortMax; ++port) {
+      order_.push_back(port);
+    }
+    index_ = 0u;
+  }
+
+  current::net::ReservedLocalPort DoIt(NagleAlgorithm nagle_algorithm_policy, int max_connections) {
+     size_t save_index = index_;
+     do {
+       if (!index_) {
+         std::shuffle(std::begin(order_), std::end(order_), current::random::mt19937_64_tls());
+       }
+       const uint16_t candidate_port = order_[index_++];
+       if (index_ == order_.size()) {
+         index_ = 0u;
+       }
+       try {
+         current::net::SocketHandle try_to_hold_port(current::net::SocketHandle::BindAndListen(), 
+                                                     BarePort(candidate_port),
+                                                     nagle_algorithm_policy,
+                                                     max_connections);
+         return current::net::ReservedLocalPort(current::net::ReservedLocalPort::Construct(),
+                                           candidate_port,
+                                           std::move(try_to_hold_port));
+       } catch (const current::net::SocketConnectException&) {
+         // Keep trying.
+         // std::cerr << "Failed in `connect`." << candidate_port << '\n';
+       } catch (const current::net::SocketBindException&) {
+         // Keep trying.
+         // std::cerr << "Failed in `bind`." << candidate_port << '\n';
+       } catch (const current::net::SocketListenException&) {
+         // Keep trying.
+         // std::cerr << "Failed in `listen`." << candidate_port << '\n';
+       }
+       // Consciously fail on other exception types here.
+     } while (index_ != save_index);
+     std::cerr << "FATAL ERROR: Failed to pick an available local port." << std::endl;
+     std::exit(-1);
+   }
+};
+
+}  // namespace current::net::impl
+
+// Pick an available local port.
+[[nodiscard]] inline ReservedLocalPort ReserveLocalPort(
+    NagleAlgorithm nagle_algorithm_policy = kDisableNagleAlgorithmByDefault,
+    int max_connections = kMaxServerQueuedConnections) {
+  return current::ThreadLocalSingleton<impl::ReserveLocalPortImpl>().DoIt(nagle_algorithm_policy, max_connections);
 }
 
 class Connection : public SocketHandle {
@@ -368,7 +506,7 @@ class Connection : public SocketHandle {
     }
   }
 
-  inline Connection& BlockingWrite(const void* buffer, size_t write_length, bool more) {
+  Connection& BlockingWrite(const void* buffer, size_t write_length, bool more) {
 #if defined(CURRENT_APPLE) || defined(CURRENT_WINDOWS)
     static_cast<void>(more);  // Supress the 'unused parameter' warning.
 #endif
@@ -393,13 +531,13 @@ class Connection : public SocketHandle {
     return *this;
   }
 
-  inline Connection& BlockingWrite(const char* s, bool more) {
+  Connection& BlockingWrite(const char* s, bool more) {
     CURRENT_ASSERT(s);
     return BlockingWrite(s, strlen(s), more);
   }
 
   template <typename T>
-  inline Connection& BlockingWrite(const T begin, const T end, bool more) {
+  Connection& BlockingWrite(const T begin, const T end, bool more) {
     if (begin != end) {
       return BlockingWrite(&(*begin), (end - begin) * sizeof(typename T::value_type), more);
     } else {
@@ -410,7 +548,7 @@ class Connection : public SocketHandle {
   // Specialization for STL containers to allow calling BlockingWrite() on std::string, std::vector, etc.
   // The `std::enable_if_t<>` clause is required, otherwise `BlockingWrite(char[N])` becomes ambiguous.
   template <typename T>
-  inline std::enable_if_t<sizeof(typename T::value_type) != 0> BlockingWrite(const T& container, bool more) {
+  std::enable_if_t<sizeof(typename T::value_type) != 0> BlockingWrite(const T& container, bool more) {
     BlockingWrite(container.begin(), container.end(), more);
   }
 
@@ -426,35 +564,28 @@ class Connection : public SocketHandle {
 
 class Socket final : public SocketHandle {
  public:
-  inline explicit Socket(const int port,
-                         const int max_connections = kMaxServerQueuedConnections,
-                         const bool disable_nagle_algorithm = kDisableNagleAlgorithmByDefault)
-      : SocketHandle(SocketHandle::NewHandle(), disable_nagle_algorithm) {
-    sockaddr_in addr_server;
-    memset(&addr_server, 0, sizeof(addr_server));
-    addr_server.sin_family = AF_INET;
-    addr_server.sin_addr.s_addr = INADDR_ANY;
-    // Catch a level 4 warning of MSVS.
-    addr_server.sin_port = htons(static_cast<decltype(std::declval<sockaddr_in>().sin_port)>(port));
-
-    CURRENT_BRICKS_NET_LOG("S%05d bind()+listen() ...\n", static_cast<SOCKET>(socket));
-
-    if (::bind(socket, reinterpret_cast<sockaddr*>(&addr_server), sizeof(addr_server)) == static_cast<SOCKET>(-1)) {
-      CURRENT_THROW(SocketBindException(port));
-    }
-
-    CURRENT_BRICKS_NET_LOG("S%05d bind()+listen() : bind() OK\n", static_cast<SOCKET>(socket));
-
-    if (::listen(socket, max_connections)) {
-      CURRENT_THROW(SocketListenException());  // LCOV_EXCL_LINE -- Not covered by the unit tests.
-    }
-
-    CURRENT_BRICKS_NET_LOG("S%05d bind() and listen() : listen() OK\n", static_cast<SOCKET>(socket));
+  explicit Socket(BarePort bare_port,
+                  NagleAlgorithm nagle_algorithm_policy = kDisableNagleAlgorithmByDefault,
+                  int max_connections = kMaxServerQueuedConnections)
+      : SocketHandle(SocketHandle::BindAndListen(), bare_port, nagle_algorithm_policy, max_connections) {
   }
 
-  Socket(Socket&&) = default;
+  explicit Socket(ReservedLocalPort&& reserved_port) : SocketHandle(std::move(reserved_port)) {}
 
-  inline Connection Accept() {
+  Socket(SocketHandle&& rhs) : SocketHandle(std::move(rhs)) {}
+  Socket(Socket&& rhs) : SocketHandle(std::move(rhs)) {}
+
+  Socket& operator=(Socket&& rhs) {
+    *static_cast<SocketHandle*>(this) = std::move(rhs);
+    rhs.socket_ = static_cast<SOCKET>(-1);
+    return *this;
+  }
+
+  Socket() = delete;
+  Socket(const Socket&) = delete;
+  Socket& operator=(const Socket&) = delete;
+
+  Connection Accept() {
     CURRENT_BRICKS_NET_LOG("S%05d accept() ...\n", static_cast<SOCKET>(socket));
     sockaddr_in addr_client;
     memset(&addr_client, 0, sizeof(addr_client));
@@ -484,14 +615,8 @@ class Socket final : public SocketHandle {
     }
     IPAndPort local(InetAddrToString(&addr_serv.sin_addr), ntohs(addr_serv.sin_port));
     IPAndPort remote(InetAddrToString(&addr_client.sin_addr), ntohs(addr_client.sin_port));
-    return Connection(SocketHandle::FromHandle(handle), std::move(local), std::move(remote));
+    return Connection(SocketHandle::FromAcceptedHandle(handle), std::move(local), std::move(remote));
   }
-
- private:
-  Socket() = delete;
-  Socket(const Socket& rhs) = delete;
-  void operator=(const Socket&) = delete;
-  void operator=(Socket&&) = delete;
 };
 
 // Smart wrapper for system-allocated `addrinfo` pointers.
@@ -532,8 +657,10 @@ template <typename T>
 inline Connection ClientSocket(const std::string& host, T port_or_serv) {
   class ClientSocket final : public SocketHandle {
    public:
-    inline explicit ClientSocket(const std::string& host, const std::string& serv)
-        : SocketHandle(SocketHandle::NewHandle()) {
+    explicit ClientSocket(const std::string& host,
+                          const std::string& serv, 
+                          NagleAlgorithm nagle_algorithm_policy = kDisableNagleAlgorithmByDefault)
+        : SocketHandle(SocketHandle::DoNotBind(), nagle_algorithm_policy) {
       CURRENT_BRICKS_NET_LOG("S%05d ", static_cast<SOCKET>(socket));
       // Deliberately left non-const because of possible Windows issues. -- M.Z.
       auto addr_info = GetAddrInfo(host, serv);

--- a/bricks/net/tcp/test.cc
+++ b/bricks/net/tcp/test.cc
@@ -291,9 +291,9 @@ TEST(TCPTest, ResolveAddress) {
   }
 }
 
-#if 1  // #ifndef CURRENT_WINDOWS -- NOTE(dkorolev): Testing this again in 2021.
-// Apparently, Windows has no problems opening two sockets on the same port -- D.K.
-// Tested on Visual Studio 2015 Preview.
+#ifndef CURRENT_WINDOWS
+// Apparently, Windows has no problems opening two sockets on the same port.
+// NOTE(dkorolev): Confirmed on Visual Studio 2015 Preview, as well as later in 2021.
 TEST(TCPTest, CanNotBindTwoSocketsToTheSamePortSimultaneously) {
   auto port_reservation = ReserveLocalPort();
   const uint16_t port_number = port_reservation;

--- a/examples/benchmark/generic/scenario_replication.h
+++ b/examples/benchmark/generic/scenario_replication.h
@@ -81,7 +81,7 @@ SCENARIO(stream_replication, "Replicate the Current stream of simple string entr
         entries_count = Value(stream)->Data()->Size();
       }
       stream_url = current::strings::Printf("127.0.0.1:%u", FLAGS_local_port);
-      scope += HTTP(FLAGS_local_port)
+      scope += HTTP(current::net::BarePort(FLAGS_local_port))
                    .Register("/", URLPathArgs::CountMask::None | URLPathArgs::CountMask::One, *Value(stream));
     } else {
       stream_url = FLAGS_remote_url;

--- a/examples/benchmark/generic/scenario_simple_http.h
+++ b/examples/benchmark/generic/scenario_simple_http.h
@@ -56,7 +56,7 @@ SCENARIO(current_http_server, "Use Current's HTTP stack for simple HTTP client-s
     for (uint16_t port = FLAGS_simple_http_local_port;
          port <= std::max(FLAGS_simple_http_local_top_port, FLAGS_simple_http_local_port);
          ++port) {
-      scope += HTTP(port).Register(FLAGS_simple_http_local_route, handler);
+      scope += HTTP(current::net::BarePort(port)).Register(FLAGS_simple_http_local_route, handler);
       urls.push_back("localhost:" + current::strings::ToString(port) + FLAGS_simple_http_local_route);
     }
   }

--- a/examples/benchmark/http/binary.cc
+++ b/examples/benchmark/http/binary.cc
@@ -30,10 +30,9 @@ SOFTWARE.
 using namespace current;
 
 DEFINE_string(benchmark_local_route, "/add", "The route spawn the server on.");
-DEFINE_int32(benchmark_local_port, PickPortForUnitTest(), "The local port to spawn the server on.");
 
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
 
-  BenchmarkTestServer(FLAGS_benchmark_local_port, FLAGS_benchmark_local_route).Join();
+  BenchmarkTestServer(current::net::ReserveLocalPort(), FLAGS_benchmark_local_route).Join();
 }

--- a/examples/benchmark/http/test.cc
+++ b/examples/benchmark/http/test.cc
@@ -27,18 +27,20 @@ SOFTWARE.
 #include "../../../bricks/dflags/dflags.h"
 #include "../../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(benchmark_test_local_port, PickPortForUnitTest(), "The local port to spawn test server on.");
-
 TEST(BenchmarkTest, OneAndOne) {
-  BenchmarkTestServer server(FLAGS_benchmark_test_local_port, "/add");
-  const auto response = HTTP(GET(Printf("http://localhost:%d/add?a=1&b=1", FLAGS_benchmark_test_local_port)));
+  auto reserved_port = current::net::ReserveLocalPort();
+  const int port = reserved_port;
+  BenchmarkTestServer server(std::move(reserved_port), "/add");
+  const auto response = HTTP(GET(Printf("http://localhost:%d/add?a=1&b=1", port)));
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_EQ(2, ParseJSON<AddResult>(response.body).sum);
 }
 
 TEST(BenchmarkTest, TenAndTen) {
-  BenchmarkTestServer server(FLAGS_benchmark_test_local_port, "/add");
-  const auto response = HTTP(GET(Printf("http://localhost:%d/add?a=10&b=10", FLAGS_benchmark_test_local_port)));
+  auto reserved_port = current::net::ReserveLocalPort();
+  const int port = reserved_port;
+  BenchmarkTestServer server(std::move(reserved_port), "/add");
+  const auto response = HTTP(GET(Printf("http://localhost:%d/add?a=10&b=10", port)));
   EXPECT_EQ(200, static_cast<int>(response.code));
   EXPECT_EQ(20, ParseJSON<AddResult>(response.body).sum);
 }

--- a/examples/datafest_talk/tier5_online_tool/nyc_taxi_dataset_service.h
+++ b/examples/datafest_talk/tier5_online_tool/nyc_taxi_dataset_service.h
@@ -110,7 +110,7 @@ class NYCTaxiDatasetServiceImpl {
   std::unordered_map<std::string, std::unique_ptr<CompiledUserFunction>> handlers_;
 
   HTTPRoutesScope RegisterRoutes(std::string route, uint16_t port) {
-    return HTTP(port).Register(route, URLPathArgs::CountMask::Any, [this](Request r) { Serve(std::move(r)); });
+    return HTTP(current::net::BarePort(port)).Register(route, URLPathArgs::CountMask::Any, [this](Request r) { Serve(std::move(r)); });
   }
 
   std::string ConstructSource(const std::string& body, const std::string& source_name = "code.cc") const {

--- a/examples/dynamic_dlopen/example.cc
+++ b/examples/dynamic_dlopen/example.cc
@@ -8,8 +8,9 @@ DEFINE_uint16(port, 3000, "The port to serve on.");
 
 int main(int argc, char** argv) {
   ParseDFlags(&argc, &argv);
-  DynamicDLOpenIrisExampleImpl impl(FLAGS_input_filename, FLAGS_port);
+  auto& http_server = HTTP(current::net::BarePort(FLAGS_port));
+  DynamicDLOpenIrisExampleImpl impl(FLAGS_input_filename, http_server);
   std::cout << "Working on " << impl.TotalFlowers() << " Iris flowers, listening on http://localhost:" << FLAGS_port
             << "." << std::endl;
-  HTTP(FLAGS_port).Join();
+  http_server.Join();
 }

--- a/examples/dynamic_dlopen/impl.h
+++ b/examples/dynamic_dlopen/impl.h
@@ -30,8 +30,8 @@ class DynamicDLOpenIrisExampleImpl {
   };
   std::unordered_map<std::string, std::unique_ptr<CompiledUserFunction>> handlers_;
 
-  HTTPRoutesScope RegisterRoutes(uint16_t port) {
-    return HTTP(port).Register("/", URLPathArgs::CountMask::Any, [this](Request r) { Serve(std::move(r)); });
+  HTTPRoutesScope RegisterRoutes(current::http::HTTPServerPOSIX& http) {
+    return http.Register("/", URLPathArgs::CountMask::Any, [this](Request r) { Serve(std::move(r)); });
   }
 
   void Serve(Request r) {
@@ -81,9 +81,10 @@ class DynamicDLOpenIrisExampleImpl {
   }
 
  public:
-  DynamicDLOpenIrisExampleImpl(Schema data, uint16_t port) : data_(std::move(data)), routes_(RegisterRoutes(port)) {}
-  DynamicDLOpenIrisExampleImpl(std::string filename, uint16_t port)
-      : data_(ParseJSON<Schema>(current::FileSystem::ReadFileAsString(filename))), routes_(RegisterRoutes(port)) {}
+  DynamicDLOpenIrisExampleImpl(Schema data, current::http::HTTPServerPOSIX& http)
+      : data_(std::move(data)), routes_(RegisterRoutes(http)) {}
+  DynamicDLOpenIrisExampleImpl(std::string filename, current::http::HTTPServerPOSIX& http)
+      : data_(ParseJSON<Schema>(current::FileSystem::ReadFileAsString(filename))), routes_(RegisterRoutes(http)) {}
 
   size_t TotalFlowers() const { return data_.size(); }
 };

--- a/examples/dynamic_dlopen/test.cc
+++ b/examples/dynamic_dlopen/test.cc
@@ -32,13 +32,14 @@ static const char* const kDefaultPathToIrisDataset = "../iris/data/dataset.json"
 static const char* const kDefaultPathToIrisDataset = "golden/dataset.json";
 #endif
 DEFINE_string(dlopen_example_test_input_filename, kDefaultPathToIrisDataset, "The input Irises dataset.");
-DEFINE_uint16(dlopen_example_test_port, PickPortForUnitTest(), "");
 
 #ifndef CURRENT_WINDOWS
 TEST(DLOpenExample, Smoke) {
-  DynamicDLOpenIrisExampleImpl impl(FLAGS_dlopen_example_test_input_filename, FLAGS_dlopen_example_test_port);
+  auto reserved_port = current::net::ReserveLocalPort();
+  const int port = reserved_port;
+  auto& http_server = HTTP(std::move(reserved_port));
 
-  const int port = static_cast<int>(FLAGS_dlopen_example_test_port);
+  DynamicDLOpenIrisExampleImpl impl(FLAGS_dlopen_example_test_input_filename, http_server);
 
   EXPECT_EQ(
       // clang-format off

--- a/examples/streamed_sockets/latencytest/workers/receiver.h
+++ b/examples/streamed_sockets/latencytest/workers/receiver.h
@@ -36,7 +36,7 @@ struct ReceivingWorker final {
   struct ReceivingWorkerImpl {
     current::net::Socket socket;
     current::net::Connection connection;
-    ReceivingWorkerImpl(uint16_t port) : socket(port), connection(socket.Accept()) {}
+    ReceivingWorkerImpl(uint16_t port) : socket(current::net::BarePort(port)), connection(socket.Accept()) {}
   };
   std::unique_ptr<ReceivingWorkerImpl> impl;
 

--- a/karl/claire.h
+++ b/karl/claire.h
@@ -111,7 +111,7 @@ class GenericClaire final : private DummyClaireNotifiable {
         karl_keepalive_route_(KarlKeepaliveRoute(karl_, codename_, port_)),
         notifiable_ref_(notifiable),
         us_start_(current::time::Now()),
-        http_scope_(HTTP(port).Register("/.current", [this](Request r) { ServeCurrent(std::move(r)); })),
+        http_scope_(HTTP(current::net::BarePort(port)).Register("/.current", [this](Request r) { ServeCurrent(std::move(r)); })),
         destructing_(false),
         keepalive_thread_force_wakeup_(false),
         keepalive_thread_running_(false) {}

--- a/karl/karl.h
+++ b/karl/karl.h
@@ -281,27 +281,27 @@ class GenericKarl final : private KarlStorage<STORAGE_TYPE>,
           state_update_thread_running_ = true;
           StateUpdateThread();
         }),
-        http_scope_(HTTP(parameters_.keepalives_port)
+        http_scope_(HTTP(current::net::BarePort(parameters_.keepalives_port))
                         .Register(parameters_.keepalives_url,
                                   URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
                                   [this](Request r) { AcceptKeepaliveViaHTTP(std::move(r)); }) +
-                    HTTP(parameters_.fleet_view_port)
+                    HTTP(current::net::BarePort(parameters_.fleet_view_port))
                         .Register(parameters_.fleet_view_url,
                                   URLPathArgs::CountMask::None,
                                   [this](Request r) { ServeFleetStatus(std::move(r)); }) +
-                    HTTP(parameters_.fleet_view_port)
+                    HTTP(current::net::BarePort(parameters_.fleet_view_port))
                         .Register(parameters_.fleet_view_url + "status",
                                   URLPathArgs::CountMask::None,
                                   [this](Request r) { ServeKarlStatus(std::move(r)); }) +
-                    HTTP(parameters_.fleet_view_port)
+                    HTTP(current::net::BarePort(parameters_.fleet_view_port))
                         .Register(parameters_.fleet_view_url + "build",
                                   URLPathArgs::CountMask::One,
                                   [this](Request r) { ServeBuild(std::move(r)); }) +
-                    HTTP(parameters_.fleet_view_port)
+                    HTTP(current::net::BarePort(parameters_.fleet_view_port))
                         .Register(parameters_.fleet_view_url + "snapshot",
                                   URLPathArgs::CountMask::One,
                                   [this](Request r) { ServeSnapshot(std::move(r)); }) +
-                    HTTP(parameters_.fleet_view_port)
+                    HTTP(current::net::BarePort(parameters_.fleet_view_port))
                         .Register(parameters_.fleet_view_url + "favicon.png", http::CurrentFaviconHandler())) {
     while (!state_update_thread_running_) {
       // Starting Karl is a rare operation, and it may take a while on an overloaded CPU.

--- a/karl/test.cc
+++ b/karl/test.cc
@@ -230,7 +230,7 @@ TEST(Karl, SmokeAnnotator) {
   }
 }
 
-#ifndef CURRENT_TRAVIS
+#ifndef CURRENT_CI_TRAVIS
 TEST(Karl, SmokeFilter) {
   current::time::ResetToZero();
 
@@ -287,7 +287,7 @@ TEST(Karl, SmokeFilter) {
     EXPECT_EQ("is_prime", per_ip_services[is_prime.ClaireCodename()].service);
   }
 }
-#endif  // !CURRENT_TRAVIS
+#endif  // !CURRENT_CI_TRAVIS
 
 TEST(Karl, Deregister) {
   current::time::ResetToZero();

--- a/karl/test_service/annotator.h
+++ b/karl/test_service/annotator.h
@@ -45,7 +45,7 @@ class ServiceAnnotator final {
       : source_numbers_stream_(service_generator + "/numbers"),
         is_prime_logic_endpoint_(service_is_prime + "/is_prime"),
         stream_(current::stream::Stream<Number>::CreateStream()),
-        http_scope_(HTTP(port).Register("/annotated", *stream_)),
+        http_scope_(HTTP(current::net::BarePort(port)).Register("/annotated", *stream_)),
         destructing_(false),
         http_stream_subscriber_(source_numbers_stream_, [this](idxts_t, Number && n) { OnNumber(std::move(n)); }),
         claire_(karl, "annotator", port, {service_generator, service_is_prime}) {

--- a/karl/test_service/filter.h
+++ b/karl/test_service/filter.h
@@ -44,8 +44,8 @@ class ServiceFilter final {
       : source_annotated_numbers_stream_(service_annotated + "/annotated"),
         stream_primes_(current::stream::Stream<Number>::CreateStream()),
         stream_composites_(current::stream::Stream<Number>::CreateStream()),
-        http_scope_(HTTP(port).Register("/primes", *stream_primes_) +
-                    HTTP(port).Register("/composites", *stream_composites_)),
+        http_scope_(HTTP(current::net::BarePort(port)).Register("/primes", *stream_primes_) +
+                    HTTP(current::net::BarePort(port)).Register("/composites", *stream_composites_)),
         http_stream_subscriber_(source_annotated_numbers_stream_,
                                 [this](idxts_t, Number && n) { OnNumber(std::move(n)); }),
         claire_(karl, "filter", port, {service_annotated}) {

--- a/karl/test_service/generator.h
+++ b/karl/test_service/generator.h
@@ -47,7 +47,7 @@ class ServiceGenerator final {
   ServiceGenerator(uint16_t port, std::chrono::microseconds sleep_between_numbers, const current::karl::Locator& karl)
       : current_value_(0),
         stream_(current::stream::Stream<Number>::CreateStream()),
-        http_scope_(HTTP(port).Register("/numbers", *stream_)),
+        http_scope_(HTTP(current::net::BarePort(port)).Register("/numbers", *stream_)),
         sleep_between_numbers_(sleep_between_numbers),
         destructing_(false),
         thread_([this]() { Thread(); }),

--- a/karl/test_service/is_prime.h
+++ b/karl/test_service/is_prime.h
@@ -52,7 +52,7 @@ class ServiceIsPrime final {
  public:
   explicit ServiceIsPrime(uint16_t port, const current::karl::Locator& karl)
       : counter_(0ull),
-        http_scope_(HTTP(port).Register("/is_prime",
+        http_scope_(HTTP(current::net::BarePort(port)).Register("/is_prime",
                                         [this](Request r) {
                                           ++counter_;
                                           r(IsPrime(current::FromString<int>(r.url.query.get("x", "0"))) ? "YES\n"

--- a/midichlorians/client/test.cc
+++ b/midichlorians/client/test.cc
@@ -55,8 +55,8 @@ class Server {
  public:
   using events_variant_t = Variant<ios_events_t>;
 
-  Server(current::net::ReservedPort reserved_port, const std::string& http_route)
-      : http_server_(std::move(reserved_port)),
+  Server(current::net::ReservedLocalPort reserved_port, const std::string& http_route)
+      : http_server_(HTTP(std::move(reserved_port))),
         routes_(http_server_.Register(http_route,
                                        [this](Request r) {
                                          events_variant_t event;

--- a/midichlorians/server/test.cc
+++ b/midichlorians/server/test.cc
@@ -246,7 +246,7 @@ TEST(midichloriansServer, iOSEventsFromCPPSmokeTest) {
   EXPECT_EQ("[12000][Error],[203000][Error]", Join(consumer.Errors(), ','));
 }
 
-#if defined(CURRENT_APPLE) && !defined(CURRENT_TRAVIS)
+#if defined(CURRENT_APPLE) && !defined(CURRENT_CI_TRAVIS)
 TEST(midichloriansServer, iOSEventsFromNativeClientSmokeTest) {
   current::time::ResetToZero();
 
@@ -291,7 +291,7 @@ TEST(midichloriansServer, iOSEventsFromNativeClientSmokeTest) {
       "[15000][iOSFocusEvent user_ms=15 gained_focus=false]",
       Join(consumer.Events(), ','));
 }
-#endif  // CURRENT_APPLE && !CURRENT_TRAVIS
+#endif  // CURRENT_APPLE && !CURRENT_CI_TRAVIS
 
 GET MockGETRequest(const std::string& base_url,
                    uint64_t ms,

--- a/midichlorians/server/test.cc
+++ b/midichlorians/server/test.cc
@@ -44,8 +44,6 @@ SOFTWARE.
 #include "../../bricks/dflags/dflags.h"
 #include "../../3rdparty/gtest/gtest-main-with-dflags.h"
 
-DEFINE_int32(midichlorians_server_test_port, PickPortForUnitTest(), "Local port to run the test.");
-
 namespace midichlorians_server_test {
 
 using current::strings::Join;
@@ -191,11 +189,15 @@ class GenericConsumer {
 TEST(midichloriansServer, iOSEventsFromCPPSmokeTest) {
   using namespace midichlorians_server_test;
 
+  auto reserved_port = current::net::ReserveLocalPort();
+  const int port = reserved_port;
+  auto& http_server = HTTP(std::move(reserved_port));
+  static_cast<void>(http_server);
+
   current::time::ResetToZero();
   GenericConsumer consumer;
-  midichloriansHTTPServer<GenericConsumer> server(
-      FLAGS_midichlorians_server_test_port, consumer, std::chrono::milliseconds(100), "/log", "OK\n");
-  const std::string server_url = Printf("http://localhost:%d/log", FLAGS_midichlorians_server_test_port);
+  midichloriansHTTPServer<GenericConsumer> server(port, consumer, std::chrono::milliseconds(100), "/log", "OK\n");
+  const std::string server_url = Printf("http://localhost:%d/log", port);
 
   current::time::SetNow(std::chrono::microseconds(12000));
   iOSAppLaunchEvent launch_event;
@@ -248,16 +250,20 @@ TEST(midichloriansServer, iOSEventsFromCPPSmokeTest) {
 TEST(midichloriansServer, iOSEventsFromNativeClientSmokeTest) {
   current::time::ResetToZero();
 
+  auto reserved_port = current::net::ReserveLocalPort();
+  const int port = reserved_port;
+  auto& http_server = HTTP(std::move(reserved_port));
+  static_cast<void>(http_server);
+
   using namespace midichlorians_server_test;
   using namespace current::midichlorians::server;
 
   current::time::ResetToZero();
   GenericConsumer consumer;
-  midichloriansHTTPServer<GenericConsumer> server(
-      FLAGS_midichlorians_server_test_port, consumer, std::chrono::milliseconds(100), "/log", "OK\n");
+  midichloriansHTTPServer<GenericConsumer> server(port, consumer, std::chrono::milliseconds(100), "/log", "OK\n");
 
   NSDictionary* launchOptions = [NSDictionary new];
-  [midichlorians setup:[NSString stringWithFormat:@"http://localhost:%d/log", FLAGS_midichlorians_server_test_port]
+  [midichlorians setup:[NSString stringWithFormat:@"http://localhost:%d/log", port]
       withLaunchOptions:launchOptions];
 
   current::time::SetNow(std::chrono::microseconds(1000));
@@ -318,6 +324,11 @@ POST MockPOSTRequest(const std::string& base_url,
 TEST(midichloriansServer, WebEventsFromCPPSmokeTest) {
   current::time::ResetToZero();
 
+  auto reserved_port = current::net::ReserveLocalPort();
+  const int port = reserved_port;
+  auto& http_server = HTTP(std::move(reserved_port));
+  static_cast<void>(http_server);
+
   using namespace midichlorians_server_test;
 
   using namespace current::midichlorians::server;
@@ -325,9 +336,8 @@ TEST(midichloriansServer, WebEventsFromCPPSmokeTest) {
 
   current::time::ResetToZero();
   GenericConsumer consumer;
-  midichloriansHTTPServer<GenericConsumer> server(
-      FLAGS_midichlorians_server_test_port, consumer, std::chrono::milliseconds(100), "/log", "OK\n");
-  const std::string server_url = Printf("http://localhost:%d/log", FLAGS_midichlorians_server_test_port);
+  midichloriansHTTPServer<GenericConsumer> server(port, consumer, std::chrono::milliseconds(100), "/log", "OK\n");
+  const std::string server_url = Printf("http://localhost:%d/log", port);
 
   current::time::SetNow(std::chrono::microseconds(1000));
   const auto response1 = HTTP(MockGETRequest(server_url, 1, "Fg"));

--- a/port.h
+++ b/port.h
@@ -202,15 +202,7 @@ struct is_same_or_compile_error {
   enum { value = std::is_same_v<T1, T2> };
   char is_same_static_assert_failed[value ? 1 : -1];
 };
-
-// Unit test ports begin with 19999 by default and go down from there.
-#define PickPortForUnitTest() PortForUnitTestPicker::PickOne()
-struct PortForUnitTestPicker {
-  static uint16_t PickOne() {
-    static uint16_t port = 20000;
-    return --port;
-  }
-};
+#define CURRENT_FAIL_IF_NOT_SAME_TYPE(A,B) static_assert(sizeof(is_same_or_compile_error<A, B>), "")
 
 #ifdef CURRENT_JAVA
 #error "Current has not been tested with Java for a while, and would likely require a bit of TLC. Thank you."

--- a/scripts/individual-tests.sh
+++ b/scripts/individual-tests.sh
@@ -17,12 +17,12 @@ for i in $(find . -name test.cc | sort) ; do
   MD5=$(echo $DIR | md5sum)
   HASH=$((0x${MD5%% *}))
   SHARD=$((((HASH % DESIRED_MOD) + DESIRED_MOD) % DESIRED_MOD))
-  echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m${DIR}\033[0m"
+  if [[ $DESIRED_MOD == 1 ]]; then
+    echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m${DIR}\033[0m"
+  fi
   if [[ " ${EXCLUDE[@]} " =~ " $DIR " ]]; then
     echo "Excluded."
-  elif [[ $SHARD != $DESIRED_SHARD ]]; then
-    echo "In another shard."
-  else
+  elif [[ $SHARD == $DESIRED_SHARD ]]; then
     cd $DIR
     if ! make -s test ; then
       FAILURES="$FAILURES\n- $DIR"
@@ -31,18 +31,22 @@ for i in $(find . -name test.cc | sort) ; do
   fi
 done
 
-# And a dedicated run for the `dlopen()`-based compilation that involves a symlink to the very Current.
-  echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m./bricks/system\033[0m [with --current_base_dir_for_dlopen_test set]"
-( \
-  DIR=$(./scripts/fullpath.sh $PWD) && \
-  cd bricks/system && \
-  make .current/test > /dev/null \
-  && ./.current/test --current_base_dir_for_dlopen_test=$DIR \
-) || FAILURES="$FAILURES\n- bricks/system [with --current_base_dir_for_dlopen_test set]"
+if [[ $DESIRED_SHARD == 0 ]]; then
+  # And a dedicated run for the `dlopen()`-based compilation that involves a symlink to the very Current.
+    echo -e "\n\033[0m\033[1mDir\033[0m: \033[36m./bricks/system\033[0m [with --current_base_dir_for_dlopen_test set]"
+  ( \
+    DIR=$(./scripts/fullpath.sh $PWD) && \
+    cd bricks/system && \
+    make .current/test > /dev/null \
+    && ./.current/test --current_base_dir_for_dlopen_test=$DIR \
+  ) || FAILURES="$FAILURES\n- bricks/system [with --current_base_dir_for_dlopen_test set]"
+fi
 
 if [ "$FAILURES" = "" ] ; then
- echo -e "\n\033[32m\033[1mALL TESTS PASS.\033[0m"
- exit 0
+  if [[ $DESIRED_MOD == 1 ]]; then
+    echo -e "\n\033[32m\033[1mALL TESTS PASS.\033[0m"
+  fi
+  exit 0
 else
  echo -e "\n\033[31m\033[1mFAIL\033[0m"
  echo -e "Failed tests:$FAILURES"

--- a/storage/api.h
+++ b/storage/api.h
@@ -515,7 +515,7 @@ class RESTfulStorage {
   void SwitchHTTPEndpointsTo503s() {
     data_->up_status_ = false;
     for (auto& route : data_->handler_routes_) {
-      HTTP(data_->port_)
+      HTTP(current::net::BarePort(data_->port_))
           .template Register<ReRegisterRoute::SilentlyUpdateExisting>(route.first, route.second, Serve503);
     }
   }
@@ -565,7 +565,7 @@ class RESTfulStorage {
     const auto path = data_->route_prefix_ + '/' + route.resource_prefix +
                       (field_name.empty() ? "" : '/' + field_name) + route.resource_suffix;
     data_->handler_routes_.emplace_back(path, route.resource_args_mask);
-    data_->handlers_scope_ += HTTP(data_->port_).Register(path, route.resource_args_mask, route.handler);
+    data_->handlers_scope_ += HTTP(current::net::BarePort(data_->port_)).Register(path, route.resource_args_mask, route.handler);
   }
 
   template <typename T, url::FillObjectMode MODE>

--- a/storage/persister/stream.h
+++ b/storage/persister/stream.h
@@ -140,9 +140,10 @@ class StreamStreamPersisterImpl final {
   }
 
   void ExposeRawLogViaHTTP(uint16_t port, const std::string& route) {
-    handlers_scope_ += HTTP(port).Register(route,
-                                           URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
-                                           [this](Request r) { (*Borrowed<stream_t>(stream_))(std::move(r)); });
+    handlers_scope_ += HTTP(current::net::BarePort(port)).Register(
+        route,
+        URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
+        [this](Request r) { (*Borrowed<stream_t>(stream_))(std::move(r)); });
   }
 
   Borrowed<stream_t> BorrowStream() const { return stream_; }

--- a/storage/test_helpers.cc
+++ b/storage/test_helpers.cc
@@ -58,8 +58,6 @@ DEFINE_string(transactional_storage_test_tmpdir, ".current", "Local path for the
 DEFINE_string(transactional_storage_test_tmpdir, "Debug", "Local path for the test to create temporary files in.");
 #endif
 
-DEFINE_int32(transactional_storage_test_port, PickPortForUnitTest(), "Local port to run [REST] API tests against.");
-
 #endif  // !CURRENT_MAKE_CHECK_MODE
 
 namespace transactional_storage_test {

--- a/stream/replicator.h
+++ b/stream/replicator.h
@@ -552,10 +552,12 @@ class MasterFlipController final {
     exposed_via_http_ = std::make_unique<ExposedStreamState>(
         port, route, std::move(restrictions), flip_started, flip_finished, flip_canceled);
     exposed_via_http_->routes_scope_ +=
-        HTTP(port).Register(route, URLPathArgs::CountMask::None | URLPathArgs::CountMask::One, *Value(stream_)) +
-        HTTP(port).Register(route + "/control/flip_to_master",
-                            URLPathArgs::CountMask::None,
-                            [this](Request r) { MasterFlipRequest(std::move(r)); });
+        HTTP(current::net::BarePort(port)).Register(route,
+                                                    URLPathArgs::CountMask::None | URLPathArgs::CountMask::One,
+                                                    *Value(stream_)) +
+        HTTP(current::net::BarePort(port)).Register(route + "/control/flip_to_master",
+                                                    URLPathArgs::CountMask::None,
+                                                    [this](Request r) { MasterFlipRequest(std::move(r)); });
     return exposed_via_http_->flip_key_;
   }
 


### PR DESCRIPTION
Max,

Sorry, couldn't stop: prototyping how modules could talk to one another, and realized "hard-coded" test ports are now on the critical path. So I fixed it. :-)

1. Fully retired the ugly `PickPortForUnitTest()`.

To accomplish this I've added a special type for the "reserved port", which holds the port. Sockets, as well the HTTP server, can be move-constructed from it. And there is a global function, `current::net::ReserveLocalPort()`, which finds a free local port, honds on to it, and returns it.

Tested:

```
# Build a debug test binary of `bricks/net/tcp`.
g++ -g -std=c++17 -W -Wall -Wno-strict-aliasing   -o ".current/test" "test.cc" -pthread -ldl

# Run in several terminals in parallel.
ulimit -c unlimited ; \
rm -f core ; \
while true ; do \
  ./.current/test \
     --gtest_throw_on_failure \
     --gtest_catch_exceptions=0 || break ;
done
```

The "canonical" test use syntax is:

```
// Reserve the port.
auto reserved_port = current::net::ReserveLocalPort();
// Extract it as `int` (`uint16_t` works too, but `int` is "%s"-frienldy w/o extra casts).
const int port = reserved_port;
// If the "legacy" code requires "just" a port (and "spawns" an HTTP server itself),
// then create the HTTP server by `std::move()`-ing this reserved port into `HTTP()`.
auto& http_server = HTTP(std::move(reserved_port));
static_cast<void>(http_server);
```
I've also made it such that in order to use a bare port for a socket it should be wrapped into `current::net::BarePort(desired_port)`. Originally, I thought it'd only be a change for during my development, but ultimately I decided to keep it this way. Hope you'll endorse it, open to suggestions regardless.

2. Added the `individual_tests_all_8` make target, which can be run with `make -j`.

Running tests in parallel is now possible, as they don't conflict on ports. On my laptop now:

```
$ time make -j individual_tests_all_8
real	1m50.030s
user	9m12.683s
sys	0m32.194s
```

I've also changed the runs for OS X on Travis accordingly.

As in the previous PR: pls don't worry about possible long lines, `clang-format-10` will change everything regardless =)