### PR TITLE
The first step towards `C5T_DEPS` and more repos under `C5T`.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Threads REQUIRED)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 option(BUILD_GMOCK OFF)
 
+set_property(GLOBAL PROPERTY C5T_LIBRARIES_PROPERTY "Threads::Threads" "C5T")
+
 # The helper to clone a dependency, or use it from a sibling dir if available.
 function(UseGitOrCloneImpl remote use_custom_branch custom_branch)
   cmake_path(GET remote FILENAME dep)
@@ -43,6 +45,16 @@ function(UseGitOrCloneImpl remote use_custom_branch custom_branch)
     file(APPEND .gitignore "${dep}/\n")  # NOTE(dkorolev): This may add extra `.gitignore` lines, ignore for now.
     set("C5T_DEP_DIR_${dep}" "${CMAKE_SOURCE_DIR}/${dep}" CACHE INTERNAL "")
   endif()
+  # If the added repository contains the `.c5t_cmake_dependency` file,
+  # then add this repo's C5T library name to all targets built by this `CMakeLists.txt`.
+  if(EXISTS "${C5T_DEP_DIR_${dep}}/.c5t_cmake_dependency")
+    message(STATUS "EXISTS ${C5T_DEP_DIR_${dep}}/.c5t_cmake_dependency!")
+    string(TOUPPER ${dep} UPPERCASE_DEP)
+    message(STATUS "ADDING C5T_${UPPERCASE_DEP}")
+    get_property(tmp GLOBAL PROPERTY C5T_LIBRARIES_PROPERTY)
+    list(APPEND tmp "C5T_${UPPERCASE_DEP}")  #"C5T_TRIVIAL_DEP")
+    set_property(GLOBAL PROPERTY C5T_LIBRARIES_PROPERTY ${tmp}) # C5T_TRIVIAL_DEP")
+  endif()
 endfunction()
 
 function(UseGitOrClone remote)
@@ -56,6 +68,15 @@ endfunction()
 UseGitOrClone(https://github.com/c5t/current)
 UseGitOrClone(https://github.com/c5t/googletest)
 
+# TODO(dkorolev): Support more than one dependency, this is just the demo / test for v0.1.
+set(C5T_DEPS $ENV{C5T_DEPS})
+if(NOT "${C5T_DEPS}" STREQUAL "")
+  message(STATUS "C5T_DEPS=${C5T_DEPS}")
+  UseGitOrClone("https://github.com/c5t/${C5T_DEPS}")  # TODO(dkorolev): `foreach()`.
+endif()
+
+get_property(C5T_LIBRARIES GLOBAL PROPERTY C5T_LIBRARIES_PROPERTY)
+
 add_custom_target(C5T_CURRENT_BUILD_INFO_H_TARGET ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h"
@@ -64,8 +85,6 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/inc/current_build_info.h"
                    DEPENDS inc/current_build_info.h.force_rebuild)
 
 add_custom_command(OUTPUT inc/current_build_info.h.force_rebuild COMMAND cmake -E echo >/dev/null)
-
-set(C5T_LIBRARIES "Threads::Threads" "C5T")
 
 # Declare shared libraries as shared library targets. Do not link them against anything external.
 file(GLOB_RECURSE BINARY_SOURCE_FILES "src/dlib_*.cc")

--- a/cmake/Makefile
+++ b/cmake/Makefile
@@ -9,6 +9,12 @@
 
 .PHONY: release debug release_dir debug_dir release_test debug_test test fmt clean
 
+# Then this `Makefile` is used to run a `cmake`-based Current build,
+# user-defined dependencies go here.
+# TODO(dkorolev): Support more than one of them on the `CMakeLists.txt` level.
+# TODO(dkorolev): Test that this works with `leveldb` too.
+C5T_DEPS=""
+
 DEBUG_BUILD_DIR=$(shell echo "$${DEBUG_BUILD_DIR:-.current_debug}")
 RELEASE_BUILD_DIR=$(shell echo "$${RELEASE_BUILD_DIR:-.current}")
 
@@ -28,7 +34,7 @@ release_dir: ${RELEASE_BUILD_DIR} .gitignore
 	@grep "^${RELEASE_BUILD_DIR}/$$" .gitignore >/dev/null || echo "${RELEASE_BUILD_DIR}/" >>.gitignore
 
 ${RELEASE_BUILD_DIR}: CMakeLists.txt src
-	@cmake -DCMAKE_BUILD_TYPE=Release -B "${RELEASE_BUILD_DIR}" .
+	@C5T_DEPS="${C5T_DEPS}" cmake -DCMAKE_BUILD_TYPE=Release -B "${RELEASE_BUILD_DIR}" .
 
 test: release
 	@(cd "${RELEASE_BUILD_DIR}"; make test)
@@ -40,7 +46,7 @@ debug_dir: ${DEBUG_BUILD_DIR} .gitignore
 	@grep "^${DEBUG_BUILD_DIR}/$$" .gitignore >/dev/null || echo "${DEBUG_BUILD_DIR}/" >>.gitignore
 
 ${DEBUG_BUILD_DIR}: CMakeLists.txt src
-	@cmake -B "${DEBUG_BUILD_DIR}" .
+	@C5T_DEPS="${C5T_DEPS}" cmake -B "${DEBUG_BUILD_DIR}" .
 
 debug_test: debug
 	@(cd "${DEBUG_BUILD_DIR}"; make test)


### PR DESCRIPTION
Learning `cmake` step by step.

This "development process" is slow because GitHub actions work on the `stable` branch of upstream.

But this seems to work on my local test.

And: it seems to work both for a header-only repo and for a non-header-only, library, repo!