### PR TITLE
Triggering action run as GH user `C5T` on branch `stable`, for badges to work.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches:
+    - stable
 
 jobs:
   try-cmake:


### PR DESCRIPTION
Hey,

So my theory for why the badges do not work yet (i.e. they show "no status" in grey) is that the actions were never run on the `stable` branch of the `C5T` Github user.

(Or `C5T` organization, or organization user, or whatever the proper term is.)

Evidence: this link shows an empty list now:

* https://github.com/C5T/Current/actions?query=branch%3Astable

And this is why these "links", or rather these images:

* https://github.com/C5T/Current/workflows/cmake/badge.svg
* https://github.com/C5T/Current/actions/workflows/cmake.yml/badge.svg

Are showing this now:

![image](https://github.com/C5T/Current/assets/88491310/805d72a5-e30d-4b9d-ad3a-443e193d644e)

Despite the fact that indeed, removing `/badge.svg` from the latter link:

* https://github.com/C5T/Current/actions/workflows/cmake.yml

Results in a page full of successful action runs.

I intend to merge this PR in myself right away -- to trigger the event of merging into `stable` -- and see if this results in any workflows run by the [very first link](https://github.com/C5T/Current/actions?query=branch%3Astable) in this text.

Thx,
Dima

CC @mzhurovich 