### PR TITLE
Using the "new" `current_build_info.h`.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -56,13 +56,6 @@ endfunction()
 UseGitOrClone(https://github.com/c5t/current)
 UseGitOrClone(https://github.com/c5t/googletest)
 
-add_custom_target(C5T_CURRENT_BUILD_H_TARGET ALL DEPENDS "${C5T_DEP_DIR_current}/current_build.h")
-
-add_custom_command(OUTPUT "${C5T_DEP_DIR_current}/current_build.h"
-                   COMMAND "${C5T_DEP_DIR_current}/scripts/gen-current-build.sh"
-                   ARGS "${C5T_DEP_DIR_current}/current_build.h"
-                   DEPENDS src)
-
 add_custom_target(C5T_CURRENT_BUILD_INFO_H_TARGET ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h"

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -68,7 +68,9 @@ add_custom_target(C5T_CURRENT_BUILD_INFO_H_TARGET ALL DEPENDS "${CMAKE_CURRENT_B
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h"
                    COMMAND "${C5T_DEP_DIR_current}/scripts/gen-current-build.sh"
                    ARGS "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h"
-                   DEPENDS src)
+                   DEPENDS inc/current_build_info.h.force_rebuild)
+
+add_custom_command(OUTPUT inc/current_build_info.h.force_rebuild COMMAND cmake -E echo >/dev/null)
 
 set(C5T_LIBRARIES "Threads::Threads" "C5T")
 

--- a/cmake/run-cmake-test.sh
+++ b/cmake/run-cmake-test.sh
@@ -101,9 +101,10 @@ cat >src/build_info.cc <<EOF
 #ifndef C5T_CMAKE_PROJECT
 #error "'C5T_CMAKE_PROJECT' is not defined, are you using Current under 'cmake' with the proper 'CMakeLists.txt'?"
 #endif
-#include "current_build.h"
+#include "current_build_info.h"
 int main() {
   std::cout << "Successfully built at: " << current::build::cmake::kBuildDateTime << std::endl;
+  std::cout << "Autogen .h 'date +%s': " << current::build::cmake::kCurrentBuildHeaderUnixEpochSeconds << std::endl;
 }
 EOF
 make

--- a/cmake/run-cmake-test.sh
+++ b/cmake/run-cmake-test.sh
@@ -94,7 +94,7 @@ echo "::endgroup::"
 
 echo
 
-# Test that the `current_build.h` file is generated automatically for each build.
+# Test that the `current_build_info.h` file is [re-]generated automatically for each build.
 echo "::group::build build_info"
 cat >src/build_info.cc <<EOF
 #include <iostream>
@@ -118,10 +118,13 @@ echo "::endgroup::"
 
 echo
 
-echo "::group::re-run build_info"
+echo "::group::re-build build_info after sleep 1"
 sleep 1
 touch src/build_info.cc
 make
+echo "::endgroup::"
+
+echo "::group::re-run build_info"
 .current/build_info
 echo "::endgroup::"
 


### PR DESCRIPTION
Fingers crossed this passes the GitHub PR guard now.

If yes, I'll remove the "old" `current_build.h` target and merge.