### PR TITLE
Added `[[nodiscard]]`, as we always wanted.

### DIFF
--- a/blocks/http/chunked_demo.cc
+++ b/blocks/http/chunked_demo.cc
@@ -150,7 +150,7 @@ CURRENT_STRUCT(ExampleMeta) {
 
 // TODO(dkorolev): Finish multithreading. Need to notify active connections and wait for them to finish.
 int main() {
-  HTTP(FLAGS_port).Register("/layout", [](Request r) {
+  HTTPRoutesScope scope = HTTP(FLAGS_port).Register("/layout", [](Request r) {
     LayoutItem layout;
     LayoutItem row;
     layout.col.push_back(row);
@@ -160,14 +160,14 @@ int main() {
       Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}),
       "application/json; charset=utf-8");
   });
-  HTTP(FLAGS_port).Register("/meta", [](Request r) {
+  scope += HTTP(FLAGS_port).Register("/meta", [](Request r) {
     r(ExampleMeta(),
       // "meta",  <--  @dkorolev, remove this source file entirely, as it's obsolete.
       HTTPResponseCode.OK,
       Headers({{"Connection", "close"}, {"Access-Control-Allow-Origin", "*"}}),
       "application/json; charset=utf-8");
   });
-  HTTP(FLAGS_port).Register("/data", [](Request r) {
+  scope += HTTP(FLAGS_port).Register("/data", [](Request r) {
     std::thread(
         [](Request&& r) {
           // Since we are in another thread, need to catch exceptions ourselves.

--- a/blocks/http/impl/posix_server.h
+++ b/blocks/http/impl/posix_server.h
@@ -221,6 +221,7 @@ class HTTPServerPOSIX final {
   // NOTE: The implementation of the above logic requires two separate signatures.
   //       An xvalue reference won't do it. Trust me, I've tried, and it results in horrible bugs. -- D.K.
   template <ReRegisterRoute POLICY = ReRegisterRoute::ThrowOnAttempt, typename F>
+  [[nodiscard]]
   HTTPRoutesScopeEntry Register(const std::string& path,
                                 const URLPathArgs::CountMask path_args_count_mask,
                                 F& handler) {
@@ -230,6 +231,7 @@ class HTTPServerPOSIX final {
   }
 
   template <ReRegisterRoute POLICY = ReRegisterRoute::ThrowOnAttempt>
+  [[nodiscard]]
   HTTPRoutesScopeEntry Register(const std::string& path,
                                 const URLPathArgs::CountMask path_args_count_mask,
                                 std::function<void(Request)> handler) {
@@ -239,12 +241,14 @@ class HTTPServerPOSIX final {
 
   // Two argument version registers handler with no URL path arguments.
   template <ReRegisterRoute POLICY = ReRegisterRoute::ThrowOnAttempt, typename F>
+  [[nodiscard]]
   HTTPRoutesScopeEntry Register(const std::string& path, F& handler) {
     std::lock_guard<std::mutex> lock(mutex_);
     return DoRegisterHandler(
         path, [&handler](Request r) { handler(std::move(r)); }, URLPathArgs::CountMask::None, POLICY);
   }
   template <ReRegisterRoute POLICY = ReRegisterRoute::ThrowOnAttempt>
+  [[nodiscard]]
   HTTPRoutesScopeEntry Register(const std::string& path, std::function<void(Request)> handler) {
     std::lock_guard<std::mutex> lock(mutex_);
     return DoRegisterHandler(path, handler, URLPathArgs::CountMask::None, POLICY);


### PR DESCRIPTION
Hi @mzhurovich, CC @amdrozdov -- I'll fix `db.cc` later, fingers crossed this PR does not break any tests.

Or I'll fix them all incrementally -- gotta go now, will get back to this later today.