### PR TITLE
Extracted a wrapper for `dlopen` only (it was only "compile C++ and then `dlopen`" before).

### DIFF
--- a/3rdparty/gtest/src/gtest-death-test.cc
+++ b/3rdparty/gtest/src/gtest-death-test.cc
@@ -1212,14 +1212,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
 static void StackLowerThanAddress(const void* ptr,
                                   bool* result) GTEST_NO_INLINE_;
 static void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy = 0;  // NOTE(dkorolev): Eliminated the warning.
   *result = (&dummy < ptr);
 }
 
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;  // NOTE(dkorolev): Eliminated the warning.
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;

--- a/bricks/system/syscalls.h
+++ b/bricks/system/syscalls.h
@@ -167,7 +167,7 @@ class DynamicLibrary {
   }
 
   template <typename F, typename S>
-  F Get(S&& function_name) {
+  F Get(S&& function_name) const {
     if (!lib_) {
       CURRENT_THROW(DLOpenException("Failed to load the library."));
     } else {

--- a/bricks/system/test.cc
+++ b/bricks/system/test.cc
@@ -80,7 +80,7 @@ TEST(Syscalls, DLOpen) {
   EXPECT_EQ(42, foo1());
   EXPECT_EQ(43, foo1());
   auto dynamic_lib = current::bricks::system::DynamicLibrary(lib.GetSOName());
-  auto foo2 = dynamic_lib.template GetFunction<int (*)()>("_Z3foov");
+  auto foo2 = dynamic_lib.template Get<int (*)()>("_Z3foov");
   EXPECT_EQ(44, foo2());
   EXPECT_EQ(45, foo1());
 }
@@ -90,7 +90,7 @@ TEST(Syscalls, DLOpenExternC) {
   auto bar1 = lib.template Get<int (*)()>("bar");
   EXPECT_EQ(100, bar1());
   auto dynamic_lib = current::bricks::system::DynamicLibrary(lib.GetSOName());
-  auto bar2 = dynamic_lib.template GetFunction<int (*)()>("bar");
+  auto bar2 = dynamic_lib.template Get<int (*)()>("bar");
   EXPECT_EQ(101, bar2());
   EXPECT_EQ(102, bar1());
   EXPECT_EQ(103, bar2());

--- a/bricks/system/test.cc
+++ b/bricks/system/test.cc
@@ -76,7 +76,7 @@ TEST(Syscalls, SystemCall) {
 #ifndef CURRENT_WINDOWS
 TEST(Syscalls, DLOpen) {
   current::bricks::system::JITCompiledCPP lib("int foo() { static int c = 42; return c++; }");
-  auto foo1 = lib.template Get<int (*)()>("_Z3foov");  // The C++-mangled name for `foo1`, use `objdump -t` if unsure.
+  auto foo1 = lib.template Get<int (*)()>("_Z3foov");  // The C++-mangled name for `foo`, use `objdump -t` if unsure.
   EXPECT_EQ(42, foo1());
   EXPECT_EQ(43, foo1());
   auto dynamic_lib = current::bricks::system::DynamicLibrary(lib.GetSOName());
@@ -87,7 +87,7 @@ TEST(Syscalls, DLOpen) {
 
 TEST(Syscalls, DLOpenExternC) {
   current::bricks::system::JITCompiledCPP lib("extern \"C\" int bar() { static int c = 100; return c++; }");
-  auto bar1 = lib.template Get<int (*)()>("bar");
+  auto bar1 = lib.template Get<int (*)()>("bar");  // With `extern "C"` there's no mangling.
   EXPECT_EQ(100, bar1());
   auto dynamic_lib = current::bricks::system::DynamicLibrary(lib.GetSOName());
   auto bar2 = dynamic_lib.template Get<int (*)()>("bar");

--- a/bricks/system/test.cc
+++ b/bricks/system/test.cc
@@ -75,9 +75,25 @@ TEST(Syscalls, SystemCall) {
 
 #ifndef CURRENT_WINDOWS
 TEST(Syscalls, DLOpen) {
-  current::bricks::system::JITCompiledCPP lib("int foo() { return 42; }");
-  auto foo = lib.template Get<int (*)()>("_Z3foov");  // The C++-mangled name for `foo`, use `objdump -t` if unsure.
-  EXPECT_EQ(42, foo());
+  current::bricks::system::JITCompiledCPP lib("int foo() { static int c = 42; return c++; }");
+  auto foo1 = lib.template Get<int (*)()>("_Z3foov");  // The C++-mangled name for `foo1`, use `objdump -t` if unsure.
+  EXPECT_EQ(42, foo1());
+  EXPECT_EQ(43, foo1());
+  auto dynamic_lib = current::bricks::system::DynamicLibrary(lib.GetSOName());
+  auto foo2 = dynamic_lib.template GetFunction<int (*)()>("_Z3foov");
+  EXPECT_EQ(44, foo2());
+  EXPECT_EQ(45, foo1());
+}
+
+TEST(Syscalls, DLOpenExternC) {
+  current::bricks::system::JITCompiledCPP lib("extern \"C\" int bar() { static int c = 100; return c++; }");
+  auto bar1 = lib.template Get<int (*)()>("bar");
+  EXPECT_EQ(100, bar1());
+  auto dynamic_lib = current::bricks::system::DynamicLibrary(lib.GetSOName());
+  auto bar2 = dynamic_lib.template GetFunction<int (*)()>("bar");
+  EXPECT_EQ(101, bar2());
+  EXPECT_EQ(102, bar1());
+  EXPECT_EQ(103, bar2());
 }
 
 TEST(Syscalls, DLOpenHasCurrentHeader) {


### PR DESCRIPTION
Also, made sure that with `"extern "C"` the name is indeed not mangled.