### PR TITLE
Added the `C5T_DLIB` symbol.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -104,6 +104,7 @@ foreach(SHARED_LIBRARY_SOURCE_FILE ${BINARY_SOURCE_FILES})
   add_dependencies(${SHARED_LIBRARY_TARGET_NAME} C5T_CURRENT_BUILD_INFO_H_TARGET)
   # TODO(dkorolev): Might be worth it to `grep` this `dlib_*.cc` source file for required library dependencies.
   target_compile_definitions(${SHARED_LIBRARY_TARGET_NAME} PRIVATE C5T_CMAKE_PROJECT)
+  target_compile_definitions(${SHARED_LIBRARY_TARGET_NAME} PRIVATE C5T_DLIB)
   target_include_directories(${SHARED_LIBRARY_TARGET_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/inc")
   target_link_libraries(${SHARED_LIBRARY_TARGET_NAME} PRIVATE "${C5T_LIBRARIES}")
 endforeach()


### PR DESCRIPTION
Hi @mzhurovich, CC @yarmaksergey,

This `#define`-d symbol for `dlib` builds makes it possible to fix OS X builds.

Context: 

* There were some functions that were not supposed to be called from certain classes when those classes are used from `dlib`-based builds.
* For example, with `C5T_LOGGER`, it can only be initialized from the "main" process, not from the `dlib` itself, while the `dlib` should use the passed-in and injected instance of `C5T_LOGGER`.
* This worked on Linux so far "just" because that code path was never executed. (And executing it would have been a failure!)
* OS X is stricter, and this was resulting in linkage errors.
* With this fix, a clean solution is now possible, implemented, and tested.

I'll merge this one-liner PR in, and link to the respective fix in the other repo in the comment.

Thx,
Dima