### PR TITLE
Next steps with `cmake`-based builds.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -65,7 +65,13 @@ function(UseGitOrCloneBranch remote branch)
 endfunction()
 
 UseGitOrClone(https://github.com/c5t/current)
-UseGitOrClone(https://github.com/c5t/googletest)
+
+# Set `C5T_NO_GTEST` in the `Makefile` to any non-empty value to speed up the builds that do not need `googletest`.
+if("$ENV{C5T_NO_GTEST}" STREQUAL "")
+  UseGitOrClone(https://github.com/c5t/googletest)
+else()
+  message(STATUS "Skipping `googletest` as `C5T_NO_GTEST` is set.")
+endif()
 
 # TODO(dkorolev): Support more than one dependency, this is just the demo / test for v0.1.
 set(C5T_DEPS $ENV{C5T_DEPS})
@@ -98,8 +104,15 @@ foreach(SHARED_LIBRARY_SOURCE_FILE ${BINARY_SOURCE_FILES})
   target_link_libraries(${SHARED_LIBRARY_TARGET_NAME} PRIVATE "${C5T_LIBRARIES}")
 endforeach()
 
+# Declare libraries as library targets. First, and add them into the `ALL_LIBRARIES` list.
 set(ALL_LIBRARIES "${C5T_LIBRARIES}")
-# Declare libraries as library targets. And add them into the `ALL_LIBRARIES` list.
+file(GLOB_RECURSE LIBRARY_SOURCE_FILES "src/lib_*.cc")
+foreach(LIBRARY_SOURCE_FILE ${LIBRARY_SOURCE_FILES})
+  get_filename_component(LIBRARY_TARGET_NAME "${LIBRARY_SOURCE_FILE}" NAME_WE)
+  list(APPEND ALL_LIBRARIES "${LIBRARY_TARGET_NAME}")
+endforeach()
+
+# Then build all the libraries, such that every library is linked against every other library.
 file(GLOB_RECURSE LIBRARY_SOURCE_FILES "src/lib_*.cc")
 foreach(LIBRARY_SOURCE_FILE ${LIBRARY_SOURCE_FILES})
   get_filename_component(LIBRARY_TARGET_NAME "${LIBRARY_SOURCE_FILE}" NAME_WE)
@@ -107,8 +120,9 @@ foreach(LIBRARY_SOURCE_FILE ${LIBRARY_SOURCE_FILES})
   add_dependencies(${LIBRARY_TARGET_NAME} C5T_CURRENT_BUILD_INFO_H_TARGET)
   target_compile_definitions(${LIBRARY_TARGET_NAME} PRIVATE C5T_CMAKE_PROJECT)
   target_include_directories(${LIBRARY_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/inc")
-  target_link_libraries(${LIBRARY_TARGET_NAME} PRIVATE "${C5T_LIBRARIES}")
-  list(APPEND ALL_LIBRARIES "${LIBRARY_TARGET_NAME}")
+  set(LIBRARY_DEPS_WO_SELF "${ALL_LIBRARIES}")
+  list(REMOVE_ITEM LIBRARY_DEPS_WO_SELF ${LIBRARY_TARGET_NAME})
+  target_link_libraries(${LIBRARY_TARGET_NAME} PRIVATE "${LIBRARY_DEPS_WO_SELF}")
 endforeach()
 
 # Declare binaries as binary targets. And link them against all the libraries.

--- a/cmake/Makefile
+++ b/cmake/Makefile
@@ -16,7 +16,7 @@
 C5T_DEPS=""
 
 # Set this var to anything non-empty to speed up builds that do not require `googletest`.
-C5T_NO_GTEST="true"
+C5T_NO_GTEST=""
 
 DEBUG_BUILD_DIR=$(shell echo "$${DEBUG_BUILD_DIR:-.current_debug}")
 RELEASE_BUILD_DIR=$(shell echo "$${RELEASE_BUILD_DIR:-.current}")

--- a/cmake/Makefile
+++ b/cmake/Makefile
@@ -15,6 +15,9 @@
 # TODO(dkorolev): Test that this works with `leveldb` too.
 C5T_DEPS=""
 
+# Set this var to anything non-empty to speed up builds that do not require `googletest`.
+C5T_NO_GTEST="true"
+
 DEBUG_BUILD_DIR=$(shell echo "$${DEBUG_BUILD_DIR:-.current_debug}")
 RELEASE_BUILD_DIR=$(shell echo "$${RELEASE_BUILD_DIR:-.current}")
 
@@ -34,7 +37,7 @@ release_dir: ${RELEASE_BUILD_DIR} .gitignore
 	@grep "^${RELEASE_BUILD_DIR}/$$" .gitignore >/dev/null || echo "${RELEASE_BUILD_DIR}/" >>.gitignore
 
 ${RELEASE_BUILD_DIR}: CMakeLists.txt src
-	@C5T_DEPS="${C5T_DEPS}" cmake -DCMAKE_BUILD_TYPE=Release -B "${RELEASE_BUILD_DIR}" .
+	@C5T_DEPS="${C5T_DEPS}" C5T_NO_GTEST="${C5T_NO_GTEST}" cmake -DCMAKE_BUILD_TYPE=Release -B "${RELEASE_BUILD_DIR}" .
 
 test: release
 	@(cd "${RELEASE_BUILD_DIR}"; make test)
@@ -46,7 +49,7 @@ debug_dir: ${DEBUG_BUILD_DIR} .gitignore
 	@grep "^${DEBUG_BUILD_DIR}/$$" .gitignore >/dev/null || echo "${DEBUG_BUILD_DIR}/" >>.gitignore
 
 ${DEBUG_BUILD_DIR}: CMakeLists.txt src
-	@C5T_DEPS="${C5T_DEPS}" cmake -B "${DEBUG_BUILD_DIR}" .
+	@C5T_DEPS="${C5T_DEPS}" C5T_NO_GTEST="${C5T_NO_GTEST}" cmake -B "${DEBUG_BUILD_DIR}" .
 
 debug_test: debug
 	@(cd "${DEBUG_BUILD_DIR}"; make test)


### PR DESCRIPTION
Incremental improvements with `cmake`:

1. Added `C5T_NO_GTEST`, since it's silly to wait ~8 extra seconds to build "Hello, World!", and
2. Made `lib_*` libraries depend on each other, so that they can use each other's functions.

Re. (2) I think `dlib_*.cc` targets should also depend on all the libraries. But also I am jet lagged, so baby steps.

Thx,
Dima