### PR TITLE
Removed `SO_REUSEADDR` on Windows.

### DIFF
--- a/bricks/net/tcp/impl/posix.h
+++ b/bricks/net/tcp/impl/posix.h
@@ -117,17 +117,18 @@ class SocketHandle : private SocketSystemInitializer {
     u_long just_one = 1;
 #endif  // CURRENT_WINDOWS
 
+#ifndef CURRENT_WINDOWS
+    // NOTE(dkorolev): On Windows, `SO_REUSEADDR` is unnecessary.
+    // First, local ports can be reused right away, so it doesn't win anything.
+    // Second, on Windows this setting allows binding the second socket to the same port, which is just bad.
     if (::setsockopt(socket_,
                      SOL_SOCKET,
                      SO_REUSEADDR,
-#ifndef CURRENT_WINDOWS
                      &just_one,
-#else
-                     reinterpret_cast<const char*>(&just_one),
-#endif
                      sizeof(just_one))) {
       CURRENT_THROW(SocketCreateException());  // LCOV_EXCL_LINE -- Not covered by the unit tests.
     }
+#endif
 
 #ifdef CURRENT_APPLE
     // Emulate MSG_NOSIGNAL behavior.

--- a/bricks/net/tcp/test.cc
+++ b/bricks/net/tcp/test.cc
@@ -291,9 +291,6 @@ TEST(TCPTest, ResolveAddress) {
   }
 }
 
-#ifndef CURRENT_WINDOWS
-// Apparently, Windows has no problems opening two sockets on the same port.
-// NOTE(dkorolev): Confirmed on Visual Studio 2015 Preview, as well as later in 2021.
 TEST(TCPTest, CanNotBindTwoSocketsToTheSamePortSimultaneously) {
   auto port_reservation = ReserveLocalPort();
   const uint16_t port_number = port_reservation;
@@ -301,7 +298,6 @@ TEST(TCPTest, CanNotBindTwoSocketsToTheSamePortSimultaneously) {
   std::unique_ptr<Socket> s2;
   ASSERT_THROW(s2 = std::make_unique<Socket>(current::net::BarePort(port_number)), SocketBindException);
 }
-#endif
 
 #if !defined(CURRENT_WINDOWS) && !defined(CURRENT_APPLE)
 // NOTE: This test appears to be flaky.


### PR DESCRIPTION
Hi Max,

After some research it turns out `SO_REUSEADDR` is not only unnecessary but also harmful on Windows. This PR removes it.

Thanks,
Dima