### PR TITLE
Fixed the `WaitableAtomic` bug with lack of notifications of updates when updating from `Wait()` with predicate + mutating "getter".

### DIFF
--- a/bricks/sync/test.cc
+++ b/bricks/sync/test.cc
@@ -369,7 +369,7 @@ TEST(WaitableAtomic, NotifiesOfChangesInWait) {
              done = true;
            }
            if (o.from) {
-             // NOTE(dkorolev): This delay  0.1ms, which is sufficient. I have tested the code with:
+             // NOTE(dkorolev): This delay is 0.1ms, which is sufficient. I have tested the code with:
              // ./.current/test --gtest_filter=WaitableAtomic.NotifiesOfChangesInWai --gtest_repeat=-1
              std::this_thread::sleep_for(std::chrono::microseconds(100));
              o.into = o.from;


### PR DESCRIPTION
I hope the first commit fails the tests, and then I push the fix in the second commit.

If this plan does not work out, I'll increase the "delay" and try the "failing" case again.

Fingers crossed!