### PR TITLE
Fixing `using namespace` for `CURRENT_STRUCT`-s.

### DIFF
--- a/typesystem/base.h
+++ b/typesystem/base.h
@@ -86,4 +86,6 @@ using ::crnt::r::TypeSelector;
 }  // namespace current::reflection
 }  // namespace current
 
+#define CRH_FOR(type) decltype(CRHTypeExtractor(std::declval<::crnt::r::TypeSelector<type>>()))
+
 #endif  // CURRENT_TYPE_SYSTEM_BASE_H

--- a/typesystem/base.h
+++ b/typesystem/base.h
@@ -86,6 +86,4 @@ using ::crnt::r::TypeSelector;
 }  // namespace current::reflection
 }  // namespace current
 
-#define CRH_FOR(type) decltype(CRHTypeExtractor(std::declval<::crnt::r::TypeSelector<type>>()))
-
 #endif  // CURRENT_TYPE_SYSTEM_BASE_H

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -165,17 +165,15 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   template <typename INSTANTIATION_TYPE>                                           \
   struct CSI_##s;                                                                  \
   using s = CSI_##s<::crnt::r::DF>;                                                \
-  template <typename>                                                              \
-  struct CRH;                                                                      \
-  template <>                                                                      \
-  struct CRH<s> {                                                                  \
+  struct CRH_##s final {                                                           \
     constexpr static size_t CURRENT_FIELD_INDEX_BASE_IMPL = __COUNTER__;           \
     constexpr static const char* CURRENT_STRUCT_NAME() { return #s; }              \
     typedef CSI_##s<::crnt::r::FC> CURRENT_FIELD_COUNT_STRUCT;                     \
-    using FIELD_INDEX_BASE = ::crnt::r::FIELD_INDEX_BASE_IMPL<CRH<s>>;             \
+    using FIELD_INDEX_BASE = ::crnt::r::FIELD_INDEX_BASE_IMPL<CRH_##s>;            \
   };                                                                               \
+  inline CRH_##s CRHTypeExtractor(::crnt::r::TypeSelector<s>);                     \
   struct CSSH_##s {                                                                \
-    using FIELD_INDEX_BASE = typename CRH<s>::FIELD_INDEX_BASE;                    \
+    using FIELD_INDEX_BASE = typename CRH_##s::FIELD_INDEX_BASE;                   \
     using INTERNAL_SUPER = super;                                                  \
     using template_inner_t_0 = void;                                               \
   }
@@ -209,7 +207,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CURRENT_STRUCT_NOT_DERIVED(s)               \
   CURRENT_STRUCT_HELPERS(s, ::crnt::CurrentStruct); \
   template <typename INSTANTIATION_TYPE>            \
-  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH<s>, INSTANTIATION_TYPE, ::crnt::CurrentStruct, std::false_type>
+  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, ::crnt::CurrentStruct, std::false_type>
 
 #define CURRENT_STRUCT_T_NOT_DERIVED(s)                                    \
   CURRENT_STRUCT_T_HELPERS(s, ::crnt::CurrentStruct);                      \
@@ -222,7 +220,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   static_assert(IS_CURRENT_STRUCT(base), #base " must be derived from `::crnt::CurrentStruct`."); \
   CURRENT_STRUCT_HELPERS(s, base);                                                                \
   template <typename INSTANTIATION_TYPE>                                                          \
-  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH<s>, INSTANTIATION_TYPE, base, std::false_type>
+  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, base, std::false_type>
 
 // TODO(dkorolev): I've sacrificed the `static_assert(IS_CURRENT_STRUCT(base), #base " must be ...");` for now.
 // TODO(dkorolev): It can be re-inserted back via a helper class to inherit from. Not now. -- D.K.
@@ -332,7 +330,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CURRENT_CONSTRUCTOR(s)                                                                                   \
   template <                                                                                                     \
       class SUPER =                                                                                              \
-          ::crnt::r::SUPER_IMPL<CRH<s>, INSTANTIATION_TYPE, typename CSSH_##s::INTERNAL_SUPER, std::false_type>, \
+          ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, typename CSSH_##s::INTERNAL_SUPER, std::false_type>, \
       typename INSTANTIATION_TYPE_IMPL = INSTANTIATION_TYPE,                                                     \
       class = std::enable_if_t<std::is_same_v<INSTANTIATION_TYPE_IMPL, ::current::reflection::DeclareFields>>>   \
   CSI_##s
@@ -370,7 +368,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 // as they are always the base class to the "s" regardless of what the INSTANTIATION_TYPE is.
 
 #define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                             \
-  using CRNT_super_t = ::crnt::r::SUPER_IMPL<CRH<s>, INSTANTIATION_TYPE, CSSH_##s::INTERNAL_SUPER, std::false_type>; \
+  using CRNT_super_t = ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, CSSH_##s::INTERNAL_SUPER, std::false_type>; \
   using CRNT_super_t::CRNT_super_t
 
 #define CURRENT_USE_T_BASE_CONSTRUCTORS(s)                                                                   \

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -327,12 +327,12 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   static ::crnt::r::FieldTypeWrapper<CURRENT_REMOVE_PARENTHESES(type)> CURRENT_REFLECTION(                             \
       ::current::reflection::Index<::current::reflection::FieldType, idx>);
 
-#define CURRENT_CONSTRUCTOR(s)                                                                                   \
-  template <                                                                                                     \
-      class SUPER =                                                                                              \
+#define CURRENT_CONSTRUCTOR(s)                                                                                    \
+  template <                                                                                                      \
+      class SUPER =                                                                                               \
           ::crnt::r::SUPER_IMPL<CRH_##s, INSTANTIATION_TYPE, typename CSSH_##s::INTERNAL_SUPER, std::false_type>, \
-      typename INSTANTIATION_TYPE_IMPL = INSTANTIATION_TYPE,                                                     \
-      class = std::enable_if_t<std::is_same_v<INSTANTIATION_TYPE_IMPL, ::current::reflection::DeclareFields>>>   \
+      typename INSTANTIATION_TYPE_IMPL = INSTANTIATION_TYPE,                                                      \
+      class = std::enable_if_t<std::is_same_v<INSTANTIATION_TYPE_IMPL, ::current::reflection::DeclareFields>>>    \
   CSI_##s
 
 #define CURRENT_ASSIGN_OPER(s)                                                                                   \
@@ -367,7 +367,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 // Use CSSH_##s and CURRENT_STRUCT_T_SUPER_HELPER_##s for this cases instead,
 // as they are always the base class to the "s" regardless of what the INSTANTIATION_TYPE is.
 
-#define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                             \
+#define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                              \
   using CRNT_super_t = ::crnt::r::SUPER_IMPL<CRH_##s, INSTANTIATION_TYPE, CSSH_##s::INTERNAL_SUPER, std::false_type>; \
   using CRNT_super_t::CRNT_super_t
 

--- a/typesystem/struct.h
+++ b/typesystem/struct.h
@@ -207,7 +207,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CURRENT_STRUCT_NOT_DERIVED(s)               \
   CURRENT_STRUCT_HELPERS(s, ::crnt::CurrentStruct); \
   template <typename INSTANTIATION_TYPE>            \
-  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, ::crnt::CurrentStruct, std::false_type>
+  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH_##s, INSTANTIATION_TYPE, ::crnt::CurrentStruct, std::false_type>
 
 #define CURRENT_STRUCT_T_NOT_DERIVED(s)                                    \
   CURRENT_STRUCT_T_HELPERS(s, ::crnt::CurrentStruct);                      \
@@ -220,7 +220,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
   static_assert(IS_CURRENT_STRUCT(base), #base " must be derived from `::crnt::CurrentStruct`."); \
   CURRENT_STRUCT_HELPERS(s, base);                                                                \
   template <typename INSTANTIATION_TYPE>                                                          \
-  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, base, std::false_type>
+  struct CSI_##s : CSSH_##s, ::crnt::r::SUPER_IMPL<CRH_##s, INSTANTIATION_TYPE, base, std::false_type>
 
 // TODO(dkorolev): I've sacrificed the `static_assert(IS_CURRENT_STRUCT(base), #base " must be ...");` for now.
 // TODO(dkorolev): It can be re-inserted back via a helper class to inherit from. Not now. -- D.K.
@@ -330,7 +330,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 #define CURRENT_CONSTRUCTOR(s)                                                                                   \
   template <                                                                                                     \
       class SUPER =                                                                                              \
-          ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, typename CSSH_##s::INTERNAL_SUPER, std::false_type>, \
+          ::crnt::r::SUPER_IMPL<CRH_##s, INSTANTIATION_TYPE, typename CSSH_##s::INTERNAL_SUPER, std::false_type>, \
       typename INSTANTIATION_TYPE_IMPL = INSTANTIATION_TYPE,                                                     \
       class = std::enable_if_t<std::is_same_v<INSTANTIATION_TYPE_IMPL, ::current::reflection::DeclareFields>>>   \
   CSI_##s
@@ -368,7 +368,7 @@ struct CurrentStructFieldsConsistency<T, 0u> {
 // as they are always the base class to the "s" regardless of what the INSTANTIATION_TYPE is.
 
 #define CURRENT_USE_BASE_CONSTRUCTORS(s)                                                                             \
-  using CRNT_super_t = ::crnt::r::SUPER_IMPL<CRH_FOR(s), INSTANTIATION_TYPE, CSSH_##s::INTERNAL_SUPER, std::false_type>; \
+  using CRNT_super_t = ::crnt::r::SUPER_IMPL<CRH_##s, INSTANTIATION_TYPE, CSSH_##s::INTERNAL_SUPER, std::false_type>; \
   using CRNT_super_t::CRNT_super_t
 
 #define CURRENT_USE_T_BASE_CONSTRUCTORS(s)                                                                   \

--- a/typesystem/test.cc
+++ b/typesystem/test.cc
@@ -1564,3 +1564,19 @@ TEST(TypeSystemTest, Patch) {
   object.PatchWith(delta_object);
   EXPECT_EQ(32, object.y);
 }
+
+namespace struct_definition_test {
+namespace inner_namespace_fails_in_april_2021 {
+namespace when_the_using_declaration_is_used {
+CURRENT_STRUCT(CurrentStructWithinNamespace) {};
+}  // namespace struct_definition_test::inner_namespace_fails_in_april_2021::when_the_using_declaration_is_used
+using namespace when_the_using_declaration_is_used;
+CURRENT_STRUCT(CurrentStructOutsideNamespace) {};
+}  // namespace struct_definition_test::inner_namespace_fails_in_april_2021
+}  // namespace struct_definition_test
+
+TEST(TypeSystemTest, UsingNamespace) {
+  using namespace struct_definition_test::inner_namespace_fails_in_april_2021;
+  CurrentStructWithinNamespace one;
+  CurrentStructOutsideNamespace two;
+}


### PR DESCRIPTION
Hi @mzhurovich,

This tweak makes it possible to reach into inner namespace with `using` and not have troubles with `CURRENT_STRUCT`-s. Tested on Windows and Linux, and the first commit illustrates what used to break before the fix, and how.

Ready to merge from my end.

Thanks,
Dima

~~... this description to be edited once the fix is a) confirmed to work, and b) is clean enough to review and to check into `C5T/stable`.~~