### PR TITLE
Added (experimental) support for `Emscripten` (WebAssembly), needed for `JSON`, etc.

### DIFF
--- a/port.h
+++ b/port.h
@@ -39,7 +39,9 @@ SOFTWARE.
 #ifndef CURRENT_PORT_H
 #define CURRENT_PORT_H
 
+#ifndef NOMINMAX
 #define NOMINMAX  // Tell Visual Studio to not mess with std::min() / std::max().
+#endif  // NOMINMAX
 
 #ifdef _MSC_VER
 // clang-format off

--- a/port.h
+++ b/port.h
@@ -141,6 +141,8 @@ using namespace current_injected_cpp17;
 #define CURRENT_APPLE
 #elif defined(_WIN32)
 #define CURRENT_WINDOWS
+#elif defined(__EMSCRIPTEN__)
+#define CURRENT_EMSCRIPTEN
 #else
 #error "Could not detect architecture. Please define one of the `CURRENT_*` macros explicitly."
 #endif
@@ -170,6 +172,10 @@ using namespace current_injected_cpp17;
 #elif defined(CURRENT_WINDOWS)
 #define CURRENT_ARCH_UNAME std::string("Windows")
 #define CURRENT_ARCH_UNAME_AS_IDENTIFIER Windows
+#elif defined(CURRENT_EMSCRIPTEN)
+#define CURRENT_ARCH_UNAME std::string("Emscripten")
+#define CURRENT_ARCH_UNAME_AS_IDENTIFIER Emscripten
+#warning "Emscripten support is experimental in Current."
 #else
 #error "Unknown architecture."
 #endif


### PR DESCRIPTION
Hi @mzhurovich,

This enables WebAssembly via Emscripten. Ref:

* https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html
* https://emscripten.org/docs/getting_started/downloads.html
* https://emscripten.org/docs/tools_reference/emsdk.html
* https://developer.mozilla.org/en-US/docs/WebAssembly/C_to_wasm

I might add a piece of example code later on (and ask John to look at it too, he may well like it!), but looks lo-pri to me now.

Thanks,
Dima

