### PR TITLE
Added multiline `ProgressLine` support.

### DIFF
--- a/blocks/xterm/example.cc
+++ b/blocks/xterm/example.cc
@@ -5,9 +5,16 @@
 #include "progress.h"
 #include "vt100.h"
 
-inline void wait() { std::this_thread::sleep_for(std::chrono::seconds(1)); }
+#include "../../bricks/dflags/dflags.h"
 
-int main() {
+DEFINE_double(progress_line_delay, 0.5, "The delay, in seconds, between progress updates.");
+
+inline void wait() {
+  std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int64_t>(1e3 * FLAGS_progress_line_delay)));
+}
+
+int main(int argc, char** argv) {
+  ParseDFlags(&argc, &argv);
   {
     // Basic VT100 demo.
     using namespace current::vt100;
@@ -131,8 +138,8 @@ int main() {
     // Progress lines that are "above" the "current" line.
     using namespace current::vt100;
     {
-      current::ProgressLine line1(std::cerr, []() { return 1; });
-      current::ProgressLine line2(std::cerr, []() { return 0; });
+      current::ProgressLine line1(std::cout, []() { return 1; });
+      current::ProgressLine line2(std::cout, []() { return 0; });
       line1 << "Line1: ";
       line2 << "Line2: ";
       wait();

--- a/blocks/xterm/example.cc
+++ b/blocks/xterm/example.cc
@@ -126,4 +126,56 @@ int main() {
     std::cout << down(1) << '\n' << "The final line." << std::endl;
     wait();
   }
+
+  {
+    // Progress lines that are "above" the "current" line.
+    using namespace current::vt100;
+    {
+      current::ProgressLine line1(std::cerr, []() { return 1; });
+      current::ProgressLine line2(std::cerr, []() { return 0; });
+      line1 << "Line1: ";
+      line2 << "Line2: ";
+      wait();
+      line1 << "Line1: A";
+      wait();
+      line2 << "Line2: AB";
+      wait();
+      line1 << "Line1: ABC";
+      wait();
+      line2 << "Line2: ABCD";
+      wait();
+      line1 << "Line1: Done.";
+      wait();
+      line2 << "Line2: Done.";
+      wait();
+    }
+    std::cout << "Two static progress lines are done." << std::endl;
+    wait();
+  }
+
+  {
+    // The multiline progress line, with new, dynamically added, lines.
+    using namespace current::vt100;
+    current::MultilineProgress multiline_progress;
+    current::ProgressLine line1 = multiline_progress();
+    line1 << "Line one: foo.";
+    wait();
+    line1 << "Line one: OK";
+    wait();
+    auto line2 = multiline_progress();
+    line2 << "Line two: blah";
+    line1 << "Line one: OK, and now with line two added.";
+    wait();
+    line2 << "Line two: OK";
+    wait();
+    line1 << "Line one: OK";
+    wait();
+    auto line3 = multiline_progress();
+    line3 << "Line three: aaaaaand " << blue << " line " << default_color << bold << " three " << reset << " ...";
+    wait();
+    line3 << "Line three: OK";
+    wait();
+    std::cout << "Three dynamic progress lines are done." << std::endl;
+    wait();
+  }
 }

--- a/blocks/xterm/example.cc
+++ b/blocks/xterm/example.cc
@@ -14,12 +14,16 @@ int main() {
 
     std::cout << "Default, " << bold << "bold" << normal << ", " << dim << "dim" << normal << ", done."
               << std::endl;
+#ifndef CURRENT_WINDOWS
     std::cout << "Default, " << italic << "italic" << noitalic << '.' << std::endl;
+#endif  // CURRENT_WINDOWS
     std::cout << "Default, " << underlined << "underlined" << nounderlined << '.' << std::endl;
+#ifndef CURRENT_WINDOWS
     std::cout << "Default, " << doubleunderlined << "double underlined" << nounderlined << '.' << std::endl;
     std::cout << "Default, " << strikeout << "strikeout" << nostrikeout << '.' << std::endl;
     std::cout << "Default, " << bold << italic << underlined << "bold & italic & underlined" << reset << '.'
               << std::endl;
+#endif  // CURRENT_WINDOWS
 
     std::ostringstream oss;
     oss << default_color << ", ";
@@ -45,7 +49,7 @@ int main() {
 
   {
     // Smoke test.
-    std::cout << "Test1> ";
+    std::cout << "Test> ";
     {
       current::ProgressLine progress;
       progress << "Hello,";
@@ -58,10 +62,12 @@ int main() {
     }
     std::cout << "Done." << std::endl;
   }
+
+#ifndef CURRENT_WINDOWS
   {
     // Cyrillic.
-    // Does not work on Windows. -- D.K.
-    std::cout << "Test2> ";
+    // Does not work correctly on Windows. -- D.K.
+    std::cout << "Test> ";
     {
       current::ProgressLine progress;
       progress << u8"Привет...";
@@ -73,6 +79,7 @@ int main() {
     }
     std::cout << "Done." << std::endl;
   }
+  #endif
 
   if (false) {
     // NOTE(dkorolev): This fails on my Linux. :/ Prints `Test3> tttesting ... OK`, then `Test3> ttDone.` at the end.
@@ -94,7 +101,7 @@ int main() {
 
   {
     // VT100 decorations.
-    std::cout << "Test3> ";
+    std::cout << "Test> ";
     {
       using namespace current::vt100;
       current::ProgressLine progress;

--- a/blocks/xterm/example.cc
+++ b/blocks/xterm/example.cc
@@ -107,4 +107,16 @@ int main() {
     }
     std::cout << "Done." << std::endl;
   }
+
+  {
+    // Multiline example.
+    using namespace current::vt100;
+    std::cout << "Line one.\nLine two unaltered ...\nLine three.\n" << std::flush;
+    wait();
+    std::cout << up(2);
+    std::cout << "Line two, altered!    \b\b\b\b" << std::flush;
+    wait();
+    std::cout << down(1) << '\n' << "The final line." << std::endl;
+    wait();
+  }
 }

--- a/blocks/xterm/multiline.cc
+++ b/blocks/xterm/multiline.cc
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <thread>
+
+#include "progress.h"
+#include "vt100.h"
+
+#include "../../bricks/util/random.h"
+
+int main() {
+  current::MultilineProgress multiline_progress;
+  std::vector<std::thread> threads;
+  int index = 0u;
+  do {
+    threads.emplace_back([&multiline_progress](int index) {
+        current::ProgressLine line = multiline_progress();
+        const double k = current::random::RandomDouble(0.01, 0.04);
+        const double b = current::random::RandomDouble(0.0, 6.28);
+        const double a = current::random::RandomDouble(20, 45);
+        const auto t0 = current::time::Now();
+        while (true) {
+          line << "Line" << index << ": " << std::string(static_cast<size_t>(
+            0.5 * (std::sin((current::time::Now() - t0).count() * 1e-3 * k + b) + 1.0) * a), '*');
+          std::this_thread::sleep_for(std::chrono::milliseconds(current::random::RandomInt(1, 25)));
+        }
+    }, ++index);
+    std::this_thread::sleep_for(std::chrono::milliseconds(current::random::RandomInt(500, 2500 * index)));
+  } while (true);
+}

--- a/blocks/xterm/progress.h
+++ b/blocks/xterm/progress.h
@@ -48,8 +48,8 @@ class ProgressLine final {
   std::string current_undecorated_status_;
   size_t current_status_length_ = 0u;  // W/o VT100 escape sequences. -- D.K.
 
-  std::unique_ptr<std::unique_lock<std::mutex>> MaybeLock() {
-    return maybe_mutex_ ? std::make_unique<std::unique_lock<std::mutex>>(*maybe_mutex_) : nullptr;
+  std::unique_lock<std::mutex> MaybeLock() {
+    return maybe_mutex_ ? std::unique_lock<std::mutex>(*maybe_mutex_) : std::unique_lock<std::mutex>();
   }
 
   void DoClearString(std::ostream& os) const {

--- a/blocks/xterm/test.cc
+++ b/blocks/xterm/test.cc
@@ -1,0 +1,50 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2021 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#include "progress.h"
+
+#include <thread>
+
+#include "../../3rdparty/gtest/gtest-main-with-dflags.h"
+
+#ifndef CURRENT_CI
+DEFINE_double(progress_line_delay, 0.5, "The delay, in seconds, between progress updates.");
+#else
+DEFINE_double(progress_line_delay, 0, "The delay, in seconds, between progress updates.");
+#endif  // CURRENT_CI
+
+TEST(ProgressLine, GetUndecoratedString) {
+  current::ProgressLine progress;
+  using namespace current::vt100;
+  EXPECT_EQ("", progress.GetUndecoratedString());
+  progress << bold << green << "[----------]" << reset << " Testing ...";
+  EXPECT_EQ("[----------] Testing ...", progress.GetUndecoratedString());
+  std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int64_t>(1e3 * FLAGS_progress_line_delay)));
+  progress << bold << green << "[----------]" << reset << ' ' << italic << red << "CO" << green << "LO" << blue << "RS";
+  EXPECT_EQ("[----------] COLORS", progress.GetUndecoratedString());
+  std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int64_t>(1e3 * FLAGS_progress_line_delay)));
+  progress << bold << green << "[----------]" << reset << bold << " OK!";
+  EXPECT_EQ("[----------] OK!", progress.GetUndecoratedString());
+  std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int64_t>(1e3 * FLAGS_progress_line_delay)));
+}

--- a/blocks/xterm/vt100.h
+++ b/blocks/xterm/vt100.h
@@ -44,7 +44,7 @@ struct E {
   E(int code) : code(code) {}
 };
 
-struct Color : E {
+struct Color final : E {
   using E::E;
 };
 
@@ -92,11 +92,34 @@ DEFINE_VT100(97, white);
 
 inline E background(Color c) { return E(c.code + 10); }
 
+// Move the caret up or down.
+struct UD final {
+  const int down = 0;
+  explicit UD(int by) : down(by) {}
+};
+
+inline UD up(int d) {
+  return UD(-d);
+}
+
+inline UD down(int d) {
+  return UD(+d);
+}
+
 }  // namespace current::vt100
 }  // namespace current
 
 inline std::ostream& operator<<(std::ostream& os, const current::vt100::E& e) {
   os << "\x1b[" << e.code << 'm';  // `\x1b` is same as `\e`, but the latter is not suppored by Visual Studio. -- D.K.
+  return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const current::vt100::UD& ud) {
+  if (ud.down < 0) {
+    os << "\x1b[" << -ud.down << 'A';
+  } else if (ud.down > 0) {
+    os << "\x1b[" << ud.down << 'B';
+  }
   return os;
 }
 

--- a/blocks/xterm/xterm.vcxproj
+++ b/blocks/xterm/xterm.vcxproj
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{48AC2552-330F-42E2-BE8C-321C7649FD70}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <OptimizeReferences>false</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <OptimizeReferences>false</OptimizeReferences>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="example.cc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="vt100.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Hi @mzhurovich,

This adds the ability to move the caret up and down using terminal escape sequences, as well as a prototype for a "progress line" that has multiple lines updated simultaneously. I.e., the user can have:

```
Process 1: [.......             ]
Process 2: Waiting for download.
Process 3: [....                ]
Process 4: Installing.
```

And update each line independently, as if it's a "progress line".

Thanks,
Dima