### PR TITLE
Better `current_build_info.h` for `cmake`-based builds.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -63,6 +63,14 @@ add_custom_command(OUTPUT "${C5T_DEP_DIR_current}/current_build.h"
                    ARGS "${C5T_DEP_DIR_current}/current_build.h"
                    DEPENDS src)
 
+# TODO(dkorolev): [re-]add `/inc/` after the respective `mkdir -p` command is live in `C5T/Current:stable`.
+add_custom_target(C5T_CURRENT_BUILD_INFO_H_TARGET ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/current_build_info.h")  # TODO add inc/
+
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/current_build_info.h"  # TODO add inc/
+                   COMMAND "${C5T_DEP_DIR_current}/scripts/gen-current-build.sh"
+                   ARGS "${CMAKE_CURRENT_BINARY_DIR}/current_build_info.h"  # TODO add inc/
+                   DEPENDS src)
+
 set(C5T_LIBRARIES "Threads::Threads" "C5T")
 
 # Declare shared libraries as shared library targets. Do not link them against anything external.
@@ -70,8 +78,10 @@ file(GLOB_RECURSE BINARY_SOURCE_FILES "src/dlib_*.cc")
 foreach(SHARED_LIBRARY_SOURCE_FILE ${BINARY_SOURCE_FILES})
   get_filename_component(SHARED_LIBRARY_TARGET_NAME "${SHARED_LIBRARY_SOURCE_FILE}" NAME_WE)
   add_library(${SHARED_LIBRARY_TARGET_NAME} SHARED "${SHARED_LIBRARY_SOURCE_FILE}") 
+  add_dependencies(${SHARED_LIBRARY_TARGET_NAME} C5T_CURRENT_BUILD_INFO_H_TARGET)
   # TODO(dkorolev): Might be worth it to `grep` this `dlib_*.cc` source file for required library dependencies.
   target_compile_definitions(${SHARED_LIBRARY_TARGET_NAME} PRIVATE C5T_CMAKE_PROJECT)
+  target_include_directories(${SHARED_LIBRARY_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")  # TODO add inc/
   target_link_libraries(${SHARED_LIBRARY_TARGET_NAME} PRIVATE "${C5T_LIBRARIES}")
 endforeach()
 
@@ -81,7 +91,9 @@ file(GLOB_RECURSE LIBRARY_SOURCE_FILES "src/lib_*.cc")
 foreach(LIBRARY_SOURCE_FILE ${LIBRARY_SOURCE_FILES})
   get_filename_component(LIBRARY_TARGET_NAME "${LIBRARY_SOURCE_FILE}" NAME_WE)
   add_library(${LIBRARY_TARGET_NAME} "${LIBRARY_SOURCE_FILE}")
+  add_dependencies(${LIBRARY_TARGET_NAME} C5T_CURRENT_BUILD_INFO_H_TARGET)
   target_compile_definitions(${LIBRARY_TARGET_NAME} PRIVATE C5T_CMAKE_PROJECT)
+  target_include_directories(${LIBRARY_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/")  # TODO add inc/
   target_link_libraries(${LIBRARY_TARGET_NAME} PRIVATE "${C5T_LIBRARIES}")
   list(APPEND ALL_LIBRARIES "${LIBRARY_TARGET_NAME}")
 endforeach()
@@ -92,7 +104,9 @@ foreach(BINARY_SOURCE_FILE ${BINARY_SOURCE_FILES})
   get_filename_component(BINARY_TARGET_NAME "${BINARY_SOURCE_FILE}" NAME_WE)
   if(NOT (BINARY_TARGET_NAME MATCHES "^lib_.*$" OR BINARY_TARGET_NAME MATCHES "^test_.*$" OR BINARY_TARGET_NAME MATCHES "^dlib_.*$"))
     add_executable(${BINARY_TARGET_NAME} "${BINARY_SOURCE_FILE}") 
+    add_dependencies(${BINARY_TARGET_NAME} C5T_CURRENT_BUILD_INFO_H_TARGET)
     target_compile_definitions(${BINARY_TARGET_NAME} PRIVATE C5T_CMAKE_PROJECT)
+    target_include_directories(${BINARY_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")  # TODO add inc/
     target_link_libraries(${BINARY_TARGET_NAME} PRIVATE "${ALL_LIBRARIES}")
   endif()
 endforeach()
@@ -103,6 +117,8 @@ file(GLOB_RECURSE TEST_SOURCE_FILES "src/test_*.cc")
 foreach(TEST_SOURCE_FILE ${TEST_SOURCE_FILES})
   get_filename_component(TEST_TARGET_NAME "${TEST_SOURCE_FILE}" NAME_WE)
   add_executable(${TEST_TARGET_NAME} "${TEST_SOURCE_FILE}") 
+  add_dependencies(${TEST_TARGET_NAME} C5T_CURRENT_BUILD_INFO_H_TARGET)
+  target_include_directories(${TEST_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")  # TODO add inc/
   target_link_libraries(${TEST_TARGET_NAME} PRIVATE gtest_main "${ALL_LIBRARIES}")
   add_test(NAME ${TEST_TARGET_NAME} COMMAND ${TEST_TARGET_NAME})
 endforeach()


### PR DESCRIPTION
Creating the `current_build_info.h` header inside the respective output directory.

This would unlock concurrent Debug and Release builds, as overwriting the file under the `current/` source dir is just wrong.