### PR TITLE
Adding support for `std::array<T, N>` to the `typesystem/`.

### DIFF
--- a/typesystem/reflection/reflection.h
+++ b/typesystem/reflection/reflection.h
@@ -135,6 +135,11 @@ struct RecursiveTypeTraverser {
     return ReflectedType_Enum(EnumName<T>(), CurrentTypeID_<typename std::underlying_type<T>::type>()).type_id;
   }
 
+  template <typename T, size_t N>
+  TypeID operator()(TypeSelector<std::array<T, N>>) {
+    return CalculateTypeID(ReflectedType_Array(CurrentTypeID_<T>(), static_cast<uint64_t>(N)));
+  }
+
   template <typename T>
   TypeID operator()(TypeSelector<std::vector<T>>) {
     return CalculateTypeID(ReflectedType_Vector(CurrentTypeID_<T>()));

--- a/typesystem/reflection/reflection.h
+++ b/typesystem/reflection/reflection.h
@@ -377,6 +377,15 @@ struct ReflectorImpl {
     return ReflectedType(ReflectedType_Enum(EnumName<T>(), CurrentTypeID<typename std::underlying_type<T>::type>()));
   }
 
+  template <typename T, size_t N>
+  ReflectedType operator()(TypeSelector<std::array<T, N>>) {
+    ReflectType<T>();
+    ReflectedType_Array result(CurrentTypeID<T>());
+    result.type_id = CurrentTypeID<std::vector<T>>();
+    result.size = static_cast<uint64_t>(N);
+    return ReflectedType(std::move(result));
+  }
+
   template <typename T>
   ReflectedType operator()(TypeSelector<std::vector<T>>) {
     ReflectType<T>();

--- a/typesystem/reflection/test.cc
+++ b/typesystem/reflection/test.cc
@@ -180,6 +180,7 @@ TEST(Reflection, CurrentTypeName) {
   EXPECT_STREQ("double", (CurrentTypeName<double, NameFormat::Z>()));
 
   // Composite types.
+  EXPECT_STREQ("std::array<std::string, 3>", (CurrentTypeName<std::array<std::string, 3u>, NameFormat::Z>()));
   EXPECT_STREQ("std::vector<std::string>", (CurrentTypeName<std::vector<std::string>, NameFormat::Z>()));
   EXPECT_STREQ("std::set<int8_t>", (CurrentTypeName<std::set<int8_t>, NameFormat::Z>()));
   EXPECT_STREQ("std::unordered_set<int16_t>", (CurrentTypeName<std::unordered_set<int16_t>, NameFormat::Z>()));

--- a/typesystem/reflection/test.cc
+++ b/typesystem/reflection/test.cc
@@ -103,6 +103,26 @@ CURRENT_STRUCT(SameStruct) {
 
 }  // namespace custom_ns3
 
+CURRENT_STRUCT(WithNoArray) {
+  CURRENT_FIELD(foo, uint32_t);
+  CURRENT_FIELD(x0, uint32_t);
+  CURRENT_FIELD(x1, uint32_t);
+};
+
+namespace of_size_one {
+CURRENT_STRUCT(WithArray) {
+  CURRENT_FIELD(foo, uint32_t);
+  CURRENT_FIELD(bar, (std::array<uint32_t, 1>));
+};
+}  // namespace of_size_one
+
+namespace of_size_two {
+CURRENT_STRUCT(WithArray) {
+  CURRENT_FIELD(foo, uint32_t);
+  CURRENT_FIELD(bar, (std::array<uint32_t, 2>));
+};
+}  // namespace of_size_two
+
 using current::reflection::Reflector;
 
 static_assert(
@@ -243,6 +263,14 @@ TEST(Reflection, CurrentTypeName) {
   EXPECT_STREQ("Tuple_Bool_Bool", (CurrentTypeName<std::tuple<bool, bool>, NameFormat::AsIdentifier>()));
   EXPECT_STREQ("Tuple_String_Char_Double",
                (CurrentTypeName<std::tuple<std::string, char, double>, NameFormat::AsIdentifier>()));
+
+  // Arrays.
+  EXPECT_STREQ("WithNoArray", (CurrentTypeName<WithNoArray>()));
+  EXPECT_STREQ("WithArray", (CurrentTypeName<of_size_one::WithArray>()));
+  EXPECT_STREQ("WithArray", (CurrentTypeName<of_size_two::WithArray>()));
+  EXPECT_STREQ("WithNoArray", (CurrentTypeName<WithNoArray, NameFormat::AsIdentifier>()));
+  EXPECT_STREQ("WithArray", (CurrentTypeName<of_size_one::WithArray, NameFormat::AsIdentifier>()));
+  EXPECT_STREQ("WithArray", (CurrentTypeName<of_size_two::WithArray, NameFormat::AsIdentifier>()));
 }
 
 TEST(Reflection, ConstInCurrentTypeName) {
@@ -545,6 +573,26 @@ TEST(Reflection, TemplatedTypeIDs) {
     EXPECT_EQ("Foo", Value(dff.super_name));
   }
 }
+
+TEST(Relection, TypeIDForArrays) {
+  using namespace reflection_test;
+  using current::reflection::CurrentTypeID;
+  EXPECT_EQ(9203440661079201605ull, static_cast<uint64_t>(CurrentTypeID<WithNoArray>()));
+  EXPECT_EQ(9204926548798288167ull, static_cast<uint64_t>(CurrentTypeID<of_size_one::WithArray>()));
+  EXPECT_EQ(9204926548831842599ull, static_cast<uint64_t>(CurrentTypeID<of_size_two::WithArray>()));
+};
+
+TEST(Reflection, ArrayLayout) {
+  using namespace reflection_test;
+  WithNoArray tmp;
+  tmp.foo = 42u;
+  tmp.x0 = 100u;
+  tmp.x1 = 101u;
+  const auto& retmp = *reinterpret_cast<const of_size_two::WithArray*>(&tmp);
+  EXPECT_EQ(42u, retmp.foo);
+  EXPECT_EQ(100u, retmp.bar[0]);
+  EXPECT_EQ(101u, retmp.bar[1]);
+};
 
 namespace reflection_test {
 CURRENT_STRUCT(A){};

--- a/typesystem/schema/json_schema_format.h
+++ b/typesystem/schema/json_schema_format.h
@@ -39,6 +39,7 @@ namespace variant_clean_type_names {
 
 CURRENT_FORWARD_DECLARE_STRUCT(primitive);
 CURRENT_FORWARD_DECLARE_STRUCT(key);                   // a.k.a. `CURRENT_ENUM()`.
+CURRENT_FORWARD_DECLARE_STRUCT(fixed_size_array);      // a.k.a. `array<>`.
 CURRENT_FORWARD_DECLARE_STRUCT(array);                 // a.k.a. `vector<>`.
 CURRENT_FORWARD_DECLARE_STRUCT(ordered_dictionary);    // a.k.a. `map<>`.
 CURRENT_FORWARD_DECLARE_STRUCT(unordered_dictionary);  // a.k.a. `unordered_map<>`.
@@ -50,7 +51,7 @@ CURRENT_FORWARD_DECLARE_STRUCT(algebraic);             // a.k.a. `Variant<>.
 CURRENT_FORWARD_DECLARE_STRUCT(object);                // a.k.a. `CURRENT_STRUCT()`.
 CURRENT_FORWARD_DECLARE_STRUCT(error);
 
-using type_variant_t = Variant<primitive, key, array, ordered_dictionary, unordered_dictionary, ordered_set, unordered_set, pair, optional, algebraic, object, error>;
+using type_variant_t = Variant<primitive, key, fixed_size_array, array, ordered_dictionary, unordered_dictionary, ordered_set, unordered_set, pair, optional, algebraic, object, error>;
 
 CURRENT_STRUCT(primitive) {
   CURRENT_FIELD(type, std::string);
@@ -61,6 +62,11 @@ CURRENT_STRUCT(key) {
   CURRENT_FIELD(name, std::string);
   CURRENT_FIELD(type, std::string);
   CURRENT_FIELD(text, std::string);
+};
+
+CURRENT_STRUCT(fixed_size_array) {
+  CURRENT_FIELD(element, type_variant_t);
+  CURRENT_FIELD(size, uint64_t);
 };
 
 CURRENT_STRUCT(array) {

--- a/typesystem/schema/schema.h
+++ b/typesystem/schema/schema.h
@@ -1056,8 +1056,9 @@ struct LanguageSyntaxImpl<Language::JSON> final {
             }
           }
           void operator()(const ReflectedType_Array& a) const {
-            variant_clean_type_names::array result;
+            variant_clean_type_names::fixed_size_array result;
             result.element = self_.TypeDescriptionForJSON(a.element_type);
+            result.size = a.size;
             result_ = result;
           }
           void operator()(const ReflectedType_Vector& v) const {

--- a/typesystem/schema/schema.h
+++ b/typesystem/schema/schema.h
@@ -331,10 +331,12 @@ struct LanguageSyntaxCPP : CurrentStructPrinter<CPP_LANGUAGE_SELECTOR> {
           }
 
           void operator()(const ReflectedType_Enum& e) const { oss_ << OptionalNamespaceName(e) << e.name; }
+          void operator()(const ReflectedType_Array& a) const {
+            oss_ << "std::array<" << self_.TypeName(a.element_type, nmspc_) << ',' << a.size << '>';
+          }
           void operator()(const ReflectedType_Vector& v) const {
             oss_ << "std::vector<" << self_.TypeName(v.element_type, nmspc_) << '>';
           }
-
           void operator()(const ReflectedType_Map& m) const {
             oss_ << "std::map<" << self_.TypeName(m.key_type, nmspc_) << ", " << self_.TypeName(m.value_type, nmspc_)
                  << '>';
@@ -659,6 +661,7 @@ struct LanguageSyntaxCPP : CurrentStructPrinter<CPP_LANGUAGE_SELECTOR> {
       CurrentStructPrinter<CPP_LANGUAGE_SELECTOR>::PrintCurrentEnum(
           os_, e, [this](TypeID id, const std::string& nmspc) -> std::string { return TypeName(id, nmspc); });
     }
+    void operator()(const ReflectedType_Array&) const {}
     void operator()(const ReflectedType_Vector&) const {}
     void operator()(const ReflectedType_Pair&) const {}
     void operator()(const ReflectedType_Map&) const {}
@@ -737,6 +740,9 @@ struct LanguageSyntaxImpl<Language::FSharp> final {
             }
           }
           void operator()(const ReflectedType_Enum& e) const { oss_ << SanitizeFSharpSymbol(e.name); }
+          void operator()(const ReflectedType_Array& a) const {
+            oss_ << SanitizeFSharpSymbol(self_.TypeName(a.element_type)) << " array";
+          }
           void operator()(const ReflectedType_Vector& v) const {
             oss_ << SanitizeFSharpSymbol(self_.TypeName(v.element_type)) << " array";
           }
@@ -788,6 +794,7 @@ struct LanguageSyntaxImpl<Language::FSharp> final {
     void operator()(const ReflectedType_Enum& e) const {
       os_ << "\ntype " << SanitizeFSharpSymbol(e.name) << " = " << TypeName(e.underlying_type) << '\n';
     }
+    void operator()(const ReflectedType_Array&) const {}
     void operator()(const ReflectedType_Vector&) const {}
     void operator()(const ReflectedType_Pair&) const {}
     void operator()(const ReflectedType_Map&) const {}
@@ -878,6 +885,9 @@ struct LanguageSyntaxImpl<Language::Markdown> final {
           void operator()(const ReflectedType_Enum& e) const {
             oss_ << "Index `" << e.name << "`, underlying type `" << self_.TypeName(e.underlying_type) << '`';
           }
+          void operator()(const ReflectedType_Array& a) const {
+            oss_ << "Array of " << self_.TypeName(a.element_type);  // TODO(dkorolev): Size omitted for now.
+          }
           void operator()(const ReflectedType_Vector& v) const {
             oss_ << "Array of " << self_.TypeName(v.element_type);
           }
@@ -925,6 +935,7 @@ struct LanguageSyntaxImpl<Language::Markdown> final {
 
     void operator()(const ReflectedType_Primitive&) const {}
     void operator()(const ReflectedType_Enum&) const {}
+    void operator()(const ReflectedType_Array&) const {}
     void operator()(const ReflectedType_Vector&) const {}
     void operator()(const ReflectedType_Pair&) const {}
     void operator()(const ReflectedType_Map&) const {}
@@ -1044,6 +1055,11 @@ struct LanguageSyntaxImpl<Language::JSON> final {
               result_ = error;
             }
           }
+          void operator()(const ReflectedType_Array& a) const {
+            variant_clean_type_names::array result;
+            result.element = self_.TypeDescriptionForJSON(a.element_type);
+            result_ = result;
+          }
           void operator()(const ReflectedType_Vector& v) const {
             variant_clean_type_names::array result;
             result.element = self_.TypeDescriptionForJSON(v.element_type);
@@ -1114,6 +1130,7 @@ struct LanguageSyntaxImpl<Language::JSON> final {
 
     void operator()(const ReflectedType_Primitive&) const {}
     void operator()(const ReflectedType_Enum&) const {}
+    void operator()(const ReflectedType_Array&) const {}
     void operator()(const ReflectedType_Vector&) const {}
     void operator()(const ReflectedType_Pair&) const {}
     void operator()(const ReflectedType_Map&) const {}
@@ -1290,6 +1307,9 @@ struct LanguageSyntaxImpl<Language::TypeScript> final {
             }
           }
           void operator()(const ReflectedType_Enum& e) const { oss_ << e.name; }
+          void operator()(const ReflectedType_Array& a) const {
+            oss_ << HackyGetName(a.element_type, ShouldAddParens::Yes) << "[]";
+          }
           void operator()(const ReflectedType_Vector& v) const {
             // TODO(dkorolev): Add more test cases for `std::vector<Optional<...>>`.
             oss_ << HackyGetName(v.element_type, ShouldAddParens::Yes) << "[]";
@@ -1353,6 +1373,7 @@ struct LanguageSyntaxImpl<Language::TypeScript> final {
       os_ << "\nexport type " << e.name << " = number;\n";
       // NOTE(dkorolev): Ignoring `e.underlying_type` for now, only `number` is supported.
     }
+    void operator()(const ReflectedType_Array&) const {}
     void operator()(const ReflectedType_Vector&) const {}
     void operator()(const ReflectedType_Pair&) const {}
     void operator()(const ReflectedType_Map&) const {}
@@ -1498,6 +1519,14 @@ struct StructSchema final {
         schema_.types.emplace(e.type_id, e);
         Reflector().ReflectedTypeByTypeID(e.underlying_type).Call(*this);
         schema_.order.push_back(e.type_id);
+      }
+    }
+
+    void operator()(const ReflectedType_Array& a) {
+      if (!schema_.types.count(a.type_id)) {
+        schema_.types.emplace(a.type_id, a);
+        Reflector().ReflectedTypeByTypeID(a.element_type).Call(*this);
+        schema_.order.push_back(a.type_id);
       }
     }
 

--- a/typesystem/schema/smoke_test_struct.h
+++ b/typesystem/schema/smoke_test_struct.h
@@ -85,6 +85,11 @@ CURRENT_STRUCT(FullTest) {
   CURRENT_FIELD_DESCRIPTION(primitives, "A structure with a lot of primitive types.");
   CURRENT_FIELD(v1, std::vector<std::string>);
   CURRENT_FIELD(v2, std::vector<Primitives>);
+#if 0
+  CURRENT_FIELD(a1, (std::array<int64_t, 2>));
+  CURRENT_FIELD(a2, (std::array<std::pair<std::string, std::string>, 4>));
+  CURRENT_FIELD(a3, (std::array<Primitives, 8>));
+#endif
   CURRENT_FIELD(p, (std::pair<std::string, Primitives>));
   CURRENT_FIELD(o, Optional<Primitives>);
   CURRENT_FIELD(q, (Variant<A, B, B2, C, Empty>));

--- a/typesystem/serialization/json.h
+++ b/typesystem/serialization/json.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 #include "serialization.h"
 
+#include "json/array.h"
 #include "json/enum.h"
 #include "json/immutable_optional.h"
 #include "json/map.h"

--- a/typesystem/serialization/json/array.h
+++ b/typesystem/serialization/json/array.h
@@ -1,0 +1,70 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2023 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_TYPE_SYSTEM_SERIALIZATION_JSON_ARRAY_H
+#define CURRENT_TYPE_SYSTEM_SERIALIZATION_JSON_ARRAY_H
+
+#include <array>
+
+#include "json.h"
+
+namespace current {
+namespace serialization {
+
+template <class JSON_FORMAT, typename T, size_t N>
+struct SerializeImpl<json::JSONStringifier<JSON_FORMAT>, std::array<T, N>> {
+  static void DoSerialize(json::JSONStringifier<JSON_FORMAT>& json_stringifier, const std::array<T, N>& value) {
+    json_stringifier.Current().SetArray();
+    for (const auto& element : value) {
+      rapidjson::Value element_to_push;
+      json_stringifier.Inner(&element_to_push, element);
+      json_stringifier.Current().PushBack(std::move(element_to_push.Move()), json_stringifier.Allocator());
+    }
+  }
+};
+
+template <class JSON_FORMAT, typename T, size_t N>
+struct DeserializeImpl<json::JSONParser<JSON_FORMAT>, std::array<T, N>> {
+  static void DoDeserialize(json::JSONParser<JSON_FORMAT>& json_parser, std::array<T, N>& destination) {
+    if (json_parser && json_parser.Current().IsArray()) {
+      for (rapidjson::SizeType i = 0; i < static_cast<rapidjson::SizeType>(N); ++i) {
+        json_parser.Inner(&json_parser.Current()[i], destination[i], "[", static_cast<int>(i), "]");
+      }
+    } else if (!json::JSONPatchMode<JSON_FORMAT>::value || (json_parser && !json_parser.Current().IsArray())) {
+      CURRENT_THROW(JSONSchemaException("array", json_parser));  // LCOV_EXCL_LINE
+    }
+  }
+};
+
+namespace json {
+template <typename T, size_t N>
+struct IsJSONSerializable<std::array<T, N>> {
+  constexpr static bool value = IsJSONSerializable<T>::value;
+};
+}  // namespace json
+
+}  // namespace serialization
+}  // namespace current
+
+#endif  // CURRENT_TYPE_SYSTEM_SERIALIZATION_JSON_ARRAY_H

--- a/typesystem/serialization/test.cc
+++ b/typesystem/serialization/test.cc
@@ -130,6 +130,7 @@ CURRENT_STRUCT(WithTime) {
 static_assert(current::serialization::json::IsJSONSerializable<int>::value, "");
 static_assert(current::serialization::json::IsJSONSerializable<std::string>::value, "");
 static_assert(current::serialization::json::IsJSONSerializable<bool>::value, "");
+static_assert(current::serialization::json::IsJSONSerializable<std::array<int, 42>>::value, "");
 static_assert(current::serialization::json::IsJSONSerializable<std::vector<int>>::value, "");
 static_assert(current::serialization::json::IsJSONSerializable<std::pair<int, int>>::value, "");
 static_assert(current::serialization::json::IsJSONSerializable<std::map<int, int>>::value, "");
@@ -277,6 +278,10 @@ TEST(JSONSerialization, CPPTypes) {
 
   EXPECT_EQ("\"a\\u0000b\"", JSON(std::string("a\0b", 3)));
   EXPECT_EQ(std::string("c\0d", 3), ParseJSON<std::string>("\"c\\u0000d\""));
+
+  // `std::array<>` is always serialized as array.
+  EXPECT_EQ("[0,0,0]", JSON(std::array<uint64_t, 3>()));
+  EXPECT_EQ(42u, (ParseJSON<std::array<uint64_t, 1>>("[42]")[0]));
 
   // `std::vector<>` is always serialized as array.
   EXPECT_EQ("[]", JSON(std::vector<uint64_t>()));

--- a/typesystem/typename.h
+++ b/typesystem/typename.h
@@ -166,6 +166,13 @@ struct CurrentTypeNameImpl<NF, T, false, false, true, false> {
 #include "primitive_types.dsl.h"
 #undef CURRENT_DECLARE_PRIMITIVE_TYPE
 
+template <NameFormat NF, typename T, size_t N>
+struct CurrentTypeNameImpl<NF, std::array<T, N>, false, false, false, false> {
+  static std::string GetCurrentTypeName() {
+    return std::string("std::array<") + CurrentTypeNameCaller<NF, T>::CallGetCurrentTypeName() + ',' + std::to_string(N) + '>';
+  }
+};
+
 template <NameFormat NF, typename T>
 struct CurrentTypeNameImpl<NF, std::vector<T>, false, false, false, false> {
   static std::string GetCurrentTypeName() {
@@ -219,6 +226,13 @@ struct CurrentTypeNameImpl<NF, Optional<T>, false, false, false, false> {
 };
 
 // Names for `AsIdentifier` name decoration.
+template <typename T, size_t N>
+struct CurrentTypeNameImpl<NameFormat::AsIdentifier, std::array<T, N>, false, false, false, false> {
+  static std::string GetCurrentTypeName() {
+    return std::string("Array_") + CurrentTypeNameCaller<NameFormat::AsIdentifier, T>::CallGetCurrentTypeName() + '_' + std::to_string(N);
+  }
+};
+
 template <typename T>
 struct CurrentTypeNameImpl<NameFormat::AsIdentifier, std::vector<T>, false, false, false, false> {
   static std::string GetCurrentTypeName() {

--- a/typesystem/typename.h
+++ b/typesystem/typename.h
@@ -169,7 +169,8 @@ struct CurrentTypeNameImpl<NF, T, false, false, true, false> {
 template <NameFormat NF, typename T, size_t N>
 struct CurrentTypeNameImpl<NF, std::array<T, N>, false, false, false, false> {
   static std::string GetCurrentTypeName() {
-    return std::string("std::array<") + CurrentTypeNameCaller<NF, T>::CallGetCurrentTypeName() + ',' + std::to_string(N) + '>';
+    return std::string("std::array<") + CurrentTypeNameCaller<NF, T>::CallGetCurrentTypeName() +
+           ", " + std::to_string(N) + '>';
   }
 };
 


### PR DESCRIPTION
Incomplete wrt schema export and evolution, but should be good enough for now.