### PR TITLE
Added `-I` for `current/` if it's present in `.`, `..`, or `../..`.

### DIFF
--- a/scripts/MakefileImpl
+++ b/scripts/MakefileImpl
@@ -26,6 +26,14 @@ CPLUSPLUS?=g++
 CPPFLAGS=-std=c++17 -W -Wall
 CPPFLAGS+= -Wno-strict-aliasing  # To suppress FnCAS tight struct packing warnings. -- D.K.
 
+ifneq ($(wildcard current/port.h),)
+  CPPFLAGS+= -Icurrent/
+else ifneq ($(wildcard ../current/port.h),)
+  CPPFLAGS+= -I../current/
+else ifneq ($(wildcard ../../current/port.h),)
+  CPPFLAGS+= -I../../current/
+endif
+
 # Disabled as it generates `-Wno-noexcept-type` on clang++. -- D.K.
 # CPPFLAGS+= -Wno-noexcept-type    # To suppress the "warning: mangled name will change in C++17" warnings. -- D.K.
 


### PR DESCRIPTION
Hi @mzhurovich,

In my `CMakeLists.txt` experiments, as well as with [my dotfiles](https://github.com/dkorolev/dotfiles/blob/main/.ycm_extra_conf.py#L7-L9), I am now used to "just" writing:

```
#include "bricks/strings/split.h"
```

This works right away, even though, obviously, the code I work on is not in the "root" directory of the `current` repo. By works I mean:

* This line is not highlighted as incorrect, with some "header file not found" error,
* This header file is parsed correctly, and
* Code completion / suggestions work.

Please see the footnotes for the illustration.

Now, for "toy" projects, I often just `ln -sf ../current/scripts/MakefileImpl Makefile`. This makes it easy to use `:mak`, as well as `:mak test` from Vim, in no time.

However, this very `:mak` does not work now with Current's default `Makefile`, since no `-I` dirs are set.

The proposal is to add a bit of logic into Current's default `Makefile`, so that if `current` is to be found in `.` or in `..` or in `../..`, this path is automatically added as `-I` when invoking `g++` / `clang++`.

What do you think?

If you like the idea but dislike making this the behavior default, I'm also open to guarding it by some environmental flag, which I'll set in my `.bashrc` / `.zshrc`.

Thanks!
Dima

Footnotes:

![image](https://github.com/C5T/Current/assets/88491310/5e33733c-58ce-46f1-83df-62b75c9bd7de)

![image](https://github.com/C5T/Current/assets/88491310/a483c23c-b97e-40ea-a0f0-42678a1320f4)

