### PR TITLE
A gentle way to add an (almost dummy) `CMakeLists.txt` into `current`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ x64
 
 # CLion.
 .idea
-CMakeLists.txt
 
 # Let's not even talk about it.
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ x64
 # CLion.
 .idea
 
+# QT Creator.
+CMakeLists.txt.user
+
 # Let's not even talk about it.
 node_modules
 **/node_modules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.14.1)
+
+project(C5T LANGUAGES C CXX)
+
+message(STATUS "Add `C5T` into `target_link_libraries()` of your `CMakeLists.txt` to use `current` headers.")
+
+add_library(C5T INTERFACE)
+target_include_directories(C5T INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/blocks/blobs/blobs.h
+++ b/blocks/blobs/blobs.h
@@ -22,8 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#ifndef CURRENT_UTILS_BLOBS_BLOBS_H
-#define CURRENT_UTILS_BLOBS_BLOBS_H
+#ifndef CURRENT_BLOCKS_BLOBS_BLOBS_H
+#define CURRENT_BLOCKS_BLOBS_BLOBS_H
 
 #include "../../port.h"
 
@@ -60,4 +60,4 @@ void ProcessBlob(const std::string& filename, F&& f) {
 
 }  // namespace current
 
-#endif  // CURRENT_UTILS_BLOBS_BLOBS_H
+#endif  // CURRENT_BLOCKS_BLOBS_BLOBS_H

--- a/typesystem/reflection/reflection.h
+++ b/typesystem/reflection/reflection.h
@@ -66,7 +66,7 @@ reflection::TypeID InternalCurrentTypeID(std::type_index top_level_type, const c
 // of correponding calls to `InternalCurrentTypeID` may and will be different in case of cyclic dependencies,
 // as the order of their resolution by definition depends on which part of the cycle was the starting point.
 
-// Called from `CurrentTypeID<T>()` defined in `typeid.h`, to be lightwaithg-injectable.
+// Called from `CurrentTypeID<T>()` defined in `typeid.h`, to be lightweight-injectable.
 template <typename T>
 struct DefaultCurrentTypeIDImpl final {
   static TypeID GetTypeID() {

--- a/typesystem/reflection/reflection.h
+++ b/typesystem/reflection/reflection.h
@@ -26,6 +26,8 @@ SOFTWARE.
 #ifndef CURRENT_TYPE_SYSTEM_REFLECTION_REFLECTION_H
 #define CURRENT_TYPE_SYSTEM_REFLECTION_REFLECTION_H
 
+#include "typeid.h"
+
 #include <map>
 #include <set>
 #include <typeindex>
@@ -63,10 +65,14 @@ reflection::TypeID InternalCurrentTypeID(std::type_index top_level_type, const c
 // `CurrentTypeID<T>()` is the "user-facing" type ID of `T`, whereas for each individual `T` the values
 // of correponding calls to `InternalCurrentTypeID` may and will be different in case of cyclic dependencies,
 // as the order of their resolution by definition depends on which part of the cycle was the starting point.
+
+// Called from `CurrentTypeID<T>()` defined in `typeid.h`, to be lightwaithg-injectable.
 template <typename T>
-reflection::TypeID CurrentTypeID() {
-  return InternalCurrentTypeID<T>(typeid(T), CurrentTypeName<T, NameFormat::Z>());
-}
+struct DefaultCurrentTypeIDImpl final {
+  static TypeID GetTypeID() {
+    return InternalCurrentTypeID<T>(typeid(T), CurrentTypeName<T, NameFormat::Z>());
+  }
+};
 
 #ifdef TODO_DKOROLEV_EXTRA_PARANOID_DEBUG_SYMBOL_NAME
 // Unused in user code, just to cover the external safety condition LOC from the unit test. -- D.K.

--- a/typesystem/reflection/typeid.h
+++ b/typesystem/reflection/typeid.h
@@ -1,0 +1,67 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2023 Maxim Zhurovich <zhurovich@gmail.com>
+          (c) 2023 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_TYPE_SYSTEM_REFLECTION_TYPEID_H
+#define CURRENT_TYPE_SYSTEM_REFLECTION_TYPEID_H
+
+// The most lightweight header to make build times of exported `CURRENT_STRUCT`-s as fast as possible.
+
+// TODO(dkorolev): If I get to extend this further, also export original names in schema-dumped C-structs.
+
+namespace current::reflection {
+
+enum class TypeID : uint64_t;
+
+template <typename T>
+struct DefaultCurrentTypeIDImpl;
+
+template <typename T>
+struct InjectableCurrentTypeID final {
+  static TypeID GetTypeID() {
+    return DefaultCurrentTypeIDImpl<T>::GetTypeID();
+  }
+};
+
+// `CurrentTypeID<T>()` is the "user-facing" type ID of `T`, whereas for each individual `T` the values
+// of correponding calls to `InternalCurrentTypeID` may and will be different in case of cyclic dependencies,
+// as the order of their resolution by definition depends on which part of the cycle was the starting point.
+template <typename T>
+reflection::TypeID CurrentTypeID() {
+  return InjectableCurrentTypeID<T>::GetTypeID();
+}
+
+}  // namespace current::reflection
+
+#define CURRENT_INJECT_TYPE_ID(type,id)      \
+namespace current::reflection {              \
+template <>                                  \
+struct InjectableCurrentTypeID<type> final { \
+  static TypeID GetTypeID() {                \
+    return static_cast<TypeID>(id);          \
+  }                                          \
+};                                           \
+}
+
+#endif  // CURRENT_TYPE_SYSTEM_REFLECTION_TYPEID_H

--- a/utils/blobs/blobs.h
+++ b/utils/blobs/blobs.h
@@ -1,0 +1,63 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2023 Dmitry "Dima" Korolev <dmitry.korolev@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*******************************************************************************/
+
+#ifndef CURRENT_UTILS_BLOBS_BLOBS_H
+#define CURRENT_UTILS_BLOBS_BLOBS_H
+
+#include "../../port.h"
+
+#include <iostream>
+
+#include "bricks/file/file.h"
+#include "typesystem/reflection/reflection.h"
+
+namespace current {
+
+template <class T>
+void WriteBlob(const std::vector<T>& data, const std::string& filename) {
+  std::ofstream file(filename, std::ios::binary);
+  const auto signature = current::reflection::CurrentTypeID<T>();
+  file.write(reinterpret_cast<const char*>(&signature), sizeof(signature));
+  file.write(reinterpret_cast<const char*>(&data[0]), sizeof(T) * data.size());
+}
+
+template <class T, class F>
+void ProcessBlob(const std::string& filename, F&& f) {
+  const std::string contents = current::FileSystem::ReadFileAsString(filename);
+  const auto signature = *reinterpret_cast<const current::reflection::TypeID*>(contents.c_str());
+  if (signature != current::reflection::CurrentTypeID<T>()) {
+    throw current::Exception("Wrong type.");
+  }
+  size_t length = contents.length();
+  size_t n = (length - sizeof(signature)) / sizeof(T);
+  if (sizeof(signature) + n * sizeof(T) != length) {
+    throw current::Exception("Wrong file size.");
+  }
+  // TODO(dkorolev): Add a wrapper class so that it has `.size()`, iteration via `for (element : elements)`, etc.
+  f(reinterpret_cast<const T*>(contents.c_str() + sizeof(signature)), n);
+}
+
+}  // namespace current
+
+#endif  // CURRENT_UTILS_BLOBS_BLOBS_H

--- a/utils/blobs/blobs.h
+++ b/utils/blobs/blobs.h
@@ -30,7 +30,7 @@ SOFTWARE.
 #include <iostream>
 
 #include "bricks/file/file.h"
-#include "typesystem/reflection/reflection.h"
+#include "typesystem/reflection/typeid.h"
 
 namespace current {
 


### PR DESCRIPTION
Tested externally with [`example_use_current_with_cmake`](https://github.com/dkorolev/example_use_current_with_cmake), this [Github action run](https://github.com/dkorolev/example_use_current_with_cmake/actions/runs/6375985888), on both Linux and macOS.

Probably best to review per commit.

TL:DR: The "shallow schema" -- replacing `CURRENT_STRUCT` by an (almost) autogenerated C++ `struct` saves ~33% of [re]build time. And `cmake`-based builds support partial cmake.

Please refer to the code of [`example_use_current_with_cmake`](https://github.com/dkorolev/example_use_current_with_cmake) for detailed example usage, can browse per-commit as well.