### PR TITLE
Moving to `clang-format-10`.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,12 @@
 BasedOnStyle: Google
 ColumnLimit: 120
+
 BinPackParameters: false  # Allow either all parameters on one line or one parameter per line, no packing.
 BinPackArguments: false   # The same for function calls.
+
+AllowShortLambdasOnASingleLine: All
+MaxEmptyLinesToKeep: 1
+SpaceInEmptyParentheses: false
+PointerAlignment: Left
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+SpacesBeforeTrailingComments: 2

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Welcome, contributors! Please [start here by signing the CLA](https://github.com
   - **macOS**: `brew install nasm`
 - `geninfo` from `lcov` for coverage report.
   - **macOS**: `brew install lcov`
-- `clang-format-3.6` for code formatting (`make indent`).
-  - **macOS**: Only `clang-format-3.8` is available via Homebrew: `brew install clang-format@3.8 && ln -s /usr/local/bin/clang-format-3.6 /usr/local/opt/clang-format@3.8/bin/clang-format` _(pretend we've got 3.6)_
+- `clang-format-10` for code formatting (`make indent`).
+  - TODO(dkorolev) On **macOS** no `clang-format-3.6` was availably, and the trick was to use `clang-format-3.8` and symlink it: `brew install clang-format@3.8 && ln -s /usr/local/bin/clang-format-3.6 /usr/local/opt/clang-format@3.8/bin/clang-format`, double-checking.
 
 ### Clean the output of the previous builds
 

--- a/scripts/indent.sh
+++ b/scripts/indent.sh
@@ -4,7 +4,7 @@
 # according to .clang-format in this directory or above.
 
 CLANG_FORMAT=${1:-clang-format-10}
-(find . -name "*.cc" ; find . -name "*.h") \
+(find . -type f -name "*.cc" ; find . -type f -name "*.h") \
 | grep -v "/.current/" | grep -v "/3rdparty/" \
 | grep -v "/docu_" \
 | xargs "$CLANG_FORMAT" -i

--- a/scripts/indent.sh
+++ b/scripts/indent.sh
@@ -3,7 +3,7 @@
 # Indents all *.cc and *.h files in the current directory and below
 # according to .clang-format in this directory or above.
 
-CLANG_FORMAT=${1:-clang-format-3.6}
+CLANG_FORMAT=${1:-clang-format-10}
 (find . -name "*.cc" ; find . -name "*.h") \
 | grep -v "/.current/" | grep -v "/3rdparty/" \
 | grep -v "/docu_" \


### PR DESCRIPTION
Hi @mzhurovich,

This PR moves Current to `clang-format-10`. I've also tweaked some `.clang-format` rules, see https://github.com/dkorolev/Current/commit/a290019130a852ae5da9f55b2f12cd9a68deb9ab for how it reformats the code.

Thinking of wrapping every top-line `#include "${relative_path}/port.h"` into `clang-format`-disabling guards, because we used to make it an important rule that `port.h` is `#include`-d first (i.e. `#define NOMINMAX` on Windows). Although we might well live without this change and see if all goes well, right?

Thanks,
Dima