### PR TITLE
The `::dlopen()` nuanced magic isolated and tested!

### DIFF
--- a/bricks/system/syscalls.h
+++ b/bricks/system/syscalls.h
@@ -148,7 +148,7 @@ class DynamicLibrary {
   DynamicLibrary(const std::string& library_file_name) : library_file_name_(library_file_name) {
     lib_ = ::dlopen(library_file_name_.c_str(), RTLD_LAZY);
     if (!lib_) {
-      CURRENT_THROW(DLOpenException("Failed to load the library."));
+      CURRENT_THROW(DLOpenException(std::string("Failed to load the library: ") + ::dlerror()));
     }
   }
 

--- a/bricks/system/test.cc
+++ b/bricks/system/test.cc
@@ -125,11 +125,11 @@ TEST(Syscalls, DLOpenTwoLibraries) {
 TEST(Syscalls, DLOpenTwoLibrariesSameNamespaceCollisionNuance) {
   // clang-format off
   current::bricks::system::JITCompiledCPP lib1(R"(
-    namespace magic {
+    namespace nuance {
       inline int N = 42;
     }
     extern "C" int Get42Correct() {
-      return magic::N;
+      return nuance::N;
     }
   )");
   // clang-format on
@@ -138,11 +138,11 @@ TEST(Syscalls, DLOpenTwoLibrariesSameNamespaceCollisionNuance) {
 
   // clang-format off
   current::bricks::system::JITCompiledCPP lib2(R"(
-    namespace magic {
+    namespace nuance {
       inline int N = 101;
     }
     extern "C" int Get101WithANuance() {
-      return magic::N;
+      return nuance::N;
     }
   )");
   // clang-format on
@@ -154,11 +154,11 @@ TEST(Syscalls, DLOpenTwoLibrariesSameNamespaceCollisionNuance) {
 TEST(Syscalls, DLOpenTwoLibrariesTwoNamespaces) {
   // clang-format off
   current::bricks::system::JITCompiledCPP lib1(R"(
-    namespace magic42 {
+    namespace nuance42 {
       inline int N = 42;
     }
     extern "C" int Get42Correct() {
-      return magic42::N;
+      return nuance42::N;
     }
   )");
   // clang-format on
@@ -167,11 +167,11 @@ TEST(Syscalls, DLOpenTwoLibrariesTwoNamespaces) {
 
   // clang-format off
   current::bricks::system::JITCompiledCPP lib2(R"(
-    namespace magic101 {
+    namespace nuance101 {
       inline int N = 101;
     }
     extern "C" int Get101Correct() {
-      return magic101::N;
+      return nuance101::N;
     }
   )");
   // clang-format on


### PR DESCRIPTION
@mzhurovich pls test on a Mac.